### PR TITLE
Fix misc jsdoc warnings

### DIFF
--- a/modules/debugging/bidInterceptor.js
+++ b/modules/debugging/bidInterceptor.js
@@ -59,10 +59,10 @@ Object.assign(BidInterceptor.prototype, {
    * @typedef {Function} MatchPredicate
    * @param {*} candidate a bid to match, or a portion of it if used inside an ObjectMather.
    * e.g. matcher((bid, bidRequest) => ....) or matcher({property: (property, bidRequest) => ...})
-   * @param {BidRequest} bidRequest the request `candidate` belongs to
+   * @param {Object} bidRequest the request `candidate` belongs to
    * @returns {boolean}
    *
-   * @typedef {{[key]: Scalar|RegExp|MatchPredicate|ObjectMatcher}} ObjectMatcher
+   * @typedef {Object.<string, Scalar|RegExp|MatchPredicate|ObjectMatcher>} ObjectMatcher
    */
 
   /**
@@ -98,11 +98,11 @@ Object.assign(BidInterceptor.prototype, {
   /**
    * @typedef {Function} ReplacerFn
    * @param {*} bid a bid that was intercepted
-   * @param {BidRequest} bidRequest the request `bid` belongs to
+   * @param {Object} bidRequest the request `bid` belongs to
    * @returns {*} the response to mock for `bid`, or a portion of it if used inside an ObjectReplacer.
    * e.g. replacer((bid, bidRequest) => mockResponse) or replacer({property: (bid, bidRequest) => mockProperty})
    *
-   * @typedef {{[key]: ReplacerFn|ObjectReplacer|*}} ObjectReplacer
+   * @typedef {Object.<string, ReplacerFn|ObjectReplacer|*>} ObjectReplacer
    */
 
   /**
@@ -222,13 +222,13 @@ Object.assign(BidInterceptor.prototype, {
    * Run a set of bids against all registered rules, filter out those that match,
    * and generate mock responses for them.
    *
-   * @param {{}[]} bids?
-   * @param {BidRequest} bidRequest
-   * @param {function(*)} addBid called once for each mock response
-   * @param addPaapiConfig called once for each mock PAAPI config
-   * @param {function()} done called once after all mock responses have been run through `addBid`
-   * @returns {{bids: {}[], bidRequest: {}} remaining bids that did not match any rule (this applies also to
-   * bidRequest.bids)
+   * @param {Object} params
+   * @param {Object[]} [params.bids]
+   * @param {Object} params.bidRequest
+   * @param {function(Object):void} params.addBid called once for each mock response
+   * @param {function(Object):void} [params.addPaapiConfig] called once for each mock PAAPI config
+   * @param {function():void} params.done called once after all mock responses have been run through `addBid`
+   * @returns {{bids: Object[], bidRequest: Object}} remaining bids that did not match any rule (this applies also to bidRequest.bids)
    */
   intercept({bids, bidRequest, addBid, addPaapiConfig, done}) {
     if (bids == null) {

--- a/modules/discoveryBidAdapter.js
+++ b/modules/discoveryBidAdapter.js
@@ -132,8 +132,8 @@ export function getCookieTimeToUTCString() {
 /**
  * format imp ad test ext params
  *
- * @param validBidRequest sigleBidRequest
- * @param bidderRequest
+ * @param {Object} bidRequest sigleBidRequest
+ * @param {Object} bidderRequest
  */
 function addImpExtParams(bidRequest = {}, bidderRequest = {}) {
   const { deepAccess } = utils;
@@ -490,7 +490,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
-   * @param {data} Containing timeout specific data
+   * @param {Object} data Containing timeout specific data
    */
   onTimeout: function (data) {
     utils.logError('DiscoveryDSP adapter timed out for the auction.');
@@ -499,7 +499,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which  will execute if a bid from this bidder won the auction
-   * @param {Bid} The bid that won the auction
+   * @param {Object} bid The bid that won the auction
    */
   onBidWon: function (bid) {
     if (bid['nurl']) {

--- a/modules/dmdIdSystem.js
+++ b/modules/dmdIdSystem.js
@@ -42,8 +42,8 @@ export const dmdIdSubmodule = {
    * performs action to obtain id and return a value in the callback's response argument
    * @function getId
    * @param {SubmoduleConfig} [config]
-   * @param {ConsentData}
-   * @param {Object} cacheIdObj - existing id, if any consentData]
+   * @param {ConsentData} consentData
+   * @param {Object} cacheIdObj - existing id, if any
    * @returns {IdResponse|undefined}
    */
   getId(config, consentData, cacheIdObj) {

--- a/modules/dsp_genieeBidAdapter.js
+++ b/modules/dsp_genieeBidAdapter.js
@@ -99,7 +99,7 @@ export const spec = {
    *
    * @param {ServerResponse} serverResponse A successful response from the server.
    * @param {BidRequest} bidRequest - the master bidRequest object
-   * @return {bids} - An array of bids which were nested inside the server.
+   * @return {Array} - An array of bids which were nested inside the server.
    */
   interpretResponse: function (serverResponse, bidRequest) {
     if (!serverResponse.body) { // empty response (no bids)

--- a/modules/dxkultureBidAdapter.js
+++ b/modules/dxkultureBidAdapter.js
@@ -287,8 +287,8 @@ function _validateBanner(bidRequest) {
 
 /**
  * Validates video bid request. If it is not video media type returns true.
- * @param {BidRequest} bidRequest, bid to validate
- * @return boolean, true if valid, otherwise false
+ * @param {Object} bidRequest bid to validate
+ * @return {boolean} true if valid, otherwise false
  */
 function _validateVideo(bidRequest) {
   // If there's no video no need to validate

--- a/modules/fabrickIdSystem.js
+++ b/modules/fabrickIdSystem.js
@@ -43,8 +43,8 @@ export const fabrickIdSubmodule = {
    * performs action to obtain id and return a value in the callback's response argument
    * @function getId
    * @param {SubmoduleConfig} [config]
-   * @param {ConsentData}
-   * @param {Object} cacheIdObj - existing id, if any consentData]
+   * @param {ConsentData} consentData
+   * @param {Object} cacheIdObj - existing id, if any
    * @returns {IdResponse|undefined}
    */
   getId(config, consentData, cacheIdObj) {

--- a/modules/feedadBidAdapter.js
+++ b/modules/feedadBidAdapter.js
@@ -90,7 +90,7 @@ const VERSION = '1.0.6';
 
 /**
  * @typedef {object} FeedAdServerResponse
- * @augments ServerResponse
+ * @augments {Object}
  * @inner
  *
  * @property {FeedAdApiBidResponse[]} body - the body of a FeedAd server response
@@ -185,8 +185,8 @@ function isValidPlacementId(placementId) {
 
 /**
  * Checks if the given media types contain unsupported settings
- * @param {MediaTypes} mediaTypes - the media types to check
- * @return {MediaTypes} the unsupported settings, empty when all types are supported
+ * @param {Object} mediaTypes - the media types to check
+ * @return {Object} the unsupported settings, empty when all types are supported
  */
 function filterSupportedMediaTypes(mediaTypes) {
   return {
@@ -198,7 +198,7 @@ function filterSupportedMediaTypes(mediaTypes) {
 
 /**
  * Checks if the given media types are empty
- * @param {MediaTypes} mediaTypes - the types to check
+ * @param {Object} mediaTypes - the types to check
  * @return {boolean} true if the types are empty
  */
 function isMediaTypesEmpty(mediaTypes) {

--- a/modules/gmosspBidAdapter.js
+++ b/modules/gmosspBidAdapter.js
@@ -90,10 +90,11 @@ export const spec = {
   /**
    * Unpack the response from the server into a list of bids.
    *
-   * @param {*} serverResponse A successful response from the server.
-   * @return {Bid[]} An array of bids which were nested inside the server.
+   * @param {*} bidderResponse A successful response from the server.
+   * @param {Array} requests
+   * @return {Array} An array of bids which were nested inside the server.
    */
-  interpretResponse: function (bidderResponse, requests) {
+ interpretResponse: function (bidderResponse, requests) {
     const res = bidderResponse.body;
 
     if (isEmpty(res)) {

--- a/modules/gppControl_usstates.js
+++ b/modules/gppControl_usstates.js
@@ -29,14 +29,15 @@ const FIELDS = {
  * List fields are also copied, but forced to the "correct" length (by truncating or padding with nulls);
  * additionally, elements within them can be moved around using the `move` argument.
  *
- * @param {Array[String]} nullify? list of fields to force to null
- * @param {{}} move? Map from list field name to an index remapping for elements within that field (using 1 as the first index).
+ * @param {Object} opts
+ * @param {string[]} [opts.nullify] list of fields to force to null
+ * @param {Object} [opts.move] Map from list field name to an index remapping for elements within that field (using 1 as the first index).
  *       For example, {SensitiveDataProcessing: {1: 2, 2: [1, 3]}} means "rearrange SensitiveDataProcessing by moving
  *       the first element to the second position, and the second element to both the first and third position."
- * @param {({}, {}) => void} fn? an optional function to run once all the processing described above is complete;
+ * @param {function(Object, Object): void} [opts.fn] an optional function to run once all the processing described above is complete;
  *       it's passed two arguments, the original (state) data, and its normalized (usnat) version.
- * @param fields
- * @returns {function({}): {}}
+ * @param {Object} [fields]
+ * @returns {function(Object): Object}
  */
 export function normalizer({nullify = [], move = {}, fn}, fields = FIELDS) {
   move = Object.fromEntries(Object.entries(move).map(([k, map]) => [k,

--- a/modules/hybridBidAdapter.js
+++ b/modules/hybridBidAdapter.js
@@ -203,8 +203,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests(validBidRequests, bidderRequest) {
     const payload = {

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -48,8 +48,8 @@ export const identityLinkSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {ConsentData} [consentData]
    * @param {SubmoduleConfig} [config]
+   * @param {ConsentData} [consentData]
    * @returns {IdResponse|undefined}
    */
   getId(config, consentData) {

--- a/modules/idxIdSystem.js
+++ b/modules/idxIdSystem.js
@@ -48,7 +48,6 @@ export const idxIdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleConfig} config
    * @return {{id: string | undefined } | undefined}
    */
   getId() {

--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -31,7 +31,7 @@ export const STORAGE_KEY = '_im_str'
 
 /**
  * Helpers object
- * @type {{getExtParamsFromBid(*): {impactify: {appId}}, createOrtbImpVideoObj(*): {context: string, playerSize: [number,number], id: string, mimes: [string]}, getDeviceType(): (number), createOrtbImpBannerObj(*, *): {format: [], id: string}}}
+ * @type {Object}
  */
 const helpers = {
   getExtParamsFromBid(bid) {
@@ -247,9 +247,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @param {bidderRequest} - the bidding request
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest - the bidding request
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
     // Create a clean openRTB request
@@ -363,7 +363,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
-   * @param {Bid} The bid that won the auction
+   * @param {Object} bid The bid that won the auction
    */
   onBidWon: function (bid) {
     ajax(`${LOGGER_URI}/prebid/won`, null, JSON.stringify(bid), {
@@ -376,7 +376,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
-   * @param {data} Containing timeout specific data
+   * @param {Object} data Containing timeout specific data
    */
   onTimeout: function (data) {
     ajax(`${LOGGER_URI}/prebid/timeout`, null, JSON.stringify(data[0]), {

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -63,8 +63,8 @@ export const spec = {
    * Unpack the response from the server into a list of bids.
    *
    * @param {*} serverResponse A successful response from the server.
-   * @param bidderRequest
-   * @return {Bid[]} An array of bids which were nested inside the server.
+   * @param {{ortbRequest:Object}} bidderRequest
+   * @return {Array} An array of bids which were nested inside the server.
    */
   interpretResponse(serverResponse, { ortbRequest }) {
     return CONVERTER.fromORTB({request: ortbRequest, response: serverResponse.body}).bids;

--- a/modules/integr8BidAdapter.js
+++ b/modules/integr8BidAdapter.js
@@ -34,8 +34,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
     let deliveryUrl = '';

--- a/modules/ivsBidAdapter.js
+++ b/modules/ivsBidAdapter.js
@@ -59,9 +59,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @param {bidderRequest} - master bidRequest object
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest - master bidRequest object
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function(validBidRequests, bidderRequest) {
     const data = converter.toORTB({ bidderRequest, validBidRequests, context: {mediaType: 'video'} });

--- a/modules/jixieBidAdapter.js
+++ b/modules/jixieBidAdapter.js
@@ -20,7 +20,7 @@ const sidTTLMins_ = 30;
  * Get bid floor from Price Floors Module
  *
  * @param {Object} bid
- * @returns {float||null}
+ * @returns {(number|null)}
  */
 function getBidFloor(bid) {
   if (!isFn(bid.getFloor)) {

--- a/modules/kinessoIdSystem.js
+++ b/modules/kinessoIdSystem.js
@@ -28,7 +28,7 @@ const id = factory();
 
 /**
  * the factory to generate unique identifier based on time and current pseudorandom number
- * @param {string} the current pseudorandom number generator
+ * @param {string} currPrng the current pseudorandom number generator
  * @returns {function(*=): *}
  */
 function factory(currPrng) {
@@ -45,7 +45,7 @@ function factory(currPrng) {
 
 /**
  * gets a a random charcter from generated pseudorandom number
- * @param {string} the generated pseudorandom number
+ * @param {string} prng the generated pseudorandom number
  * @returns {string}
  */
 function randomChar(prng) {
@@ -58,8 +58,8 @@ function randomChar(prng) {
 
 /**
  * encodes random character
- * @param len
- * @param prng
+ * @param {number} len
+ * @param {function(): number} prng
  * @returns {string}
  */
 function encodeRandom(len, prng) {
@@ -72,8 +72,8 @@ function encodeRandom(len, prng) {
 
 /**
  * encodes the time based on the length
- * @param now
- * @param len
+ * @param {number} now
+ * @param {number} len
  * @returns {string} encoded time.
  */
 function encodeTime(now, len) {
@@ -112,7 +112,7 @@ function encodeTime(now, len) {
 /**
  * creates and logs the error message
  * @function
- * @param {string} error message
+ * @param {string} message error message
  * @returns {Error}
  */
 function createError(message) {
@@ -125,7 +125,7 @@ function createError(message) {
 /**
  * detects the pseudorandom number generator and generates the random number
  * @function
- * @param {string} error message
+ * @param {string} root
  * @returns {string} a random number
  */
 function detectPrng(root) {
@@ -145,9 +145,8 @@ function detectPrng(root) {
 
 /**
  * existing id generation call back
- * @param result
- * @param callback
- * @returns {{success: success, error: error}}
+ * @param {string} storedId
+ * @returns {{success: function(Object): void, error: function(): void}}
  */
 function syncId(storedId) {
   return {
@@ -178,6 +177,7 @@ function encodeId(value) {
 
 /**
  * Builds and returns the shared Id URL with attached consent data if applicable
+ * @param {number} accountId
  * @param {Object} consentData
  * @return {string}
  */
@@ -206,7 +206,7 @@ export const kinessoIdSubmodule = {
    * decode the stored id value for passing to bid requests
    * @function
    * @param {string} value
-   * @returns {{kpuid:{ id: string}} or undefined if value doesn't exists
+   * @returns {{kpuid:{id: string}}|undefined}
    */
   decode(value) {
     return (value) ? encodeId(value) : undefined;
@@ -217,7 +217,7 @@ export const kinessoIdSubmodule = {
    * @function
    * @param {SubmoduleConfig} [config]
    * @param {ConsentData|undefined} consentData
-   * @returns {knssoId}
+   * @returns {string|undefined}
    */
   getId(config, consentData) {
     const configParams = (config && config.params) || {};

--- a/modules/lemmaDigitalBidAdapter.js
+++ b/modules/lemmaDigitalBidAdapter.js
@@ -62,8 +62,9 @@ export var spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: (validBidRequests, bidderRequest) => {
     if (validBidRequests.length === 0) {

--- a/modules/limelightDigitalBidAdapter.js
+++ b/modules/limelightDigitalBidAdapter.js
@@ -77,7 +77,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
-   * @param {Bid} The bid that won the auction
+   * @param {Object} bid The bid that won the auction
    */
   onBidWon: (bid) => {
     const cpm = bid.pbMg;

--- a/modules/lmpIdSystem.js
+++ b/modules/lmpIdSystem.js
@@ -9,6 +9,11 @@ import { submodule } from '../src/hook.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 import { getStorageManager } from '../src/storageManager.js';
 
+/**
+ * @typedef {import('../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
+ */
+
 const MODULE_NAME = 'lmpid';
 const STORAGE_KEY = '__lmpid';
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });

--- a/modules/malltvBidAdapter.js
+++ b/modules/malltvBidAdapter.js
@@ -33,8 +33,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
     const storageId = storage.localStorageIsEnabled() ? storage.getDataFromLocalStorage(STORAGE_ID) || '' : '';

--- a/modules/mediagoBidAdapter.js
+++ b/modules/mediagoBidAdapter.js
@@ -390,7 +390,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
-   * @param {data} Containing timeout specific data
+   * @param {Object} data Containing timeout specific data
    */
   //   onTimeout: function (data) {
   //     // console.log('onTimeout', data);
@@ -399,7 +399,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
-   * @param {Bid} The bid that won the auction
+   * @param {Object} bid The bid that won the auction
    */
   onBidWon: function (bid) {
     // console.log('onBidWon： ', bid, config.getConfig('priceGranularity'));

--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -465,9 +465,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {BidRequest[]} bidRequests A non-empty list of bid requests which should be sent to the Server.
-   * @param {BidderRequests} bidderRequests
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} bidRequests A non-empty list of bid requests which should be sent to the Server.
+   * @param {Object} bidderRequests
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function(bidRequests, bidderRequests) {
     // convert Native ORTB definition to old-style prebid native definition
@@ -526,7 +526,7 @@ export const spec = {
   },
 
   /**
-   * @param {TimedOutBid} timeoutData
+   * @param {Object} bid
    */
   onTimeout: (timeoutData) => {
     try {

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -40,8 +40,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function(validBidRequests, bidderRequest) {
     // convert Native ORTB definition to old-style prebid native definition
@@ -178,7 +179,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
-   * @param {Bid} The bid that won the auction
+   * @param {Object} bid The bid that won the auction
    */
   onBidWon: function(bid) {
     // fires a pixel to confirm a winning bid

--- a/modules/merkleIdSystem.js
+++ b/modules/merkleIdSystem.js
@@ -103,7 +103,7 @@ export const merkleIdSubmodule = {
    * decode the stored id value for passing to bid requests
    * @function
    * @param {string} value
-   * @returns {{eids:arrayofields}}
+   * @returns {{eids:Array}}
    */
   decode(value) {
     // Legacy support for a single id

--- a/modules/multibid/index.js
+++ b/modules/multibid/index.js
@@ -46,7 +46,7 @@ config.getConfig(MODULE_NAME, conf => {
 
 /**
  * @summary validates multibid configuration entries
- * @param {Object[]} multibid - example [{bidder: 'bidderA', maxbids: 2, prefix: 'bidA'}, {bidder: 'bidderB', maxbids: 2}]
+ * @param {Object[]} conf - example [{bidder: 'bidderA', maxbids: 2, prefix: 'bidA'}, {bidder: 'bidderB', maxbids: 2}]
  * @return {Boolean}
  */
 export function validateMultibid(conf) {
@@ -79,7 +79,7 @@ export function validateMultibid(conf) {
 /**
  * @summary addBidderRequests before hook
  * @param {Function} fn reference to original function (used by hook logic)
- * @param {Object[]} array containing copy of each bidderRequest object
+ * @param {Object[]} bidderRequests containing copy of each bidderRequest object
  */
 export function adjustBidderRequestsHook(fn, bidderRequests) {
   bidderRequests.map(bidRequest => {
@@ -164,10 +164,10 @@ export function sortByMultibid(a, b) {
 /**
  * @summary getHighestCpmBidsFromBidPool before hook
  * @param {Function} fn reference to original function (used by hook logic)
- * @param {Object[]} array of objects containing all bids from bid pool
- * @param {Function} function to reduce to only highest cpm value for each bidderCode
- * @param {Number} adUnit bidder targeting limit, default set to 0
- * @param {Boolean} default set to false, this hook modifies targeting and sets to true
+ * @param {Object[]} bidsReceived array of objects containing all bids from bid pool
+ * @param {Function} highestCpmCallback function to reduce to only highest cpm value for each bidderCode
+ * @param {Number} adUnitBidLimit bidder targeting limit, default set to 0
+ * @param {Boolean} hasModified default set to false, this hook modifies targeting and sets to true
  */
 export function targetBidPoolHook(fn, bidsReceived, highestCpmCallback, adUnitBidLimit = 0, hasModified = false) {
   if (!config.getConfig('multibid')) resetMultiConfig();

--- a/modules/mwOpenLinkIdSystem.js
+++ b/modules/mwOpenLinkIdSystem.js
@@ -124,8 +124,8 @@ export const mwOpenLinkIdSubModule = {
   /**
    * decode the stored id value for passing to bid requests
    * @function
-   * @param {MwOlId} mwOlId
-   * @return {(Object|undefined}
+   * @param {Object} mwOlId
+   * @return {(Object|undefined)}
    */
   decode(mwOlId) {
     const id = mwOlId && isPlainObject(mwOlId) ? mwOlId.eid : undefined;
@@ -135,8 +135,8 @@ export const mwOpenLinkIdSubModule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
-   * @param {SubmoduleParams} [submoduleParams]
-   * @returns {id:MwOlId | undefined}
+   * @param {SubmoduleConfig} [submoduleConfig]
+   * @returns {(Object|undefined)}
    */
   getId(submoduleConfig) {
     const submoduleConfigParams = (submoduleConfig && submoduleConfig.params) || {};

--- a/modules/nativoBidAdapter.js
+++ b/modules/nativoBidAdapter.js
@@ -53,7 +53,7 @@ export function BidDataMap() {
   /**
    * Add a refence to the index by key value
    * @param {String} key - The key to store the index reference
-   * @param {Integer} index - The index value of the bidData
+   * @param {number} index - The index value of the bidData
    */
   function addKeyReference(key, index) {
     if (!referenceMap.hasOwnProperty(key)) {
@@ -64,7 +64,7 @@ export function BidDataMap() {
   /**
    * Adds a bid to the map
    * @param {Object} bid - Bid data
-   * @param {Array/String} keys - Keys to reference the index value
+   * @param {(Array|string)} keys - Keys to reference the index value
    */
   function addBidData(bid, keys) {
     const index = bids.length
@@ -129,7 +129,7 @@ export const spec = {
   /**
    * Determines whether or not the given bid request is valid.
    *
-   * @param {BidRequest} bid The bid params to validate.
+   * @param {Object} bid The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
@@ -721,7 +721,7 @@ function appendQSParamString(str, key, value) {
 
 /**
  * Convert an object to query string parameters
- * @param {Object} obj - Object to convert
+ * @param {Object[]} arr - Object to convert
  * @returns
  */
 function arrayToQS(arr) {

--- a/modules/netIdSystem.js
+++ b/modules/netIdSystem.js
@@ -34,8 +34,6 @@ export const netIdSubmodule = {
    * performs action to obtain id and return a value in the callback's response argument
    * @function
    * @param {SubmoduleConfig} [config]
-   * @param {ConsentData} [consentData]
-   * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */
   getId(config) {

--- a/modules/neuwoRtdProvider.js
+++ b/modules/neuwoRtdProvider.js
@@ -156,7 +156,7 @@ export function convertSegment(segment) {
 
 /**
  * map array of objects to segments
- * @param {Array[{ID: string}]} normalizable
+ * @param {Array<{ID: string}>} normalizable
  * @returns array of IAB "segments"
  */
 export function pickSegments(normalizable) {

--- a/modules/nextrollBidAdapter.js
+++ b/modules/nextrollBidAdapter.js
@@ -32,7 +32,7 @@ export const spec = {
   /**
    * Determines whether or not the given bid request is valid.
    *
-   * @param {BidRequest} bid The bid params to validate.
+   * @param {Object} bidRequest The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bidRequest) {
@@ -42,8 +42,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
     // convert Native ORTB definition to old-style prebid native definition

--- a/modules/nobidBidAdapter.js
+++ b/modules/nobidBidAdapter.js
@@ -391,8 +391,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function(validBidRequests, bidderRequest) {
     function resolveEndpoint() {
@@ -496,7 +497,7 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
-   * @param {data} Containing timeout specific data
+   * @param {Object} data Containing timeout specific data
    */
   onTimeout: function(data) {
     window.nobid.timeoutTotal++;

--- a/modules/novatiqIdSystem.js
+++ b/modules/novatiqIdSystem.js
@@ -35,7 +35,7 @@ export const novatiqIdSubmodule = {
   /**
    * decode the stored id value for passing to bid requests
    * @function
-   * @returns {novatiq: {snowflake: string}}
+   * @returns {{novatiq: {snowflake: string}}}
    */
   decode(novatiqId, config) {
     let responseObj = {
@@ -60,7 +60,7 @@ export const novatiqIdSubmodule = {
    * performs action to obtain id and return a value in the callback's response argument
    * @function
    * @param {SubmoduleConfig} config
-   * @returns {id: string}
+   * @returns {string}
    */
   getId(config) {
     const configParams = config.params || {};

--- a/modules/oneKeyIdSystem.js
+++ b/modules/oneKeyIdSystem.js
@@ -61,7 +61,7 @@ export const oneKeyIdSubmodule = {
   /**
    * decode the stored data value for passing to bid requests
    * @function decode
-   * @param {(Object|string)} value
+   * @param {(Object|string)} data
    * @returns {(Object|undefined)}
    */
   decode(data) {
@@ -71,7 +71,6 @@ export const oneKeyIdSubmodule = {
    * performs action to obtain id and return a value in the callback's response argument
    * @function
    * @param {SubmoduleConfig} [config]
-   * @param {ConsentData} [consentData]
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */

--- a/modules/oneKeyRtdProvider.js
+++ b/modules/oneKeyRtdProvider.js
@@ -22,9 +22,8 @@ window.OneKey.queue = window.OneKey.queue || [];
  * https://docs.prebid.org/dev-docs/add-rtd-submodule.html#getbidrequestdata
  *
  * @param {Object} reqBidsConfigObj
- * @param {function} callback
+ * @param {function} done
  * @param {Object} rtdConfig
- * @param {Object} userConsent
  */
 const getTransmissionInBidRequest = (reqBidsConfigObj, done, rtdConfig) => {
   const adUnits = reqBidsConfigObj.adUnits || getGlobal().adUnits;

--- a/modules/operaadsBidAdapter.js
+++ b/modules/operaadsBidAdapter.js
@@ -186,14 +186,14 @@ export const spec = {
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
    *
-   * @param {data} timeoutData Containing timeout specific data
+   * @param {Object} timeoutData Containing timeout specific data
    */
   onTimeout: function (timeoutData) { },
 
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
    *
-   * @param {Bid} bid The bid that won the auction
+   * @param {Object} bid The bid that won the auction
    */
   onBidWon: function (bid) {
     if (!bid || !isStr(bid.nurl)) {
@@ -486,9 +486,9 @@ function interpretNativeAd(nativeResponse, currency, cpm) {
 /**
  * Create an imp array
  *
- * @param {BidRequest} bidRequest
- * @param {Currency} cur
- * @returns {Imp[]}
+ * @param {Object} bidRequest
+ * @param {string} cur
+ * @returns {Array}
  */
 function createImp(bidRequest) {
   const imp = [];

--- a/modules/optidigitalBidAdapter.js
+++ b/modules/optidigitalBidAdapter.js
@@ -40,8 +40,9 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @return ServerRequest Info describing the request to the server.
+   * @param {Array} validBidRequests - an array of bids
+   * @param {Object} bidderRequest
+   * @return {Object} Info describing the request to the server.
    */
   buildRequests: function(validBidRequests, bidderRequest) {
     if (!validBidRequests || validBidRequests.length === 0 || !bidderRequest || !bidderRequest.bids) {

--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -147,7 +147,7 @@ export const spec = {
 /**
  * Get bid floor from Price Floors Module
  * @param {Object} bid
- * @returns {float||undefined}
+ * @returns {(number|undefined)}
  */
 function getBidFloor(bid) {
   if (!isFn(bid.getFloor)) {

--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -375,9 +375,9 @@ export function partitionBuyersByBidder(igbRequests) {
 /**
  * Expand PAAPI api filters into a map from ad unit code to auctionId.
  *
- * @param auctionId when specified, the result will have this as the value for each entry.
- * when not specified, each ad unit will map to the latest auction that involved that ad unit.
- * @param adUnitCode when specified, the result will contain only one entry (for this ad unit) or be empty (if this ad
+ * @param {string} [auctionId] when specified, the result will have this as the value for each entry.
+ *   when not specified, each ad unit will map to the latest auction that involved that ad unit.
+ * @param {string} [adUnitCode] when specified, the result will contain only one entry (for this ad unit) or be empty (if this ad
  * unit was never involved in an auction).
  * when not specified, the result will contain an entry for every ad unit that was involved in any auction.
  * @return {{[adUnitCode: string]: string}}

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -894,7 +894,7 @@ config.getConfig('aliasRegistry', config => {
  * The bid response object returned by an external bidder adapter during the auction.
  * @typedef {Object} AdapterBidResponse
  * @property {string} pbAg Auto granularity price bucket; CPM <= 5 ? increment = 0.05 : CPM > 5 && CPM <= 10 ? increment = 0.10 : CPM > 10 && CPM <= 20 ? increment = 0.50 : CPM > 20 ? priceCap = 20.00.  Example: `"0.80"`.
- * @property {string} pbCg Custom price bucket.  For example setup, see {@link setPriceGranularity}.  Example: `"0.84"`.
+ * @property {string} pbCg Custom price bucket.  For example setup, see `setConfig({ priceGranularity: ... })`.  Example: `"0.84"`.
  * @property {string} pbDg Dense granularity price bucket; CPM <= 3 ? increment = 0.01 : CPM > 3 && CPM <= 8 ? increment = 0.05 : CPM > 8 && CPM <= 20 ? increment = 0.50 : CPM > 20? priceCap = 20.00.  Example: `"0.84"`.
  * @property {string} pbLg Low granularity price bucket; $0.50 increment, capped at $5, floored to two decimal places.  Example: `"0.50"`.
  * @property {string} pbMg Medium granularity price bucket; $0.10 increment, capped at $20, floored to two decimal places.  Example: `"0.80"`.

--- a/src/utils/focusTimeout.js
+++ b/src/utils/focusTimeout.js
@@ -26,9 +26,9 @@ export function reset() {
 /**
  * Wraps native setTimeout function in order to count time only when page is focused
  *
- * @param {function(*): ()} [callback] - A function that will be invoked after passed time
+ * @param {function(): void} [callback] - A function that will be invoked after the passed time
  * @param {number} [milliseconds] - Minimum duration (in milliseconds) that the callback will be executed after
- * @returns {function(*): (number)} - Getter function for current timer id
+ * @returns {function(): number} - Getter function for current timer id
  */
 export function setFocusTimeout(callback, milliseconds) {
   const startTime = timeOutOfFocus;

--- a/src/utils/perfMetrics.js
+++ b/src/utils/perfMetrics.js
@@ -129,11 +129,11 @@ export function metricsFactory({now = getTime, mkNode = makeNode, mkTimer = make
 
       /**
        * @typedef {Function} HookFn
-       * @property {Function(T): void} bail
+       * @property {(function(T): void)} bail
        *
        * @template T
        * @typedef {HookFn} TimedHookFn
-       * @property {Function(): void} stopTiming
+       * @property {(function(): void)} stopTiming
        * @property {T} untimed
        */
 

--- a/src/utils/ttlCollection.js
+++ b/src/utils/ttlCollection.js
@@ -5,25 +5,26 @@ import {setFocusTimeout} from './focusTimeout.js';
 /**
  * Create a set-like collection that automatically forgets items after a certain time.
  *
- * @param {function(*): (number|Promise<number>)} [startTime=timestamp] - A function taking an item added to this collection,
+ * @param {Object} [options={}] - Optional settings
+ * @param {function(*): (number|Promise<number>)} [options.startTime=timestamp] - A function taking an item added to this collection,
  *   and returning (a promise to) a timestamp to be used as the starting time for the item
  *   (the item will be dropped after `ttl(item)` milliseconds have elapsed since this timestamp).
  *   Defaults to the time the item was added to the collection.
- * @param {function(*): (number|void|Promise<number|void>)} [ttl=() => null] - A function taking an item added to this collection,
+ * @param {function(*): (number|void|Promise<number|void>)} [options.ttl=() => null] - A function taking an item added to this collection,
  *   and returning (a promise to) the duration (in milliseconds) the item should be kept in it.
  *   May return null to indicate that the item should be persisted indefinitely.
- * @param {boolean} [monotonic=false] - Set to true for better performance, but only if, given any two items A and B in this collection:
+ * @param {boolean} [options.monotonic=false] - Set to true for better performance, but only if, given any two items A and B in this collection:
  *   if A was added before B, then:
  *     - startTime(A) + ttl(A) <= startTime(B) + ttl(B)
  *     - Promise.all([startTime(A), ttl(A)]) never resolves later than Promise.all([startTime(B), ttl(B)])
- * @param {number} [slack=5000] - Maximum duration (in milliseconds) that an item is allowed to persist
+ * @param {number} [options.slack=5000] - Maximum duration (in milliseconds) that an item is allowed to persist
  *   once past its TTL. This is also roughly the interval between "garbage collection" sweeps.
  * @returns {Object} A set-like collection with automatic TTL expiration.
  * @returns {function(*): void} return.add - Add an item to the collection.
  * @returns {function(): void} return.clear - Clear the collection.
  * @returns {function(): Array<*>} return.toArray - Get all the items in the collection, in insertion order.
  * @returns {function(): void} return.refresh - Refresh the TTL for each item in the collection.
- * @returns {function(function(*)): function(): void} return.onExpiry - Register a callback to be run when an item has expired and is about to be
+ * @returns {(function(function(*): void): function(): void)} return.onExpiry - Register a callback to be run when an item has expired and is about to be
  *   removed from the collection. Returns an un-registration function
  */
 export function ttlCollection(


### PR DESCRIPTION
## Summary
- fix incorrect `setPriceGranularity` reference
- clarify parameter/return types in `focusTimeout`, `perfMetrics` and `ttlCollection`
- address numerous JSDoc warnings across modules

## Testing
- `npm run lint`
