### PR TITLE
Fix sovrnAnalyticsAdapter findBid when bidder missing

### DIFF
--- a/modules/sovrnAnalyticsAdapter.js
+++ b/modules/sovrnAnalyticsAdapter.js
@@ -171,6 +171,7 @@ class AuctionData {
     const bidder = find(this.auction.requests, r => (r.bidderCode === event.bidderCode))
     if (!bidder) {
       this.auction.unsynced.push(JSON.parse(JSON.stringify(event)))
+      return
     }
     let bid = find(bidder.bids, b => (b.bidId === event.requestId))
 

--- a/test/spec/modules/sovrnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sovrnAnalyticsAdapter_spec.js
@@ -322,6 +322,19 @@ describe('Sovrn Analytics Adapter', function () {
       expect(bidRequest).to.not.have.property('adserverTargeting');
       expect(bidRequest).to.not.have.property('cpm');
       expect(currentAuction.auction.unsynced[0]).to.deep.equal(bidResponseNoMatchingRequest);
+      expect(server.requests.length).to.equal(0);
+    });
+
+    it('should handle missing bidder on bid adjustment without error', function () {
+      let auctionId = '456.456.456.457';
+      emitEvent('AUCTION_INIT', auctionInit, auctionId);
+      emitEvent('BID_REQUESTED', bidRequested, auctionId);
+      emitEvent('BID_ADJUSTMENT', bidAdjustmentNoMatchingRequest, auctionId);
+
+      let auctionData = sovrnAnalyticsAdapter.getAuctions();
+      let currentAuction = auctionData[auctionId];
+      expect(currentAuction.auction.unsynced[0]).to.deep.equal(bidAdjustmentNoMatchingRequest);
+      expect(server.requests.length).to.equal(0);
     });
     it('should adjust the bid ', function () {
       let auctionId = '567.567.567.567';


### PR DESCRIPTION
## Summary
- prevent errors in sovrnAnalyticsAdapter when a bid response arrives for an unknown bidder
- add unit tests for missing bidder scenarios

## Testing
- `npx gulp test --file "test/spec/modules/sovrnAnalyticsAdapter_spec.js" --nolint` *(fails: No ChromeHeadless binary)*