### PR TITLE
Fix failsafe targeting for Prebid integration samples

### DIFF
--- a/integrationExamples/gpt/1plusXRtdProviderExample.html
+++ b/integrationExamples/gpt/1plusXRtdProviderExample.html
@@ -65,10 +65,14 @@
       pbjs.adserverRequestSent = true;
 
       googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+          pbjs.que.push(function () {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        } else {
           googletag.pubads().refresh();
-        });
+        }
       });
     }
 

--- a/integrationExamples/gpt/51DegreesRtdProvider_example.html
+++ b/integrationExamples/gpt/51DegreesRtdProvider_example.html
@@ -25,10 +25,14 @@
             if (pbjs.initAdserverSet) return;
 
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
 
             pbjs.initAdserverSet = true;

--- a/integrationExamples/gpt/adUnitFloors.html
+++ b/integrationExamples/gpt/adUnitFloors.html
@@ -75,10 +75,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -109,8 +109,12 @@
 
                 googletag.cmd.push(function() {
                     const adUnitCodes = adUnits.map(adUnit => adUnit.code);
-                    pbjs.setTargetingForGPTAsync(adUnitCodes);
-                    googletag.pubads().refresh();
+                    if (pbjs.libLoaded) {
+                        pbjs.setTargetingForGPTAsync(adUnitCodes);
+                        googletag.pubads().refresh();
+                    } else {
+                        googletag.pubads().refresh();
+                    }
                 });
 
                 var videoBids = bids[videoAdUnit.code];

--- a/integrationExamples/gpt/adnuntius_example.html
+++ b/integrationExamples/gpt/adnuntius_example.html
@@ -64,10 +64,14 @@
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/adnuntius_multiformat_example.html
+++ b/integrationExamples/gpt/adnuntius_multiformat_example.html
@@ -95,10 +95,14 @@
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/advanced_size_mapping.html
+++ b/integrationExamples/gpt/advanced_size_mapping.html
@@ -108,16 +108,20 @@ Feel free to play around with different settings and configurations for size map
 			});
 		});
 
-		function sendAdserverRequest() {
-			if (pbjs.adserverRequestSent) return;
-			pbjs.adserverRequestSent = true;
-			googletag.cmd.push(function () {
-				pbjs.que.push(function () {
-					pbjs.setTargetingForGPTAsync();
-					googletag.pubads().refresh();
-				});
-			});
-		}
+                function sendAdserverRequest() {
+                        if (pbjs.adserverRequestSent) return;
+                        pbjs.adserverRequestSent = true;
+                        googletag.cmd.push(function () {
+                                if (pbjs.libLoaded) {
+                                        pbjs.que.push(function () {
+                                                pbjs.setTargetingForGPTAsync();
+                                                googletag.pubads().refresh();
+                                        });
+                                } else {
+                                        googletag.pubads().refresh();
+                                }
+                        });
+                }
 
 		setTimeout(function () {
 			sendAdserverRequest();

--- a/integrationExamples/gpt/airgridRtdProvider_example.html
+++ b/integrationExamples/gpt/airgridRtdProvider_example.html
@@ -91,10 +91,14 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function () {
-          pbjs.que.push(function () {
-            pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function () {
+              pbjs.setTargetingForGPTAsync();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
 

--- a/integrationExamples/gpt/akamaidap_segments_example.html
+++ b/integrationExamples/gpt/akamaidap_segments_example.html
@@ -97,10 +97,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/anonymised_segments_example.html
+++ b/integrationExamples/gpt/anonymised_segments_example.html
@@ -78,10 +78,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/azerionedgeRtdProvider_example.html
+++ b/integrationExamples/gpt/azerionedgeRtdProvider_example.html
@@ -66,10 +66,14 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function () {
-          pbjs.que.push(function () {
-            pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function () {
+              pbjs.setTargetingForGPTAsync();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
       setTimeout(sendAdserverRequest, FAILSAFE_TIMEOUT);

--- a/integrationExamples/gpt/blueconicRtdProvider_example.html
+++ b/integrationExamples/gpt/blueconicRtdProvider_example.html
@@ -71,10 +71,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/contxtfulRtdProvider_example.html
+++ b/integrationExamples/gpt/contxtfulRtdProvider_example.html
@@ -151,10 +151,14 @@ function refreshBids() {
 
 function initAdserver() {
   googletag.cmd.push(function () {
-    pbjs.que.push(function () {
-      pbjs.setTargetingForGPTAsync();
+    if (pbjs.libLoaded) {
+      pbjs.que.push(function () {
+        pbjs.setTargetingForGPTAsync();
+        googletag.pubads().refresh();
+      });
+    } else {
       googletag.pubads().refresh();
-    });
+    }
   });
 }
 

--- a/integrationExamples/gpt/esp_example.html
+++ b/integrationExamples/gpt/esp_example.html
@@ -125,11 +125,15 @@
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    pbjs.registerSignalSources();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        pbjs.registerSignalSources();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
         // in case PBJS doesn't load

--- a/integrationExamples/gpt/gdpr_hello_world.html
+++ b/integrationExamples/gpt/gdpr_hello_world.html
@@ -70,10 +70,14 @@
           if (pbjs.adserverRequestSent) return;
           pbjs.adserverRequestSent = true;
           googletag.cmd.push(function() {
-            pbjs.que.push(function() {
-              pbjs.setTargetingForGPTAsync();
+            if (pbjs.libLoaded) {
+              pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+              });
+            } else {
               googletag.pubads().refresh();
-            });
+            }
           });
         }
 

--- a/integrationExamples/gpt/gpp_us_hello_world.html
+++ b/integrationExamples/gpt/gpp_us_hello_world.html
@@ -87,10 +87,14 @@
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
       googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+          pbjs.que.push(function () {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        } else {
           googletag.pubads().refresh();
-        });
+        }
       });
     }
 

--- a/integrationExamples/gpt/gpp_us_hello_world_iframe_subpage.html
+++ b/integrationExamples/gpt/gpp_us_hello_world_iframe_subpage.html
@@ -84,10 +84,14 @@
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
       googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+          pbjs.que.push(function () {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        } else {
           googletag.pubads().refresh();
-        });
+        }
       });
     }
 

