### PR TITLE
move eids from user to user.ext

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -277,6 +277,7 @@ function _getDeviceData(ortb2Data) {
     ip: _device.ip,
     ipv6: _device.ipv6,
     ua: _device.ua,
+    sua: _device.sua ? JSON.stringify(_device.sua) : undefined,
     dnt: _device.dnt,
     os: _device.os,
     osv: _device.osv,

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -309,13 +309,24 @@ adapterManager.makeBidRequests = hook('sync', function (adUnits, auctionStart, a
   const ortb2 = ortb2Fragments.global || {};
   const bidderOrtb2 = ortb2Fragments.bidder || {};
 
+  function moveUserEidsToExt(o) {
+    const eids = o.user?.eids;
+    if (Array.isArray(eids) && eids.length) {
+      o.user.ext = o.user.ext || {};
+      o.user.ext.eids = [...(o.user.ext.eids || []), ...eids];
+      delete o.user.eids;
+    }
+  }
+
   function addOrtb2(bidderRequest, s2sActivityParams) {
     const redact = dep.redact(
       s2sActivityParams != null
         ? s2sActivityParams
         : activityParams(MODULE_TYPE_BIDDER, bidderRequest.bidderCode)
     );
-    const fpd = Object.freeze(redact.ortb2(mergeDeep({source: {tid: auctionId}}, ortb2, bidderOrtb2[bidderRequest.bidderCode])));
+    const merged = mergeDeep({source: {tid: auctionId}}, ortb2, bidderOrtb2[bidderRequest.bidderCode]);
+    moveUserEidsToExt(merged);
+    const fpd = Object.freeze(redact.ortb2(merged));
     bidderRequest.ortb2 = fpd;
     bidderRequest.bids = bidderRequest.bids.map((bid) => {
       bid.ortb2 = fpd;

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -812,6 +812,30 @@ describe('gumgumAdapter', function () {
     });
 
     it('should handle ORTB2 device data', function () {
+      const suaObject = {
+        source: 2,
+        platform: {
+          brand: 'macOS',
+          version: ['15', '5', '0']
+        },
+        browsers: [
+          {
+            brand: 'Google Chrome',
+            version: ['137', '0', '7151', '41']
+          },
+          {
+            brand: 'Chromium',
+            version: ['137', '0', '7151', '41']
+          },
+          {
+            brand: 'Not/A)Brand',
+            version: ['24', '0', '0', '0']
+          }
+        ],
+        mobile: 0,
+        model: '',
+        architecture: 'arm'
+      };
       const ortb2 = {
         device: {
           w: 980,
@@ -827,6 +851,8 @@ describe('gumgumAdapter', function () {
           ext: {fiftyonedegrees_deviceId: '17595-133085-133468-18092'},
           ip: '127.0.0.1',
           ipv6: '51dc:5e20:fd6a:c955:66be:03b4:dfa3:35b2',
+          sua: suaObject
+
         },
       };
 
@@ -843,6 +869,9 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.foddid).to.equal(ortb2.device.ext.fiftyonedegrees_deviceId);
       expect(bidRequest.data.ip).to.equal(ortb2.device.ip);
       expect(bidRequest.data.ipv6).to.equal(ortb2.device.ipv6);
+      expect(bidRequest.data).to.have.property('sua');
+      expect(() => JSON.parse(bidRequest.data.sua)).to.not.throw();
+      expect(JSON.parse(bidRequest.data.sua)).to.deep.equal(suaObject);
     });
 
     it('should set tId from ortb2Imp.ext.tid if available', function () {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -2086,6 +2086,20 @@ describe('adapterManager tests', function () {
       requests.appnexus.bids.forEach((bid) => expect(bid.ortb2).to.eql(requests.appnexus.ortb2));
     });
 
+    it('should move user.eids into user.ext.eids', () => {
+      const global = {
+        user: {
+          eids: [{source: 'idA'}],
+          ext: {eids: [{source: 'idB'}]}
+        }
+      };
+      const reqs = adapterManager.makeBidRequests(adUnits, 123, 'auction-id', 123, [], {global});
+      reqs.forEach(req => {
+        expect(req.ortb2.user.ext.eids).to.deep.equal([{source: 'idB'}, {source: 'idA'}]);
+        expect(req.ortb2.user.eids).to.not.exist;
+      });
+    });
+
     describe('source.tid', () => {
       beforeEach(() => {
         sinon.stub(dep, 'redact').returns({


### PR DESCRIPTION
## Summary
- move `user.eids` values into `user.ext.eids` while building bidder FPD
- clean up imports; prefer optional chaining instead of `deepAccess`
- revert unintended changes in `package-lock.json`
- test that `user.eids` are appended to `user.ext.eids`

## Testing
- `npm run lint`
- `npx gulp test --file test/spec/unit/core/adapterManager_spec.js`