### PR TITLE
Add CodeQL check for application/json requests

### DIFF
--- a/.github/codeql/queries/jsonRequestContentType.ql
+++ b/.github/codeql/queries/jsonRequestContentType.ql
@@ -1,0 +1,16 @@
+/**
+ * @id prebid/json-request-content-type
+ * @name Application/json request type in bidder
+ * @kind problem
+ * @problem.severity warning
+ * @description Using 'application/json' as request type triggers browser preflight requests and may increase bidder timeouts
+ */
+
+import javascript
+
+from PropertyAssignment prop
+where
+  prop.getPropertyName() = "contentType" and
+  prop.getValue() instanceof StringLiteral and
+  prop.getValue().(StringLiteral).getStringValue() = "application/json"
+select prop, "application/json request type triggers preflight requests and may increase bidder timeouts"


### PR DESCRIPTION
## Summary
- warn in CodeQL when a bidder sets `contentType` to `application/json`

## Testing
- `npm test` *(fails: Browserslist outdated and bundling step hangs)*