### PR TITLE
Refactor layout calculations

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { hasPurpose1Consent } from '../src/utils/gdpr.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
+import { getViewportCoordinates } from '../libraries/viewport/viewport.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -267,9 +268,10 @@ function getUserId(id, source, uidExt, atype) {
 function getOffset(el) {
   if (el) {
     const rect = getBoundingClientRect(el);
+    const viewport = getViewportCoordinates();
     return {
-      left: rect.left + window.scrollX,
-      top: rect.top + window.scrollY
+      left: rect.left + (viewport.left || 0),
+      top: rect.top + (viewport.top || 0)
     };
   }
 }

--- a/modules/cwireBidAdapter.js
+++ b/modules/cwireBidAdapter.js
@@ -2,6 +2,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {generateUUID, getParameterByName, isNumber, logError, logInfo} from '../src/utils.js';
+import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
 import { sendBeacon } from '../src/ajax.js';
 
@@ -37,8 +38,7 @@ function slotDimensions(bid) {
 
   if (slotEl) {
     logInfo(`Slot element found: ${adUnitCode}`)
-    const slotW = slotEl.offsetWidth
-    const slotH = slotEl.offsetHeight
+    const { width: slotW, height: slotH } = getBoundingClientRect(slotEl);
     const cssMaxW = slotEl.style?.maxWidth;
     const cssMaxH = slotEl.style?.maxHeight;
     logInfo(`Slot dimensions (w/h): ${slotW} / ${slotH}`)

--- a/modules/h12mediaBidAdapter.js
+++ b/modules/h12mediaBidAdapter.js
@@ -1,4 +1,4 @@
-import { inIframe, logError, logMessage, deepAccess } from '../src/utils.js';
+import { inIframe, logError, logMessage, deepAccess, getWinDimensions } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { getViewportSize } from '../libraries/viewport/viewport.js';
@@ -219,8 +219,10 @@ function getClientDimensions() {
 
 function getDocumentDimensions() {
   try {
-    const D = window.top.document;
-    return [D.body.offsetWidth, Math.max(D.body.scrollHeight, D.documentElement.scrollHeight, D.body.offsetHeight, D.documentElement.offsetHeight, D.body.clientHeight, D.documentElement.clientHeight)]
+    const {document: {documentElement, body}} = getWinDimensions();
+    const width = body.clientWidth;
+    const height = Math.max(body.scrollHeight, body.offsetHeight, documentElement.clientHeight, documentElement.scrollHeight, documentElement.offsetHeight);
+    return [width, height];
   } catch (t) {
     return [-1, -1]
   }

--- a/modules/nexx360BidAdapter.js
+++ b/modules/nexx360BidAdapter.js
@@ -6,6 +6,7 @@ import {getGlobal} from '../src/prebidGlobal.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js'
 
 import { createResponse, enrichImp, enrichRequest, getAmxId, getUserSyncs } from '../libraries/nexx360Utils/index.js';
+import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -77,8 +78,9 @@ const converter = ortbConverter({
     const divId = bidRequest.params.divId || bidRequest.adUnitCode;
     const slotEl = document.getElementById(divId);
     if (slotEl) {
-      deepSetValue(imp, 'ext.dimensions.slotW', slotEl.offsetWidth);
-      deepSetValue(imp, 'ext.dimensions.slotH', slotEl.offsetHeight);
+      const { width, height } = getBoundingClientRect(slotEl);
+      deepSetValue(imp, 'ext.dimensions.slotW', width);
+      deepSetValue(imp, 'ext.dimensions.slotH', height);
       deepSetValue(imp, 'ext.dimensions.cssMaxW', slotEl.style?.maxWidth);
       deepSetValue(imp, 'ext.dimensions.cssMaxH', slotEl.style?.maxHeight);
     }

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { _map, getWinDimensions, isArray, triggerPixel } from '../src/utils.js';
+import { getViewportCoordinates } from '../libraries/viewport/viewport.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -221,12 +222,12 @@ function ttfb() {
 function geom(adunitCode) {
   const slot = document.getElementById(adunitCode);
   if (slot) {
-    const scrollY = window.scrollY;
     const { top, left, width, height } = getBoundingClientRect(slot);
     const viewport = {
       width: getWinDimensions().innerWidth,
       height: getWinDimensions().innerHeight,
     };
+    const scrollY = getViewportCoordinates().top || 0;
 
     return {
       scrollY,

--- a/modules/undertoneBidAdapter.js
+++ b/modules/undertoneBidAdapter.js
@@ -3,6 +3,8 @@
  */
 
 import {deepAccess, parseUrl, extractDomainFromHost, getWinDimensions} from '../src/utils.js';
+import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
+import { getViewportCoordinates } from '../libraries/viewport/viewport.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 
@@ -37,23 +39,13 @@ function getGdprQueryParams(gdprConsent) {
 }
 
 function getBannerCoords(id) {
-  let element = document.getElementById(id);
-  let left = -1;
-  let top = -1;
+  const element = document.getElementById(id);
   if (element) {
-    left = element.offsetLeft;
-    top = element.offsetTop;
-
-    let parent = element.offsetParent;
-    if (parent) {
-      left += parent.offsetLeft;
-      top += parent.offsetTop;
-    }
-
-    return [left, top];
-  } else {
-    return null;
+    const {left, top} = getBoundingClientRect(element);
+    const viewport = getViewportCoordinates();
+    return [Math.round(left + (viewport.left || 0)), Math.round(top + (viewport.top || 0))];
   }
+  return null;
 }
 
 export const spec = {

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -86,7 +86,8 @@ describe('C-WIRE bid adapter', () => {
       const documentStub = sandbox.stub(document, 'getElementById');
       documentStub.withArgs(`${bidRequests[0].adUnitCode}`).returns({
         offsetWidth: 200,
-        offsetHeight: 250
+        offsetHeight: 250,
+        getBoundingClientRect() { return { width: 200, height: 250 }; }
       });
     });
     it('width and height should be set', function () {
@@ -115,7 +116,8 @@ describe('C-WIRE bid adapter', () => {
         style: {
           maxWidth: '400px',
           maxHeight: '350px',
-        }
+        },
+        getBoundingClientRect() { return { width: 0, height: 0 }; }
       });
     });
     it('css maxWidth should be set', function () {
@@ -231,7 +233,9 @@ describe('C-WIRE bid adapter', () => {
   describe('buildRequests maps flattens params for legacy compat', function () {
     before(function () {
       const documentStub = sandbox.stub(document, 'getElementById');
-      documentStub.withArgs(`${bidRequests[0].adUnitCode}`).returns({});
+      documentStub.withArgs(`${bidRequests[0].adUnitCode}`).returns({
+        getBoundingClientRect() { return { width: 0, height: 0 }; }
+      });
     });
     it('pageId flattened', function () {
       let bidRequest = deepClone(bidRequests[0]);

--- a/test/spec/modules/nexx360BidAdapter_spec.js
+++ b/test/spec/modules/nexx360BidAdapter_spec.js
@@ -186,7 +186,8 @@ describe('Nexx360 bid adapter tests', () => {
         style: {
           maxWidth: '400px',
           maxHeight: '350px',
-        }
+        },
+        getBoundingClientRect() { return { width: 200, height: 250 }; }
       });
       sandbox.stub(STORAGE, 'localStorageIsEnabled').callsFake(() => true);
       sandbox.stub(STORAGE, 'setDataInLocalStorage');

--- a/test/spec/modules/undertoneBidAdapter_spec.js
+++ b/test/spec/modules/undertoneBidAdapter_spec.js
@@ -310,7 +310,8 @@ describe('Undertone Adapter', () => {
         offsetLeft: 100,
         offsetTop: 100,
         offsetWidth: 300,
-        offsetHeight: 250
+        offsetHeight: 250,
+        getBoundingClientRect() { return { left: 100, top: 100, width: 300, height: 250 }; }
       };
 
       sandbox = sinon.sandbox.create();
@@ -518,8 +519,8 @@ describe('Undertone Adapter', () => {
       const request = spec.buildRequests(bidReq, bidderReq);
       const bid1 = JSON.parse(request.data)['x-ut-hb-params'][0];
       expect(bid1.coordinates).to.be.an('array');
-      expect(bid1.coordinates[0]).to.equal(200);
-      expect(bid1.coordinates[1]).to.equal(200);
+      expect(bid1.coordinates[0]).to.equal(100);
+      expect(bid1.coordinates[1]).to.equal(100);
     });
   });
 


### PR DESCRIPTION
## Summary
- use viewport utilities in Undertone and CWire adapters
- use viewport utilities in H12Media, Seedtag, Concert, and Nexx360 modules

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for ChromeHeadless)*