--- a/integrationExamples/gpt/growthcode.html
+++ b/integrationExamples/gpt/growthcode.html
@@ -101,10 +101,14 @@
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
       googletag.cmd.push(function() {
-        pbjs.que.push(function() {
-          pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+          pbjs.que.push(function() {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        } else {
           googletag.pubads().refresh();
-        });
+        }
       });
     }
 

--- a/integrationExamples/gpt/hadronRtdProvider_example.html
+++ b/integrationExamples/gpt/hadronRtdProvider_example.html
@@ -71,10 +71,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/hello_world.html
+++ b/integrationExamples/gpt/hello_world.html
@@ -59,10 +59,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/idImportLibrary_example.html
+++ b/integrationExamples/gpt/idImportLibrary_example.html
@@ -122,10 +122,14 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+              pbjs.setTargetingForGPTAsync();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
       var FAILSAFE_TIMEOUT = 2000;

--- a/integrationExamples/gpt/id_lift_measurement.html
+++ b/integrationExamples/gpt/id_lift_measurement.html
@@ -89,8 +89,12 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.setTargetingForGPTAsync();
-                googletag.pubads().refresh();
+                if (pbjs.libLoaded) {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                } else {
+                    googletag.pubads().refresh();
+                }
             });
         }
 

--- a/integrationExamples/gpt/imRtdProvider_example.html
+++ b/integrationExamples/gpt/imRtdProvider_example.html
@@ -63,10 +63,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/ixMultiFormat.html
+++ b/integrationExamples/gpt/ixMultiFormat.html
@@ -80,10 +80,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/liveIntentRtdProviderExample.html
+++ b/integrationExamples/gpt/liveIntentRtdProviderExample.html
@@ -119,10 +119,14 @@
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
         // in case PBJS doesn't load

--- a/integrationExamples/gpt/mgidRtdProvider_example.html
+++ b/integrationExamples/gpt/mgidRtdProvider_example.html
@@ -111,8 +111,12 @@
         if (pbjs.initAdserverSet) return;
         pbjs.initAdserverSet = true;
         googletag.cmd.push(function () {
-          pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
+          if (pbjs.libLoaded) {
+            pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          } else {
+            googletag.pubads().refresh();
+          }
         });
       }
 

