### PR TITLE
Fix JSDoc comments in adotBidAdapter

### DIFF
--- a/modules/adotBidAdapter.js
+++ b/modules/adotBidAdapter.js
@@ -22,6 +22,23 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
  * @typedef {import('../src/adapters/bidderFactory.js').Video} Video
  * @typedef {import('../src/adapters/bidderFactory.js').AdUnit} AdUnit
  * @typedef {import('../src/adapters/bidderFactory.js').Imp} Imp
+ * @typedef {Object} OpenRtbBid
+ * @typedef {Object} OpenRtbBidResponse
+ * @typedef {Object} OpenRTBBidRequest
+ * @typedef {Object} Regs
+ * @typedef {Object} Ext
+ * @typedef {Object} OpenRtbBanner
+ * @typedef {Object} OpenRtbVideo
+ * @typedef {Object} NativeMedia
+ * @typedef {Object} OpenRtbNativeAssets
+ * @typedef {Object} OpenRtbNative
+ * @typedef {Object} VideoMedia
+ * @typedef {Object} AjaxRequest
+ * @typedef {Object} NativeAssets
+ * @typedef {Object} PrebidJSResponse
+ * @typedef {Object} Format
+ * @typedef {BidRequest} PrebidBidRequest
+ * @typedef {Record<string, BidRequest>} Dictionnary
  */
 
 const BIDDER_CODE = 'adot';
@@ -128,7 +145,6 @@ function getOpenRTBRegsObject(bidderRequest) {
 /**
  * Create and return Ext OpenRtb object
  *
- * @param {BidderRequest} bidderRequest
  * @returns {Ext|null} Formatted Ext OpenRtb object or null
  */
 function getOpenRTBExtObject() {
@@ -357,7 +373,7 @@ function buildBidRequest(adUnits, bidderRequest, requestId) {
  * @param {BidderRequest} bidderRequest PrebidJS BidderRequest
  * @param {string} bidderUrl Adot Bidder URL
  * @param {string} requestId Request ID
- * @returns
+ * @returns {AjaxRequest}
  */
 function buildAjaxRequest(adUnits, bidderRequest, bidderUrl, requestId) {
   return {
@@ -370,8 +386,8 @@ function buildAjaxRequest(adUnits, bidderRequest, bidderUrl, requestId) {
 /**
  * Split given PrebidJS Request in Dictionnary
  *
- * @param {Array<PrebidBidRequest>} validBidRequests
- * @returns {Dictionnary<PrebidBidRequest>}
+ * @param {Array<BidRequest>} validBidRequests
+ * @returns {Dictionnary}
  */
 function splitAdUnits(validBidRequests) {
   return validBidRequests.reduce((adUnits, adUnit) => {
@@ -387,7 +403,7 @@ function splitAdUnits(validBidRequests) {
 /**
  * Build Ajax request Array
  *
- * @param {Array<PrebidBidRequest>} validBidRequests
+ * @param {Array<BidRequest>} validBidRequests
  * @param {BidderRequest} bidderRequest
  * @returns {Array<AjaxRequest>}
  */
@@ -517,7 +533,7 @@ function isBidImpInvalid(bid, imp) {
  *
  * @param {OpenRtbBid} bid
  * @param {OpenRtbBidResponse} bidResponse
- * @param {OpenRtbBid} imp
+ * @param {Imp} imp
  * @returns {PrebidJSResponse}
  */
 function buildBidResponse(bid, bidResponse, imp) {
@@ -544,7 +560,7 @@ function buildBidResponse(bid, bidResponse, imp) {
  * Find OpenRtb Imp from request with same id that given bid
  *
  * @param {OpenRtbBid} bid
- * @param {OpenRtbRequest} bidRequest
+ * @param {Object} bidRequest
  * @returns {Imp} OpenRtb Imp
  */
 function getImpfromBid(bid, bidRequest) {
@@ -569,7 +585,7 @@ function isValidResponse(response) {
 /**
  * Return if given request is valid
  *
- * @param {OpenRtbRequest} request
+ * @param {Object} request
  * @returns {boolean}
  */
 function isValidRequest(request) {
@@ -582,7 +598,7 @@ function isValidRequest(request) {
  * Interpret given OpenRtb Response to build PrebidJS Response
  *
  * @param {OpenRtbBidResponse} serverResponse
- * @param {OpenRtbRequest} request
+ * @param {Object} request
  * @returns {PrebidJSResponse}
  */
 function interpretResponse(serverResponse, request) {
@@ -624,9 +640,6 @@ function getFloor(adUnit, size, mediaType, currency) {
 /**
  * Call getFloor for each format and return the lower floor
  * Return 0 by default
- *
- * interface Format { w: number; h: number }
- *
  * @param {AdUnit} adUnit
  * @param {Array<Format>} formats Media formats
  * @param {string} mediaType

--- a/modules/visiblemeasuresBidAdapter.js
+++ b/modules/visiblemeasuresBidAdapter.js
@@ -126,8 +126,8 @@ export const spec = {
       deviceHeight = winTop.screen.height;
       winLocation = winTop.location;
     } catch (e) {
-      winLocation = window.location;
       logMessage(e);
+      winLocation = window.location;
     }
 
     const refferUrl = bidderRequest.refererInfo && bidderRequest.refererInfo.page;

--- a/modules/visiblemeasuresBidAdapter.js
+++ b/modules/visiblemeasuresBidAdapter.js
@@ -127,6 +127,7 @@ export const spec = {
       winLocation = winTop.location;
     } catch (e) {
       winLocation = window.location;
+      logMessage(e);
     }
 
     const refferUrl = bidderRequest.refererInfo && bidderRequest.refererInfo.page;


### PR DESCRIPTION
## Summary
- define custom JSDoc typedefs for adotBidAdapter
- drop unused parameter from `getOpenRTBExtObject`
- correct request typing for `splitAdUnits`, `buildRequests`, `getImpfromBid`, `isValidRequest` and `interpretResponse`

## Testing
- `npm run lint`
- `npx eslint modules/adotBidAdapter.js`
