### PR TITLE
Add anchor ad support

### DIFF
--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -127,7 +127,7 @@ function creativeMessageHandler(deps) {
 }
 
 export const getRenderingData = hook('sync', function (bidResponse, options) {
-  const {ad, adUrl, cpm, originalCpm, width, height, instl} = bidResponse
+  const {ad, adUrl, cpm, originalCpm, width, height, instl, anchor} = bidResponse
   const repl = {
     AUCTION_PRICE: originalCpm || cpm,
     CLICKTHROUGH: options?.clickUrl || ''
@@ -137,7 +137,8 @@ export const getRenderingData = hook('sync', function (bidResponse, options) {
     adUrl: replaceMacros(adUrl, repl),
     width,
     height,
-    instl
+    instl,
+    anchor
   };
 })
 
@@ -154,9 +155,9 @@ export const doRender = hook('sync', function({renderFn, resizeFn, bidResponse, 
   }
   const data = getRenderingData(bidResponse, options);
   renderFn(Object.assign({adId: bidResponse.adId}, data));
-  const {width, height} = data;
+  const {width, height, anchor} = data;
   if ((width ?? height) != null) {
-    resizeFn(width, height);
+    resizeFn(width, height, anchor);
   }
 });
 
@@ -256,10 +257,17 @@ export function renderAdDirect(doc, adId, options) {
   function fail(reason, message) {
     emitAdRenderFail(Object.assign({id: adId, bid}, {reason, message}));
   }
-  function resizeFn(width, height) {
+  function resizeFn(width, height, anchor) {
     const frame = doc.defaultView?.frameElement;
     if (frame) {
-      if (width) {
+      if (anchor) {
+        if (width) {
+          frame.width = width;
+        }
+        frame.style.width = '100%';
+        frame.style.marginLeft = 'auto';
+        frame.style.marginRight = 'auto';
+      } else if (width) {
         frame.width = width;
         frame.style.width && (frame.style.width = `${width}px`);
       }

--- a/src/auction.js
+++ b/src/auction.js
@@ -638,6 +638,7 @@ function getPreparedBidForAuction(bid, {index = auctionManager.index} = {}) {
 
   const adUnit = index.getAdUnit(bid);
   bid.instl = adUnit?.ortb2Imp?.instl === 1;
+  bid.anchor = !!adUnit?.anchor;
 
   // a publisher-defined renderer can be used to render bids
   const bidRenderer = index.getBidRequest(bid)?.renderer || adUnit.renderer;

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -80,8 +80,8 @@ function getResizer(adId, bidResponse) {
   // in some situations adId !== bidResponse.adId
   // the first is the one that was requested and is tied to the element
   // the second is the one that is being rendered (sometimes different, e.g. in some paapi setups)
-  return function (width, height) {
-    resizeRemoteCreative({...bidResponse, width, height, adId});
+  return function (width, height, anchor = bidResponse.anchor) {
+    resizeRemoteCreative({...bidResponse, width, height, anchor, adId});
   }
 }
 function handleRenderRequest(reply, message, bidResponse) {
@@ -135,7 +135,7 @@ function handleEventRequest(reply, data, adObject) {
   return handleCreativeEvent(data, adObject);
 }
 
-export function resizeRemoteCreative({instl, adId, adUnitCode, width, height}) {
+export function resizeRemoteCreative({instl, anchor, adId, adUnitCode, width, height}) {
   // do not resize interstitials - the creative frame takes the full screen and sizing of the ad should
   // be handled within it.
   if (instl) return;
@@ -148,7 +148,12 @@ export function resizeRemoteCreative({instl, adId, adUnitCode, width, height}) {
     let element = getElementByAdUnit(elmType + ':not([style*="display: none"])');
     if (element) {
       let elementStyle = element.style;
-      elementStyle.width = getDimension(width)
+      if (anchor && elmType === 'div') {
+        elementStyle.width = '100%';
+        elementStyle.textAlign = 'center';
+      } else {
+        elementStyle.width = getDimension(width)
+      }
       elementStyle.height = getDimension(height);
     } else {
       logError(`Unable to locate matching page element for adUnitCode ${adUnitCode}.  Can't resize it to ad's dimensions.  Please review setup.`);

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -181,7 +181,7 @@ describe('adRendering', () => {
       it('invokes resizeFn with w/h from rendering data', () => {
         getRenderingDataStub.returns({width: 123, height: 321});
         doRender({renderFn, resizeFn, bidResponse});
-        sinon.assert.calledWith(resizeFn, 123, 321);
+        sinon.assert.calledWith(resizeFn, 123, 321, undefined);
       });
 
       it('does not invoke resizeFn if rendering data has no w/h', () => {

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -589,5 +589,23 @@ describe('secureCreatives', () => {
       });
       sinon.assert.notCalled(document.getElementById);
     })
+
+    it('should apply anchor styling', () => {
+      const div = {style: {}};
+      const iframe = {style: {}};
+      document.getElementById.returns({querySelector: sinon.stub()
+        .onFirstCall().returns(div)
+        .onSecondCall().returns(iframe)});
+      resizeRemoteCreative({
+        adId: 'adId',
+        adUnitCode: 'au1',
+        width: 320,
+        height: 50,
+        anchor: true
+      });
+      expect(div.style.textAlign).to.eql('center');
+      expect(div.style.width).to.eql('100%');
+      expect(iframe.style.width).to.eql('320px');
+    })
   })
 });


### PR DESCRIPTION
## Summary
- support anchor ad units to keep width centered
- include new `anchor` flag from AdUnit to bids
- adjust resizing logic for anchor ads
- test anchor ad behaviour

## Testing
- `gulp lint` *(fails: Browserslist: caniuse-lite is outdated)*
- `gulp test --file test/spec/unit/secureCreatives_spec.js` *(fails: Browserslist: caniuse-lite is outdated)*