--- a/integrationExamples/gpt/neuwoRtdProvider_example.html
+++ b/integrationExamples/gpt/neuwoRtdProvider_example.html
@@ -135,10 +135,14 @@
                 if (pbjs.initAdserverSet) return;
                 pbjs.initAdserverSet = true;
                 googletag.cmd.push(function() {
-                    pbjs.que.push(function() {
-                        pbjs.setTargetingForGPTAsync();
+                    if (pbjs.libLoaded) {
+                        pbjs.que.push(function() {
+                            pbjs.setTargetingForGPTAsync();
+                            googletag.pubads().refresh();
+                        });
+                    } else {
                         googletag.pubads().refresh();
-                    });
+                    }
                 });
             }
 

--- a/integrationExamples/gpt/nexverse.html
+++ b/integrationExamples/gpt/nexverse.html
@@ -82,10 +82,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/optableRtdProvider_example.html
+++ b/integrationExamples/gpt/optableRtdProvider_example.html
@@ -70,10 +70,14 @@
             if (pbjs.initAdserverSet) return;
 
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
 
             pbjs.initAdserverSet = true;

--- a/integrationExamples/gpt/optimeraRtdProvider_example.html
+++ b/integrationExamples/gpt/optimeraRtdProvider_example.html
@@ -97,10 +97,14 @@
       if (pbjs.initAdserverSet) return;
       pbjs.initAdserverSet = true;
       googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-              pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+              pbjs.que.push(function() {
+                  pbjs.setTargetingForGPTAsync();
+                  googletag.pubads().refresh();
+              });
+          } else {
               googletag.pubads().refresh();
-          });
+          }
       });
   }
   // in case PBJS doesn't load

--- a/integrationExamples/gpt/paapi_example.html
+++ b/integrationExamples/gpt/paapi_example.html
@@ -63,11 +63,15 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
-            pbjs.setPAAPIConfigForGPT();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+              pbjs.setTargetingForGPTAsync();
+              pbjs.setPAAPIConfigForGPT();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
 

--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -227,10 +227,14 @@
                 if (pbjs.initAdserverSet) return;
                 pbjs.initAdserverSet = true;
                 googletag.cmd.push(function() {
-                    pbjs.que.push(function() {
-                        pbjs.setTargetingForGPTAsync();
+                    if (pbjs.libLoaded) {
+                        pbjs.que.push(function() {
+                            pbjs.setTargetingForGPTAsync();
+                            googletag.pubads().refresh();
+                        });
+                    } else {
                         googletag.pubads().refresh();
-                    });
+                    }
                 });
             }
             // in case PBJS doesn't load

--- a/integrationExamples/gpt/prebidServer_paapi_example.html
+++ b/integrationExamples/gpt/prebidServer_paapi_example.html
@@ -68,10 +68,14 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+              pbjs.setTargetingForGPTAsync();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
 

--- a/integrationExamples/gpt/precisoExample.html
+++ b/integrationExamples/gpt/precisoExample.html
@@ -109,7 +109,9 @@
         },
         enableTIDs: true
       });
-      pbjs.setTargetingForGPTAsync();
+      if (pbjs.libLoaded) {
+        pbjs.setTargetingForGPTAsync();
+      }
       pbjs.requestBids({
         bidsBackHandler: function () {
           // call for the bid response which have the high bid price 

--- a/integrationExamples/gpt/proxistore_example.html
+++ b/integrationExamples/gpt/proxistore_example.html
@@ -80,10 +80,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/publir_hello_world.html
+++ b/integrationExamples/gpt/publir_hello_world.html
@@ -48,10 +48,14 @@
 
         function sendAdserverRequest() {
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync('div-gpt-ad-1460505748561-0');
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync('div-gpt-ad-1460505748561-0');
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/raveltechRtdProvider_example.html
+++ b/integrationExamples/gpt/raveltechRtdProvider_example.html
@@ -324,10 +324,14 @@
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
       googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+          pbjs.que.push(function () {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        } else {
           googletag.pubads().refresh();
-        });
+        }
       });
     }
 

--- a/integrationExamples/gpt/raynRtdProvider_example.html
+++ b/integrationExamples/gpt/raynRtdProvider_example.html
@@ -116,15 +116,19 @@
         document.getElementById("rayn-segments").innerHTML =
           window.localStorage.getItem("rayn-segtax");
 
