### PR TITLE
move eids from user to user.ext

### DIFF
--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -2086,6 +2086,20 @@ describe('adapterManager tests', function () {
       requests.appnexus.bids.forEach((bid) => expect(bid.ortb2).to.eql(requests.appnexus.ortb2));
     });
 
+    it('should move user.eids into user.ext.eids', () => {
+      const global = {
+        user: {
+          eids: [{source: 'idA'}],
+          ext: {eids: [{source: 'idB'}]}
+        }
+      };
+      const reqs = adapterManager.makeBidRequests(adUnits, 123, 'auction-id', 123, [], {global});
+      reqs.forEach(req => {
+        expect(req.ortb2.user.ext.eids).to.deep.equal([{source: 'idB'}, {source: 'idA'}]);
+        expect(req.ortb2.user.eids).to.not.exist;
+      });
+    });
+
     describe('source.tid', () => {
       beforeEach(() => {
         sinon.stub(dep, 'redact').returns({


### PR DESCRIPTION
## Summary
- move any user.eids into user.ext.eids when building FPD
- test that adapterManager does this

## Testing
- `npm run lint`
- `npx gulp test --file test/spec/unit/core/adapterManager_spec.js` *(fails: No binary for ChromeHeadless)*