### PR TITLE
Fix test timeout for enrichment module

### DIFF
--- a/test/spec/modules/enrichmentLiftMeasurement_spec.js
+++ b/test/spec/modules/enrichmentLiftMeasurement_spec.js
@@ -20,7 +20,8 @@ describe('enrichmentLiftMeasurement', () => {
     reset();
   })
   
-  it('should properly split traffic basing on percentage', () => {
+  it('should properly split traffic basing on percentage', function () {
+    this.timeout(6000);
     const TEST_SAMPLE_SIZE = 10000;
     const MARGIN_OF_ERROR = 0.05;
     const modulesConfig = [
@@ -30,7 +31,7 @@ describe('enrichmentLiftMeasurement', () => {
       { name: 'idSystem4', percentage: 1 },
       { name: 'idSystem5', percentage: 0 },
     ];
-    const TOTAL_RANDOM_CALLS = TEST_SAMPLE_SIZE * modulesConfig.length;
+    const TOTAL_RANDOM_CALLS = (TEST_SAMPLE_SIZE + 1) * modulesConfig.length;
     const fixedRandoms = Array.from({ length: TOTAL_RANDOM_CALLS }, (_, i) => i / TOTAL_RANDOM_CALLS);
     let callIndex = 0;
 


### PR DESCRIPTION
## Summary
- extend timeout on enrichmentLiftMeasurement spec
- adjust random call count for init

## Testing
- `npm run lint --silent` *(fails: Browserslist outdated warning, but lint finished with warnings)*