-        if (pbjs.adserverRequestSent) return;
-        pbjs.adserverRequestSent = true;
-        googletag.cmd.push(function () {
+      if (pbjs.adserverRequestSent) return;
+      pbjs.adserverRequestSent = true;
+      googletag.cmd.push(function () {
+        if (pbjs.libLoaded) {
           pbjs.que.push(function () {
             pbjs.setTargetingForGPTAsync();
             googletag.pubads().refresh();
           });
-        });
-      }
+        } else {
+          googletag.pubads().refresh();
+        }
+      });
+    }
 
       setTimeout(function () {
         sendAdserverRequest();

--- a/integrationExamples/gpt/reconciliationRtdProvider_example.html
+++ b/integrationExamples/gpt/reconciliationRtdProvider_example.html
@@ -67,10 +67,14 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+              pbjs.setTargetingForGPTAsync();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
 

--- a/integrationExamples/gpt/relevadRtdProvider_example.html
+++ b/integrationExamples/gpt/relevadRtdProvider_example.html
@@ -92,10 +92,14 @@
         if (pbjs.initAdserverSet) return;
         pbjs.initAdserverSet = true;
         googletag.cmd.push(function() {
-            pbjs.que.push(function() {
-                pbjs.setTargetingForGPTAsync();
+            if (pbjs.libLoaded) {
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            } else {
                 googletag.pubads().refresh();
-            });
+            }
         });
     }
 

--- a/integrationExamples/gpt/revcontent_example_banner.html
+++ b/integrationExamples/gpt/revcontent_example_banner.html
@@ -74,11 +74,15 @@
         });
         function sendAdServerRequest() {
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync('/21623266709/prebid-test');
-                    pbjs.setTargetingForGPTAsync('/21623266709/prebid-test-2');
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync('/21623266709/prebid-test');
+                        pbjs.setTargetingForGPTAsync('/21623266709/prebid-test-2');
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
     </script>

--- a/integrationExamples/gpt/revcontent_example_native.html
+++ b/integrationExamples/gpt/revcontent_example_native.html
@@ -73,8 +73,12 @@
                 if (pbjs.initAdserverSet) return;
                 pbjs.initAdserverSet = true;
                 googletag.cmd.push(function() {
-                    pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
+                    if (pbjs.libLoaded) {
+                        pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    } else {
+                        googletag.pubads().refresh();
+                    }
                 });
             }
             

--- a/integrationExamples/gpt/rewardedInterestIdSystem_example.html
+++ b/integrationExamples/gpt/rewardedInterestIdSystem_example.html
@@ -60,10 +60,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/sirdataRtdProvider_example.html
+++ b/integrationExamples/gpt/sirdataRtdProvider_example.html
@@ -105,10 +105,14 @@
         if (pbjs.initAdserverSet) return;
         pbjs.initAdserverSet = true;
         googletag.cmd.push(function() {
-            pbjs.que.push(function() {
-                pbjs.setTargetingForGPTAsync();
+            if (pbjs.libLoaded) {
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            } else {
                 googletag.pubads().refresh();
-            });
+            }
         });
     }
 

--- a/integrationExamples/gpt/symitridap_segments_example.html
+++ b/integrationExamples/gpt/symitridap_segments_example.html
@@ -96,10 +96,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -303,10 +303,14 @@
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
       googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+          pbjs.que.push(function () {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+          });
+        } else {
           googletag.pubads().refresh();
-        });
+        }
       });
     }
 

--- a/integrationExamples/gpt/weboramaRtdProvider_example.html
+++ b/integrationExamples/gpt/weboramaRtdProvider_example.html
@@ -153,10 +153,14 @@
         if (pbjs.initAdserverSet) return;
         pbjs.initAdserverSet = true;
         googletag.cmd.push(function () {
-          pbjs.que.push(function () {
-            pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function () {
+              pbjs.setTargetingForGPTAsync();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
 

--- a/integrationExamples/gpt/wurflRtdProvider_example.html
+++ b/integrationExamples/gpt/wurflRtdProvider_example.html
@@ -70,10 +70,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 

--- a/integrationExamples/top-level-paapi/gam-contextual.html
+++ b/integrationExamples/top-level-paapi/gam-contextual.html
@@ -82,10 +82,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
+                if (pbjs.libLoaded) {
+                    pbjs.que.push(function () {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+                } else {
                     googletag.pubads().refresh();
-                });
+                }
             });
         }
 


### PR DESCRIPTION
## Summary
- improve failsafe handling in integration examples
- check `pbjs.libLoaded` before calling Prebid targeting

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser)*