### PR TITLE
Fix typos in Magnite analytics test

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -957,7 +957,7 @@ function applyRegulations(r, bidderRequest) {
  * @param  {Array}  impressions        List of impressions to be added to the request.
  * @param  {Array}  impKeys            List of impression keys.
  * @param  {object} r                  Reuqest object.
- * @param  {number}    adUnitIndex        Index of the current add unit
+ * @param  {number}    adUnitIndex        Index of the current ad unit
  * @return {object}                    Reqyest object with added impressions describing the request to the server.
  */
 function addImpressions(impressions, impKeys, r, adUnitIndex) {
@@ -1254,7 +1254,7 @@ function addAdUnitFPD(imp, bid) {
  * @param  {Array}  impressions        List of impressions to be added to the request.
  * @param  {object} r                  Reuqest object.
  * @param  {Array}  impKeys            List of impression keys.
- * @param  {number}    adUnitIndex        Index of the current add unit
+ * @param  {number}    adUnitIndex        Index of the current ad unit
  * @param  {object} payload            Request payload object.
  * @param  {string} baseUrl            Base exchagne URL.
  * @return {object}                    Reqyest object with added indentigfier info to ixDiag.

--- a/test/spec/modules/magniteAnalyticsAdapter_spec.js
+++ b/test/spec/modules/magniteAnalyticsAdapter_spec.js
@@ -2199,7 +2199,7 @@ describe('magnite analytics adapter', function () {
       config.setConfig({ rubicon: { updatePageView: true } });
     });
 
-    it('should add a no-bid bid to the add unit if it recieves one from the server', () => {
+    it('should add a no-bid bid to the ad unit if it receives one from the server', () => {
       const bidResponse = utils.deepClone(MOCK.BID_RESPONSE);
       const auctionInit = utils.deepClone(MOCK.AUCTION_INIT);
 


### PR DESCRIPTION
## Summary
- correct typo in magniteAnalyticsAdapter_spec description
- update ixBidAdapter documentation comments

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*
- `npm run lint`