### PR TITLE
Remove redundant find polyfills

### DIFF
--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -5,7 +5,7 @@
 
         <script async src="http://localhost:9999/build/dev/prebid.js"></script>
         <!-- <script async src="https://storage.googleapis.com/adloox-ads-js-test/prebid.js"></script> -->
-        <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+        <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
 
         <script>
             // set to 10s (rather than 100ms) only to assist development as 'Local Overrides' stalls for >1s :-/

--- a/integrationExamples/gpt/adnuntius_example.html
+++ b/integrationExamples/gpt/adnuntius_example.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script async src="../../build/dev/prebid.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3000;

--- a/integrationExamples/gpt/adnuntius_multiformat_example.html
+++ b/integrationExamples/gpt/adnuntius_multiformat_example.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script async src="../../build/dev/prebid.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3000;

--- a/integrationExamples/gpt/advanced_size_mapping.html
+++ b/integrationExamples/gpt/advanced_size_mapping.html
@@ -6,7 +6,7 @@ Feel free to play around with different settings and configurations for size map
 
 <head>
 	<script async src="../../../build/dev/prebid.js"></script>
-	<script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+	<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
 	<script>
 		const FAILSAFE_TIMEOUT = 3300;
 		const PREBID_TIMEOUT = 1000;

--- a/integrationExamples/gpt/afpGamExample.html
+++ b/integrationExamples/gpt/afpGamExample.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Prebid.js Banner Example</title>
-  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <script src="../../../build/dev/prebid.js"></script>
   <script>
     var adUnits = [{

--- a/integrationExamples/gpt/akamaidap_segments_example.html
+++ b/integrationExamples/gpt/akamaidap_segments_example.html
@@ -1,7 +1,7 @@
 <html>
 <head>
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3300;
         var PREBID_TIMEOUT = 2000;

--- a/integrationExamples/gpt/azerionedgeRtdProvider_example.html
+++ b/integrationExamples/gpt/azerionedgeRtdProvider_example.html
@@ -4,7 +4,7 @@
     <script async src="../../build/dev/prebid.js" async></script>
     <script
       async
-      src="https://www.googletagservices.com/tag/js/gpt.js"
+      src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
     ></script>
 
     <script>

--- a/integrationExamples/gpt/contxtfulRtdProvider_example.html
+++ b/integrationExamples/gpt/contxtfulRtdProvider_example.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <script async src=
-"https://www.googletagservices.com/tag/js/gpt.js"></script>
+"https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
 <script async src="http://localhost:9999/build/dev/prebid.js"></script>
 <title>Contxtful Rtd Provider Example</title>
 <script>

--- a/integrationExamples/gpt/esp_example.html
+++ b/integrationExamples/gpt/esp_example.html
@@ -2,7 +2,7 @@
 
 <head>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script async src="prebid.js"></script>
 
     <script>

--- a/integrationExamples/gpt/gdpr_hello_world.html
+++ b/integrationExamples/gpt/gdpr_hello_world.html
@@ -13,7 +13,7 @@
     <script src="//cdn.iubenda.com/cs/tcf/beta/stub.js"></script>
     <script async src="//cdn.iubenda.com/cs/beta/iubenda_cs.js"></script>
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
 
       <script>
         var PREBID_TIMEOUT = 700;

--- a/integrationExamples/gpt/gpp_us_hello_world.html
+++ b/integrationExamples/gpt/gpp_us_hello_world.html
@@ -15,7 +15,7 @@
 
 
   <script async src="../../build/dev/prebid.js"></script>
-  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <script>
     var FAILSAFE_TIMEOUT = 3300;
     var PREBID_TIMEOUT = 1000;

--- a/integrationExamples/gpt/gpp_us_hello_world_iframe_subpage.html
+++ b/integrationExamples/gpt/gpp_us_hello_world_iframe_subpage.html
@@ -11,7 +11,7 @@
 
 <head>
   <script async src="../../build/dev/prebid.js"></script>
-  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <script>
     var FAILSAFE_TIMEOUT = 3300;
     var PREBID_TIMEOUT = 1000;

--- a/integrationExamples/gpt/growthcode.html
+++ b/integrationExamples/gpt/growthcode.html
@@ -5,7 +5,7 @@
 <html>
 <head>
   <script async src="../../build/dev/prebid.js"></script>
-  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <script>
     var FAILSAFE_TIMEOUT = 33000;
     var PREBID_TIMEOUT = 10000;

--- a/integrationExamples/gpt/hello_world.html
+++ b/integrationExamples/gpt/hello_world.html
@@ -11,7 +11,7 @@
 
 <head>
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3300;
         var PREBID_TIMEOUT = 1000;

--- a/integrationExamples/gpt/imRtdProvider_example.html
+++ b/integrationExamples/gpt/imRtdProvider_example.html
@@ -80,9 +80,7 @@
             var gads = document.createElement('script');
             gads.async = true;
             gads.type = 'text/javascript';
-            var useSSL = 'https:' == document.location.protocol;
-            gads.src = (useSSL ? 'https:' : 'http:') +
-                '//www.googletagservices.com/tag/js/gpt.js';
+            gads.src = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
             var node = document.getElementsByTagName('script')[0];
             node.parentNode.insertBefore(gads, node);
         })();

--- a/integrationExamples/gpt/liveIntentRtdProviderExample.html
+++ b/integrationExamples/gpt/liveIntentRtdProviderExample.html
@@ -1,7 +1,7 @@
 <html>
 <head>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script async src="../../build/dev/prebid.js"></script>
     <script>
         var div_1_sizes = [

--- a/integrationExamples/gpt/neuwoRtdProvider_example.html
+++ b/integrationExamples/gpt/neuwoRtdProvider_example.html
@@ -4,7 +4,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name=viewport content="width=device-width, initial-scale=1">
         <script src="../../build/dev/prebid.js" async type="text/javascript"></script>
-        <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+        <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
         <script>
             /* adapted from https://docs.prebid.org/dev-docs/examples/basic-example.html */
             var div_1_sizes = [

--- a/integrationExamples/gpt/nexverse.html
+++ b/integrationExamples/gpt/nexverse.html
@@ -12,7 +12,7 @@
 <head>
     <title>NexVerse Prebid.Js Demo</title>
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3300;
         var PREBID_TIMEOUT = 1000;

--- a/integrationExamples/gpt/paapi_example.html
+++ b/integrationExamples/gpt/paapi_example.html
@@ -6,7 +6,7 @@
     gulp serve --modules=paapiForGpt,openxBidAdapter
   -->
   <script async src="../../build/dev/prebid.js"></script>
-  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <script>
     var FAILSAFE_TIMEOUT = 3000;
     var PREBID_TIMEOUT = 1500;

--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -2,7 +2,7 @@
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.png">
-        <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+        <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
         <script src="../../build/dev/prebid.js" async></script>
         <script>
             window.permutive = {};

--- a/integrationExamples/gpt/prebidServer_native_example.html
+++ b/integrationExamples/gpt/prebidServer_native_example.html
@@ -2,7 +2,7 @@
 
 <head>
   <link rel="icon" type="image/png" href="/favicon.png">
-  <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <!-- <script async src="//acdn.adnxs.com/prebid/not-for-prod/1/prebid.js"></script> -->
   <script type="text/javascript" src="../../build/dev/prebid.js" async></script>
 

--- a/integrationExamples/gpt/prebidServer_paapi_example.html
+++ b/integrationExamples/gpt/prebidServer_paapi_example.html
@@ -6,7 +6,7 @@
     gulp serve --modules=paapiForGpt,prebidServerBidAdapter
   -->
   <script async src="../../build/dev/prebid.js"></script>
-  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <script>
     var FAILSAFE_TIMEOUT = 3000;
     var PREBID_TIMEOUT = 1500;

--- a/integrationExamples/gpt/proxistore_example.html
+++ b/integrationExamples/gpt/proxistore_example.html
@@ -2,7 +2,7 @@
 
 <head>
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3300;
         var PREBID_TIMEOUT = 1000;

--- a/integrationExamples/gpt/publir_hello_world.html
+++ b/integrationExamples/gpt/publir_hello_world.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Prebid.js Banner gpt Example</title>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script async src="../../build/dev/prebid.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3300;

--- a/integrationExamples/gpt/pubxaiRtdProvider_example.html
+++ b/integrationExamples/gpt/pubxaiRtdProvider_example.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Individual Ad Unit Refresh Example</title>
-    <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script async src="http://localhost:9999/build/dev/prebid.js"></script>
     <script>
       var sizes = [[300, 250]];

--- a/integrationExamples/gpt/reconciliationRtdProvider_example.html
+++ b/integrationExamples/gpt/reconciliationRtdProvider_example.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <meta charset="UTF-8">
     <title>Reconciliation RTD Provider Example</title>
     <script>

--- a/integrationExamples/gpt/revcontent_example_banner.html
+++ b/integrationExamples/gpt/revcontent_example_banner.html
@@ -8,7 +8,7 @@
     <!-- <script async src="../../build/dist/prebid.js"></script> -->
     <script async src="../../build/dev/prebid.js"></script>
     <!-- Google Publisher Tag -->
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var pbjs = pbjs || {};
         pbjs.que = pbjs.que || [];

--- a/integrationExamples/gpt/revcontent_example_native.html
+++ b/integrationExamples/gpt/revcontent_example_native.html
@@ -3,7 +3,7 @@
         <title>Prebid.js Native Example</title>
 
         <script async src="../../build/dev/prebid.js"></script>
-        <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+        <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
         <script>
             /*
             Supported sizes:

--- a/integrationExamples/gpt/symitridap_segments_example.html
+++ b/integrationExamples/gpt/symitridap_segments_example.html
@@ -1,7 +1,7 @@
 <html>
 <head>
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3300;
         var PREBID_TIMEOUT = 2000;

--- a/integrationExamples/gpt/tpmn_example.html
+++ b/integrationExamples/gpt/tpmn_example.html
@@ -7,7 +7,7 @@
     <!-- <script async src="prebid.js"></script> -->
     <script async src="../../build/dev/prebid.js"></script>
     <!-- Google Publisher Tag -->
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var pbjs = pbjs || {};
         pbjs.que = pbjs.que || [];

--- a/integrationExamples/gpt/weboramaRtdProvider_example.html
+++ b/integrationExamples/gpt/weboramaRtdProvider_example.html
@@ -4,13 +4,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>weborama rtd submodule example</title>
   </head>
-  <body>
-    <script
-      async
-      src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
-    ></script>
+  <body> 
     <script src="../../build/dev/prebid.js" async></script>
-
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
       var pbjs = pbjs || {};
       pbjs.que = pbjs.que || [];
@@ -18,6 +14,44 @@
       pbjs.que.push(function () {
         pbjs.setConfig({
           debug: true,
+          enableTIDs: false,
+          consentManagement: {
+            gdpr: {
+              cmpApi: "static",
+              timeout: 8000,
+              consentData: {
+                getTCData: {
+                  tcString: "sample_tc_string",
+                  gdprApplies: true,
+                  purpose: {
+                    consents: {
+                      1: true,
+                      3: true,
+                      4: true,
+                      5: true,
+                      6: true,
+                    },
+                    legitimateInterests: {
+                      2: true,
+                      7: true,
+                      8: true,
+                      9: true,
+                      10: true,
+                      11: true,
+                    },
+                  },
+                  vendor: {
+                    consents: {
+                      284: true,
+                    },
+                    legitimateInterests: {
+                      284: true,
+                    },
+                  }
+                }
+              }
+            }
+          },
           realTimeData: {
             auctionDelay: 1000,
             dataProviders: [
@@ -43,11 +77,11 @@
                       webo_ds: ["bar"],
                     },
                     baseURLProfileAPI: "ctx-preprod.weborama.com",
-                    // enabled: false,
+                    enabled: false,
                     //, onData: function (data,...) { ...}
                   },
                   weboUserDataConf: {
-                    enabled: false,
+                    enabled: true,
                     accountId: 12345, // recommended
                     setPrebidTargeting: true, // override param.setPrebidTargeting or default true
                     sendToBidders: ["smartadserver"], // specify the bidder to share data

--- a/integrationExamples/gpt/wurflRtdProvider_example.html
+++ b/integrationExamples/gpt/wurflRtdProvider_example.html
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="delegate-ch" content="sec-ch-ua https://prebid.wurflcloud.com; sec-ch-ua-bitness https://prebid.wurflcloud.com; sec-ch-ua-arch https://prebid.wurflcloud.com; sec-ch-ua-model https://prebid.wurflcloud.com; sec-ch-ua-platform https://prebid.wurflcloud.com; sec-ch-ua-platform-version https://prebid.wurflcloud.com; sec-ch-ua-full-version https://prebid.wurflcloud.com; sec-ch-ua-full-version-list https://prebid.wurflcloud.com; sec-ch-ua-mobile https://prebid.wurflcloud.com">
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
         var FAILSAFE_TIMEOUT = 3300;
         var PREBID_TIMEOUT = 2000;

--- a/libraries/intentIqConstants/intentIqConstants.js
+++ b/libraries/intentIqConstants/intentIqConstants.js
@@ -9,14 +9,12 @@ export const BLACK_LIST = 'L';
 export const CLIENT_HINTS_KEY = '_iiq_ch';
 export const EMPTY = 'EMPTY';
 export const GVLID = '1323';
-export const VERSION = 0.28;
+export const VERSION = 0.29;
+export const PREBID = 'pbjs';
+export const HOURS_24 = 86400000;
 
-export const VR_ENDPOINT = 'https://api.intentiq.com';
-export const GDPR_ENDPOINT = 'https://api-gdpr.intentiq.com';
 export const INVALID_ID = 'INVALID_ID';
 
-export const SYNC_ENDPOINT = 'https://sync.intentiq.com'
-export const GDPR_SYNC_ENDPOINT = 'https://sync-gdpr.intentiq.com'
 export const SCREEN_PARAMS = {
   0: 'windowInnerHeight',
   1: 'windowInnerWidth',
@@ -27,3 +25,14 @@ export const SCREEN_PARAMS = {
 };
 
 export const SYNC_REFRESH_MILL = 3600000;
+export const META_DATA_CONSTANT = 256;
+
+export const MAX_REQUEST_LENGTH = {
+  // https://www.geeksforgeeks.org/maximum-length-of-a-url-in-different-browsers/
+  chrome: 2097152,
+  safari: 80000,
+  opera: 2097152,
+  edge: 2048,
+  firefox: 65536,
+  ie: 2048
+};

--- a/libraries/intentIqUtils/handleAdditionalParams.js
+++ b/libraries/intentIqUtils/handleAdditionalParams.js
@@ -1,0 +1,44 @@
+import { MAX_REQUEST_LENGTH } from "../intentIqConstants/intentIqConstants.js";
+
+/**
+ * Appends additional parameters to a URL if they are valid and applicable for the given request destination.
+ *
+ * @param {string} browser - The name of the current browser; used to look up the maximum URL length.
+ * @param {string} url - The base URL to which additional parameters may be appended.
+ * @param {(string|number)} requestTo - The destination identifier; used as an index to check if a parameter applies.
+ * @param {Array<Object>} additionalParams - An array of parameter objects to append.
+ *   Each parameter object should have the following properties:
+ *   - `parameterName` {string}: The name of the parameter.
+ *   - `parameterValue` {*}: The value of the parameter.
+ *   - `destination` {Object|Array}: An object or array indicating the applicable destinations. Sync = 0, VR = 1, reporting = 2
+ *
+ * @return {string} The resulting URL with additional parameters appended if valid; otherwise, the original URL.
+ */
+export function handleAdditionalParams(browser, url, requestTo, additionalParams) {
+  let queryString = '';
+
+  if (!Array.isArray(additionalParams)) return url;
+
+  for (let i = 0; i < additionalParams.length; i++) {
+    const param = additionalParams[i];
+
+    if (
+      typeof param !== 'object' ||
+      !param.parameterName ||
+      !param.parameterValue ||
+      !param.destination ||
+      !Array.isArray(param.destination)
+    ) {
+      continue;
+    }
+
+    if (param.destination[requestTo]) {
+      queryString += `&agp_${encodeURIComponent(param.parameterName)}=${param.parameterValue}`;
+    }
+  }
+
+  const maxLength = MAX_REQUEST_LENGTH[browser] ?? 2048;
+  if ((url.length + queryString.length) > maxLength) return url;
+
+  return url + queryString;
+}

--- a/libraries/intentIqUtils/intentIqConfig.js
+++ b/libraries/intentIqUtils/intentIqConfig.js
@@ -1,0 +1,3 @@
+export const iiqServerAddress = (configParams, gdprDetected) => typeof configParams?.iiqServerAddress === 'string' ? configParams.iiqServerAddress : gdprDetected ? 'https://api-gdpr.intentiq.com' : 'https://api.intentiq.com'
+export const iiqPixelServerAddress = (configParams, gdprDetected) => typeof configParams?.iiqPixelServerAddress === 'string' ? configParams.iiqPixelServerAddress : gdprDetected ? 'https://sync-gdpr.intentiq.com' : 'https://sync.intentiq.com'
+export const reportingServerAddress = (configParams, gdprDetected) => typeof configParams?.params?.reportingServerAddress === 'string' ? configParams.params.reportingServerAddress : gdprDetected ? 'https://reports-gdpr.intentiq.com/report' : 'https://reports.intentiq.com/report'

--- a/libraries/intentIqUtils/storageUtils.js
+++ b/libraries/intentIqUtils/storageUtils.js
@@ -87,3 +87,16 @@ export function defineStorageType(params) {
   const filteredArr = params.filter(item => SUPPORTED_TYPES.includes(item));
   return filteredArr.length ? filteredArr : ['html5'];
 }
+
+/**
+ * Parse json if possible, else return null
+ * @param data
+ */
+export function tryParse(data) {
+  try {
+    return JSON.parse(data);
+  } catch (err) {
+    logError(err);
+    return null;
+  }
+}

--- a/libraries/intentIqUtils/urlUtils.js
+++ b/libraries/intentIqUtils/urlUtils.js
@@ -1,0 +1,5 @@
+export function appendSPData (url, firstPartyData) {
+  const spdParam = firstPartyData?.spd ? encodeURIComponent(typeof firstPartyData.spd === 'object' ? JSON.stringify(firstPartyData.spd) : firstPartyData.spd) : '';
+  url += spdParam ? '&spd=' + spdParam : '';
+  return url
+};

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -13,7 +13,8 @@ import {
   logError,
   logInfo,
   logWarn,
-  mergeDeep} from '../src/utils.js';
+  mergeDeep,
+} from '../src/utils.js';
 import { getRefererInfo, parseDomain } from '../src/refererDetection.js';
 import { OUTSTREAM, validateOrtbVideoFields } from '../src/video.js';
 import { Renderer } from '../src/Renderer.js';

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -20,6 +20,7 @@ import { Renderer } from '../src/Renderer.js';
 import { _ADAGIO } from '../libraries/adagioUtils/adagioUtils.js';
 import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import { } from '../src/polyfill.js';
 import { getGptSlotInfoForAdUnitCode } from '../libraries/gptUtils/gptUtils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { userSync } from '../src/userSync.js';

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -757,7 +757,7 @@ export const spec = {
         }
         if (response.bids) {
           response.bids.forEach(bidObj => {
-            const bidReq = (((bidRequest.data.adUnits) || []).find(bid => bid.bidId === bidObj.requestId));
+            const bidReq = (find(bidRequest.data.adUnits, bid => bid.bidId === bidObj.requestId));
 
             if (bidReq) {
               // bidObj.meta is the `bidResponse.meta` object according to https://docs.prebid.org/dev-docs/bidder-adaptor.html#interpreting-the-response

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -20,7 +20,7 @@ import { Renderer } from '../src/Renderer.js';
 import { _ADAGIO } from '../libraries/adagioUtils/adagioUtils.js';
 import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
-import { } from '../src/polyfill.js';
+import { find } from '../src/polyfill.js';
 import { getGptSlotInfoForAdUnitCode } from '../libraries/gptUtils/gptUtils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { userSync } from '../src/userSync.js';

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -20,7 +20,6 @@ import { Renderer } from '../src/Renderer.js';
 import { _ADAGIO } from '../libraries/adagioUtils/adagioUtils.js';
 import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
-import { } from '../src/polyfill.js';
 import { getGptSlotInfoForAdUnitCode } from '../libraries/gptUtils/gptUtils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { userSync } from '../src/userSync.js';

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -13,15 +13,14 @@ import {
   logError,
   logInfo,
   logWarn,
-  mergeDeep,
-} from '../src/utils.js';
+  mergeDeep} from '../src/utils.js';
 import { getRefererInfo, parseDomain } from '../src/refererDetection.js';
 import { OUTSTREAM, validateOrtbVideoFields } from '../src/video.js';
 import { Renderer } from '../src/Renderer.js';
 import { _ADAGIO } from '../libraries/adagioUtils/adagioUtils.js';
 import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
-import { find } from '../src/polyfill.js';
+import { } from '../src/polyfill.js';
 import { getGptSlotInfoForAdUnitCode } from '../libraries/gptUtils/gptUtils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { userSync } from '../src/userSync.js';
@@ -757,7 +756,7 @@ export const spec = {
         }
         if (response.bids) {
           response.bids.forEach(bidObj => {
-            const bidReq = (find(bidRequest.data.adUnits, bid => bid.bidId === bidObj.requestId));
+            const bidReq = (((bidRequest.data.adUnits) || []).find(bid => bid.bidId === bidObj.requestId));
 
             if (bidReq) {
               // bidObj.meta is the `bidResponse.meta` object according to https://docs.prebid.org/dev-docs/bidder-adaptor.html#interpreting-the-response

--- a/modules/adhashBidAdapter.js
+++ b/modules/adhashBidAdapter.js
@@ -1,6 +1,6 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
-import { includes } from '../src/polyfill.js';
+
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const VERSION = '3.6';
@@ -159,7 +159,7 @@ export const spec = {
     try {
       const { publisherId, platformURL, bidderURL } = bid.params;
       return (
-        (includes(Object.keys(bid.mediaTypes), BANNER) || includes(Object.keys(bid.mediaTypes), VIDEO)) &&
+        (Object.keys(bid.mediaTypes).includes(BANNER) || Object.keys(bid.mediaTypes).includes(VIDEO)) &&
         typeof publisherId === 'string' &&
         publisherId.length === 42 &&
         typeof platformURL === 'string' &&
@@ -190,7 +190,7 @@ export const spec = {
       const url = `${bidderURL}/rtb?version=${VERSION}&prebid=true`;
       const index = Math.floor(Math.random() * validBidRequests[i].sizes.length);
       const size = validBidRequests[i].sizes[index].join('x');
-      const creativeData = includes(Object.keys(validBidRequests[i].mediaTypes), VIDEO) ? {
+      const creativeData = Object.keys(validBidRequests[i].mediaTypes).includes(VIDEO) ? {
         size: 'preroll',
         position: validBidRequests[i].adUnitCode,
         playerSize: size
@@ -298,14 +298,14 @@ export const spec = {
         advertiserDomains: responseBody.advertiserDomains ? [responseBody.advertiserDomains] : []
       }
     };
-    if (typeof request == 'object' && typeof request.bidRequest == 'object' && typeof request.bidRequest.mediaTypes == 'object' && includes(Object.keys(request.bidRequest.mediaTypes), BANNER)) {
+    if (typeof request == 'object' && typeof request.bidRequest == 'object' && typeof request.bidRequest.mediaTypes == 'object' && Object.keys(request.bidRequest.mediaTypes).includes(BANNER)) {
       response = Object.assign({
         ad:
         `<div id="${oneTimeId}"></div>
         <script src="${bidderURL}/static/scripts/creative.min.js"></script>
         <script>callAdvertiser(${bidderResponse},['${oneTimeId}'],${requestData},${publisherURL})</script>`
       }, response);
-    } else if (includes(Object.keys(request.bidRequest.mediaTypes), VIDEO)) {
+    } else if (Object.keys(request.bidRequest.mediaTypes).includes(VIDEO)) {
       response = Object.assign({
         vastUrl: responseBody.creatives[0].vastURL,
         mediaType: VIDEO

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -18,7 +18,6 @@ import {
 } from '../src/utils.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {find} from '../src/polyfill.js';
 import {config} from '../src/config.js';
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
 import {getBidFloor} from '../libraries/adkernelUtils/adkernelUtils.js'
@@ -165,7 +164,7 @@ export const spec = {
       .reduce((a, b) => a.concat(b), []);
 
     return rtbBids.map(rtbBid => {
-      let imp = find(rtbRequest.imp, imp => imp.id === rtbBid.impid);
+      let imp = ((rtbRequest.imp) || []).find(imp => imp.id === rtbBid.impid);
       let prBid = {
         requestId: rtbBid.impid,
         cpm: rtbBid.price,

--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -10,7 +10,6 @@ import {loadExternalScript} from '../src/adloader.js';
 import {auctionManager} from '../src/auctionManager.js';
 import {AUCTION_COMPLETED} from '../src/auction.js';
 import {EVENTS} from '../src/constants.js';
-import {find} from '../src/polyfill.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {
   deepAccess,
@@ -65,7 +64,7 @@ MACRO['pageurl'] = function(b, c) {
   return (refererInfo.page || '').substr(0, 300).split(/[?#]/)[0];
 };
 MACRO['gpid'] = function(b, c) {
-  const adUnit = find(auctionManager.getAdUnits(), a => b.adUnitCode === a.code);
+  const adUnit = ((auctionManager.getAdUnits()) || []).find(a => b.adUnitCode === a.code);
   return deepAccess(adUnit, 'ortb2Imp.ext.gpid') || deepAccess(adUnit, 'ortb2Imp.ext.data.pbadslot') || getGptSlotInfoForAdUnitCode(b.adUnitCode).gptSlot || b.adUnitCode;
 };
 MACRO['pbAdSlot'] = MACRO['pbadslot'] = MACRO['gpid']; // legacy

--- a/modules/admixerBidAdapter.js
+++ b/modules/admixerBidAdapter.js
@@ -3,7 +3,6 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
 import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
-import {find} from '../src/polyfill.js';
 
 const BIDDER_CODE = 'admixer';
 const ENDPOINT_URL = 'https://inv-nets.admixer.net/prebid.1.2.aspx';
@@ -47,8 +46,7 @@ export const spec = {
     const payload = {
       imps: [],
       ortb2: bidderRequest.ortb2,
-      docReferrer: docRef,
-    };
+      docReferrer: docRef};
     let endpointUrl;
     if (bidderRequest) {
       // checks if there is specified any endpointUrl in bidder config
@@ -119,7 +117,7 @@ export const spec = {
 };
 
 function getEndpointUrl(code) {
-  return find(ALIASES, (val) => val.code === code)?.endpoint || ENDPOINT_URL;
+  return ((ALIASES) || []).find((val) => val.code === code)?.endpoint || ENDPOINT_URL;
 }
 
 function getBidFloor(bid) {

--- a/modules/adnowBidAdapter.js
+++ b/modules/adnowBidAdapter.js
@@ -1,7 +1,7 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE} from '../src/mediaTypes.js';
 import {deepAccess, parseQueryStringParameters, parseSizesInput} from '../src/utils.js';
-import {includes} from '../src/polyfill.js';
+
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
 const BIDDER_CODE = 'adnow';
@@ -44,7 +44,7 @@ export const spec = {
 
     const mediaType = bid.params.mediaType || NATIVE;
 
-    return includes(this.supportedMediaTypes, mediaType);
+    return this.supportedMediaTypes.includes(mediaType);
   },
 
   /**
@@ -113,7 +113,7 @@ export const spec = {
     }
 
     const mediaType = bid.meta.mediaType || NATIVE;
-    if (!includes(this.supportedMediaTypes, mediaType)) {
+    if (!this.supportedMediaTypes.includes(mediaType)) {
       return [];
     }
 

--- a/modules/adotBidAdapter.js
+++ b/modules/adotBidAdapter.js
@@ -4,7 +4,6 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
-import { find } from '../src/polyfill.js';
 import { isArray, isBoolean, isFn, isPlainObject, isStr, logError, replaceAuctionPrice } from '../src/utils.js';
 import { OUTSTREAM } from '../src/video.js';
 import { NATIVE_ASSETS_IDS as NATIVE_ID_MAPPING, NATIVE_ASSETS as NATIVE_PLACEMENTS } from '../libraries/braveUtils/nativeAssets.js';
@@ -150,8 +149,7 @@ function getOpenRTBUserObject(bidderRequest) {
   return {
     ext: {
       consent: bidderRequest.gdprConsent.consentString,
-      pubProvidedId: bidderRequest.userId && bidderRequest.userId.pubProvidedId,
-    },
+      pubProvidedId: bidderRequest.userId && bidderRequest.userId.pubProvidedId},
   };
 }
 
@@ -590,7 +588,7 @@ function buildBidResponse(bid, bidResponse, imp) {
 function getImpfromBid(bid, bidRequest) {
   if (!bidRequest || !bidRequest.imp) return null;
   const imps = bidRequest.imp;
-  return find(imps, (imp) => imp.id === bid.impid);
+  return ((imps) || []).find((imp) => imp.id === bid.impid);
 }
 
 /**

--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -36,7 +36,6 @@ import {getHook, module, setupBeforeHookFnOnce} from '../src/hook.js';
 import {store} from '../src/videoCache.js';
 import {config} from '../src/config.js';
 import {ADPOD} from '../src/mediaTypes.js';
-import {find} from '../src/polyfill.js';
 import {auctionManager} from '../src/auctionManager.js';
 import { TARGETING_KEYS } from '../src/constants.js';
 
@@ -329,14 +328,14 @@ function checkBidDuration(videoMediaType, bidResponse) {
   if (!videoMediaType.requireExactDuration) {
     let max = Math.max(...adUnitRanges);
     if (bidDuration <= (max + buffer)) {
-      let nextHighestRange = find(adUnitRanges, range => (range + buffer) >= bidDuration);
+      let nextHighestRange = ((adUnitRanges) || []).find(range => (range + buffer) >= bidDuration);
       bidResponse.video.durationBucket = nextHighestRange;
     } else {
       logWarn(`Detected a bid with a duration value outside the accepted ranges specified in adUnit.mediaTypes.video.durationRangeSec.  Rejecting bid: `, bidResponse);
       return false;
     }
   } else {
-    if (find(adUnitRanges, range => range === bidDuration)) {
+    if (((adUnitRanges) || []).find(range => range === bidDuration)) {
       bidResponse.video.durationBucket = bidDuration;
     } else {
       logWarn(`Detected a bid with a duration value not part of the list of accepted ranges specified in adUnit.mediaTypes.video.durationRangeSec.  Exact match durations must be used for this adUnit. Rejecting bid: `, bidResponse);

--- a/modules/adrelevantisBidAdapter.js
+++ b/modules/adrelevantisBidAdapter.js
@@ -15,7 +15,7 @@ import {
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
@@ -79,7 +79,7 @@ export const spec = {
     bidRequests = convertOrtbRequestToProprietaryNative(bidRequests);
 
     const tags = bidRequests.map(bidToTag);
-    const userObjBid = find(bidRequests, hasUserInfo);
+    const userObjBid = ((bidRequests) || []).find(hasUserInfo);
     let userObj;
     if (config.getConfig('coppa') === true) {
       userObj = {'coppa': true};
@@ -91,7 +91,7 @@ export const spec = {
         .forEach(param => userObj[param] = userObjBid.params.user[param]);
     }
 
-    const appDeviceObjBid = find(bidRequests, hasAppDeviceInfo);
+    const appDeviceObjBid = ((bidRequests) || []).find(hasAppDeviceInfo);
     let appDeviceObj;
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
@@ -100,7 +100,7 @@ export const spec = {
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
-    const appIdObjBid = find(bidRequests, hasAppId);
+    const appIdObjBid = ((bidRequests) || []).find(hasAppId);
     let appIdObj;
     if (appIdObjBid && appIdObjBid.params && appDeviceObjBid.params.app && appDeviceObjBid.params.app.id) {
       appIdObj = {
@@ -319,7 +319,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
         bid.vastXml = rtbBid.rtb.video.content;
 
         if (rtbBid.renderer_url) {
-          const videoBid = find(bidderRequest.bids, bid => bid.bidId === serverBid.uuid);
+          const videoBid = ((bidderRequest.bids) || []).find(bid => bid.bidId === serverBid.uuid);
           const rendererOptions = deepAccess(videoBid, 'renderer.options');
           bid.renderer = newRenderer(bid.adUnitCode, rtbBid, rendererOptions);
         }
@@ -370,8 +370,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       bid['native'].image = {
         url: nativeAd.main_img.url,
         height: nativeAd.main_img.height,
-        width: nativeAd.main_img.width,
-      };
+        width: nativeAd.main_img.width};
     }
     if (nativeAd.icon) {
       bid['native'].icon = {
@@ -535,7 +534,7 @@ function hasAppId(bid) {
 }
 
 function getRtbBid(tag) {
-  return tag && tag.ads && tag.ads.length && find(tag.ads, ad => ad.rtb);
+  return tag && tag.ads && tag.ads.length && ((tag.ads) || []).find(ad => ad.rtb);
 }
 
 function buildNativeRequest(params) {

--- a/modules/adrelevantisBidAdapter.js
+++ b/modules/adrelevantisBidAdapter.js
@@ -15,7 +15,7 @@ import {
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
@@ -87,7 +87,7 @@ export const spec = {
     if (userObjBid) {
       userObj = {};
       Object.keys(userObjBid.params.user)
-        .filter(param => includes(USER_PARAMS, param))
+        .filter(param => USER_PARAMS.includes(param))
         .forEach(param => userObj[param] = userObjBid.params.user[param]);
     }
 
@@ -96,7 +96,7 @@ export const spec = {
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
       Object.keys(appDeviceObjBid.params.app)
-        .filter(param => includes(APP_DEVICE_PARAMS, param))
+        .filter(param => APP_DEVICE_PARAMS.includes(param))
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
@@ -175,7 +175,7 @@ export const spec = {
       serverResponse.tags.forEach(serverBid => {
         const rtbBid = getRtbBid(serverBid);
         if (rtbBid) {
-          if (rtbBid.cpm !== 0 && includes(this.supportedMediaTypes, rtbBid.ad_type)) {
+          if (rtbBid.cpm !== 0 && this.supportedMediaTypes.includes(rtbBid.ad_type)) {
             const bid = newBid(serverBid, rtbBid, bidderRequest);
             bid.mediaType = parseMediaType(rtbBid);
             bids.push(bid);
@@ -476,7 +476,7 @@ function bidToTag(bid) {
     tag.video = {};
     // place any valid video params on the tag
     Object.keys(bid.params.video)
-      .filter(param => includes(VIDEO_TARGETING, param))
+      .filter(param => VIDEO_TARGETING.includes(param))
       .forEach(param => tag.video[param] = bid.params.video[param]);
   }
 

--- a/modules/adtargetBidAdapter.js
+++ b/modules/adtargetBidAdapter.js
@@ -2,7 +2,6 @@ import {_map, deepAccess, flatten, isArray, logError, parseSizesInput} from '../
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
-import {find} from '../src/polyfill.js';
 import {chunk} from '../libraries/chunk/chunk.js';
 import {
   createTag, getUserSyncsFn,
@@ -68,7 +67,7 @@ function parseResponse(serverResponse, adapterRequest) {
   }
 
   serverResponse.bids.forEach(serverBid => {
-    const request = find(adapterRequest.bids, (bidRequest) => {
+    const request = ((adapterRequest.bids) || []).find((bidRequest) => {
       return bidRequest.bidId === serverBid.requestId;
     });
 

--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -3,7 +3,6 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {ADPOD, BANNER, VIDEO} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import {Renderer} from '../src/Renderer.js';
-import {find} from '../src/polyfill.js';
 import {chunk} from '../libraries/chunk/chunk.js';
 import {
   createTag, getUserSyncsFn,
@@ -31,8 +30,7 @@ const HOST_GETTERS = {
   ocm: () => 'ghb.cenarius.orangeclickmedia.com',
   '9dotsmedia': () => 'ghb.platform.audiodots.com',
   indicue: () => 'ghb.console.indicue.com',
-  stellormedia: () => 'ghb.ads.stellormedia.com',
-}
+  stellormedia: () => 'ghb.ads.stellormedia.com'}
 const getUri = function (bidderCode) {
   let bidderWithoutSuffix = bidderCode.split('_')[0];
   let getter = HOST_GETTERS[bidderWithoutSuffix] || HOST_GETTERS['default'];
@@ -114,7 +112,7 @@ function parseRTBResponse(serverResponse, adapterRequest) {
   }
 
   serverResponse.bids.forEach(serverBid => {
-    const request = find(adapterRequest.bids, (bidRequest) => {
+    const request = ((adapterRequest.bids) || []).find((bidRequest) => {
       return bidRequest.bidId === serverBid.requestId;
     });
 

--- a/modules/adxpremiumAnalyticsAdapter.js
+++ b/modules/adxpremiumAnalyticsAdapter.js
@@ -3,7 +3,7 @@ import {ajax} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
 import { EVENTS } from '../src/constants.js';
-import {includes} from '../src/polyfill.js';
+
 
 const analyticsType = 'endpoint';
 const defaultUrl = 'https://adxpremium.services/graphql';
@@ -211,7 +211,7 @@ function deviceType() {
 }
 
 function clearSlot(elementId) {
-  if (includes(elementIds, elementId)) { elementIds.splice(elementIds.indexOf(elementId), 1); logInfo('AdxPremium Analytics - Done with: ' + elementId); }
+  if (elementIds.includes(elementId)) { elementIds.splice(elementIds.indexOf(elementId), 1); logInfo('AdxPremium Analytics - Done with: ' + elementId); }
   if (elementIds.length == 0 && !requestSent && !timeoutBased) {
     requestSent = true;
     sendEvent(completeObject);

--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -1,7 +1,6 @@
 import {buildUrl, deepAccess, parseSizesInput} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
-import {find} from '../src/polyfill.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
@@ -228,7 +227,7 @@ export const spec = {
 
 /* Get hostname from bids */
 function getHostname(bidderRequest) {
-  let dcHostname = find(bidderRequest, bid => bid.params.DC);
+  let dcHostname = ((bidderRequest) || []).find(bid => bid.params.DC);
   if (dcHostname) {
     return ('-' + dcHostname.params.DC);
   }

--- a/modules/afpBidAdapter.js
+++ b/modules/afpBidAdapter.js
@@ -1,4 +1,4 @@
-import {includes} from '../src/polyfill.js';
+
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
@@ -85,7 +85,7 @@ export const spec = {
           return false
         }
       }
-      if (includes([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE], placeType)) {
+      if ([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE].includes(placeType)) {
         if (imageUrl && imageWidth && imageHeight) {
           return true
         }
@@ -110,7 +110,7 @@ export const spec = {
           sizes,
           placeId,
         }
-        if (includes([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE], placeType)) {
+        if ([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE].includes(placeType)) {
           Object.assign(bidRequest, {
             imageUrl,
             imageWidth: Math.floor(imageWidth),

--- a/modules/afpBidAdapter.md
+++ b/modules/afpBidAdapter.md
@@ -273,7 +273,7 @@ var adUnits = [{
 <head>
 	<meta charset="UTF-8">
 	<title>Prebid.js In-image Example</title>
-	<script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+   <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
 	<script async src="prebid.js"></script>
 	<script>
 		var adUnits = [{

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -22,7 +22,7 @@ import {Renderer} from '../src/Renderer.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {ADPOD, BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {bidderSettings} from '../src/bidderSettings.js';
@@ -156,7 +156,7 @@ export const spec = {
     bidRequests = convertOrtbRequestToProprietaryNative(bidRequests);
 
     const tags = bidRequests.map(bidToTag);
-    const userObjBid = find(bidRequests, hasUserInfo);
+    const userObjBid = ((bidRequests) || []).find(hasUserInfo);
     let userObj = {};
     if (config.getConfig('coppa') === true) {
       userObj = { 'coppa': true };
@@ -182,7 +182,7 @@ export const spec = {
         });
     }
 
-    const appDeviceObjBid = find(bidRequests, hasAppDeviceInfo);
+    const appDeviceObjBid = ((bidRequests) || []).find(hasAppDeviceInfo);
     let appDeviceObj;
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
@@ -191,7 +191,7 @@ export const spec = {
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
-    const appIdObjBid = find(bidRequests, hasAppId);
+    const appIdObjBid = ((bidRequests) || []).find(hasAppId);
     let appIdObj;
     if (appIdObjBid && appIdObjBid.params && appDeviceObjBid.params.app && appDeviceObjBid.params.app.id) {
       appIdObj = {
@@ -223,7 +223,7 @@ export const spec = {
         'debug_timeout': 'number'
       }, debugObj);
 
-      const debugBidRequest = find(bidRequests, hasDebug);
+      const debugBidRequest = ((bidRequests) || []).find(hasDebug);
       if (debugBidRequest && debugBidRequest.debug) {
         debugObj = debugBidRequest.debug;
       }
@@ -237,10 +237,10 @@ export const spec = {
         });
     }
 
-    const memberIdBid = find(bidRequests, hasMemberId);
+    const memberIdBid = ((bidRequests) || []).find(hasMemberId);
     const member = memberIdBid ? parseInt(memberIdBid.params.member, 10) : 0;
     const schain = bidRequests[0].schain;
-    const omidSupport = find(bidRequests, hasOmidSupport);
+    const omidSupport = ((bidRequests) || []).find(hasOmidSupport);
 
     const payload = {
       tags: [...tags],
@@ -341,7 +341,7 @@ export const spec = {
     }
 
     if (FEATURES.VIDEO) {
-      const hasAdPodBid = find(bidRequests, hasAdPod);
+      const hasAdPodBid = ((bidRequests) || []).find(hasAdPod);
       if (hasAdPodBid) {
         bidRequests.filter(hasAdPod).forEach(adPodBid => {
           const adPodTags = createAdPodRequest(tags, adPodBid);
@@ -601,8 +601,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       complete: 0,
       nodes: [{
         bsid: rtbBid.buyer_member_id.toString()
-      }],
-    };
+      }]};
 
     return dchain;
   }
@@ -643,7 +642,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
         bid.vastXml = rtbBid.rtb.video.content;
 
         if (rtbBid.renderer_url) {
-          const videoBid = find(bidderRequest.bids, bid => bid.bidId === serverBid.uuid);
+          const videoBid = ((bidderRequest.bids) || []).find(bid => bid.bidId === serverBid.uuid);
           let rendererOptions = deepAccess(videoBid, 'mediaTypes.video.renderer.options'); // mediaType definition has preference (shouldn't options be .config?)
           if (!rendererOptions) {
             rendererOptions = deepAccess(videoBid, 'renderer.options'); // second the adUnit definition has preference (shouldn't options be .config?)
@@ -1221,7 +1220,7 @@ function setVideoProperty(tag, key, value) {
 }
 
 function getRtbBid(tag) {
-  return tag && tag.ads && tag.ads.length && find(tag.ads, ad => ad.rtb);
+  return tag && tag.ads && tag.ads.length && ((tag.ads) || []).find(ad => ad.rtb);
 }
 
 function buildNativeRequest(params) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -22,7 +22,7 @@ import {Renderer} from '../src/Renderer.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {ADPOD, BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {bidderSettings} from '../src/bidderSettings.js';
@@ -163,7 +163,7 @@ export const spec = {
     }
     if (userObjBid) {
       Object.keys(userObjBid.params.user)
-        .filter(param => includes(USER_PARAMS, param))
+        .filter(param => USER_PARAMS.includes(param))
         .forEach((param) => {
           let uparam = convertCamelToUnderscore(param);
           if (param === 'segments' && isArray(userObjBid.params.user[param])) {
@@ -187,7 +187,7 @@ export const spec = {
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
       Object.keys(appDeviceObjBid.params.app)
-        .filter(param => includes(APP_DEVICE_PARAMS, param))
+        .filter(param => APP_DEVICE_PARAMS.includes(param))
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
@@ -231,7 +231,7 @@ export const spec = {
 
     if (debugObj && debugObj.enabled) {
       Object.keys(debugObj)
-        .filter(param => includes(DEBUG_PARAMS, param))
+        .filter(param => DEBUG_PARAMS.includes(param))
         .forEach(param => {
           debugObjParams[param] = debugObj[param];
         });
@@ -425,7 +425,7 @@ export const spec = {
         const rtbBid = getRtbBid(serverBid);
         if (rtbBid) {
           const cpmCheck = (bidderSettings.get(bidderRequest.bidderCode, 'allowZeroCpmBids') === true) ? rtbBid.cpm >= 0 : rtbBid.cpm > 0;
-          if (cpmCheck && includes(this.supportedMediaTypes, rtbBid.ad_type)) {
+          if (cpmCheck && this.supportedMediaTypes.includes(rtbBid.ad_type)) {
             const bid = newBid(serverBid, rtbBid, bidderRequest);
             bid.mediaType = parseMediaType(rtbBid);
             bids.push(bid);
@@ -950,7 +950,7 @@ function bidToTag(bid) {
       tag.video = {};
       // place any valid video params on the tag
       Object.keys(bid.params.video)
-        .filter(param => includes(VIDEO_TARGETING, param))
+        .filter(param => VIDEO_TARGETING.includes(param))
         .forEach(param => {
           switch (param) {
             case 'context':
@@ -976,7 +976,7 @@ function bidToTag(bid) {
     if (videoMediaType) {
       tag.video = tag.video || {};
       Object.keys(videoMediaType)
-        .filter(param => includes(VIDEO_RTB_TARGETING, param))
+        .filter(param => VIDEO_RTB_TARGETING.includes(param))
         .forEach(param => {
           switch (param) {
             case 'minduration':
@@ -1164,10 +1164,10 @@ function hasOmidSupport(bid) {
   const bidderParams = bid.params;
   const videoParams = bid.params.video;
   if (bidderParams.frameworks && isArray(bidderParams.frameworks)) {
-    hasOmid = includes(bid.params.frameworks, 6);
+    hasOmid = bid.params.frameworks.includes(6);
   }
   if (!hasOmid && videoParams && videoParams.frameworks && isArray(videoParams.frameworks)) {
-    hasOmid = includes(bid.params.video.frameworks, 6);
+    hasOmid = bid.params.video.frameworks.includes(6);
   }
   return hasOmid;
 }

--- a/modules/astraoneBidAdapter.md
+++ b/modules/astraoneBidAdapter.md
@@ -114,7 +114,7 @@ var adUnits = [{
 <head>
   <meta charset="UTF-8">
   <title>Prebid.js Banner gpt Example</title>
-  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
   <script async src="../../../build/dev/prebid.js"></script>
   <style>
     .banner-block {

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -10,7 +10,6 @@ import {
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {find} from '../src/polyfill.js';
 import { getFirstSize, getOsVersion, getVideoSizes, getBannerSizes, isConnectedTV, getDoNotTrack, isMobile, isBannerBid, isVideoBid, getBannerBidFloor, getVideoBidFloor, getVideoTargetingParams, getTopWindowLocation } from '../libraries/advangUtils/index.js';
 
 const ADAPTER_VERSION = '1.21';
@@ -133,7 +132,7 @@ export const spec = {
       return response
         .filter(bid => bid.adm)
         .map((bid) => {
-          let request = find(bidRequest, req => req.adUnitCode === bid.slot);
+          let request = ((bidRequest) || []).find(req => req.adUnitCode === bid.slot);
           let responseMeta = Object.assign({ mediaType: BANNER, advertiserDomains: [] }, bid.meta);
           return {
             requestId: request.bidId,
@@ -156,7 +155,7 @@ export const spec = {
   getUserSyncs(syncOptions, serverResponses = [], gdprConsent = {}, uspConsent = '', gppConsent = {}) {
     let { gdprApplies, consentString = '' } = gdprConsent;
     let { gppString = '', applicableSections = [] } = gppConsent;
-    let bannerResponse = find(serverResponses, (res) => isArray(res.body));
+    let bannerResponse = ((serverResponses) || []).find((res) => isArray(res.body));
 
     let syncs = [];
     let params = {

--- a/modules/betweenBidAdapter.js
+++ b/modules/betweenBidAdapter.js
@@ -1,6 +1,6 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {parseSizesInput} from '../src/utils.js';
-import {includes} from '../src/polyfill.js';
+
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
 
 /**
@@ -64,7 +64,7 @@ export const spec = {
         params.mind = video.mind;
         params.pos = 'atf';
         params.jst = 'pvc';
-        params.codeType = includes(CODE_TYPES, video.codeType) ? video.codeType : 'inpage';
+        params.codeType = CODE_TYPES.includes(video.codeType) ? video.codeType : 'inpage';
       }
 
       if (i.params.itu !== undefined) {

--- a/modules/bidViewability.js
+++ b/modules/bidViewability.js
@@ -1,5 +1,5 @@
 // This module, when included, will trigger a BID_VIEWABLE event which can be consumed by Bidders and Analytics adapters
-// GPT API is used to when a bid is viewable, https://developers.google.com/publisher-tag/reference#googletag.events.impressionviewableevent
+// GPT API is used to find when a bid is viewable, https://developers.google.com/publisher-tag/reference#googletag.events.impressionviewableevent
 // Does not work with other than GPT integration
 
 import {config} from '../src/config.js';

--- a/modules/bidViewability.js
+++ b/modules/bidViewability.js
@@ -1,5 +1,5 @@
 // This module, when included, will trigger a BID_VIEWABLE event which can be consumed by Bidders and Analytics adapters
-// GPT API is used to find when a bid is viewable, https://developers.google.com/publisher-tag/reference#googletag.events.impressionviewableevent
+// GPT API is used to when a bid is viewable, https://developers.google.com/publisher-tag/reference#googletag.events.impressionviewableevent
 // Does not work with other than GPT integration
 
 import {config} from '../src/config.js';
@@ -8,7 +8,6 @@ import {EVENTS} from '../src/constants.js';
 import {isFn, logWarn, triggerPixel} from '../src/utils.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 import adapterManager, {gppDataHandler, uspDataHandler} from '../src/adapterManager.js';
-import {find} from '../src/polyfill.js';
 import {gdprParams} from '../libraries/dfpUtils/dfpUtils.js';
 
 const MODULE_NAME = 'bidViewability';
@@ -23,7 +22,7 @@ export let isBidAdUnitCodeMatchingSlot = (bid, slot) => {
 }
 
 export let getMatchingWinningBidForGPTSlot = (globalModuleConfig, slot) => {
-  return find(getGlobal().getAllWinningBids(),
+  return getGlobal().getAllWinningBids().find(
     // supports custom match function from config
     bid => isFn(globalModuleConfig[CONFIG_CUSTOM_MATCH])
       ? globalModuleConfig[CONFIG_CUSTOM_MATCH](bid, slot)

--- a/modules/bridgewellBidAdapter.js
+++ b/modules/bridgewellBidAdapter.js
@@ -1,7 +1,6 @@
 import {_each, deepSetValue, inIframe} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE} from '../src/mediaTypes.js';
-import {find} from '../src/polyfill.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
 /**
@@ -97,8 +96,7 @@ export const spec = {
         referrer: bidderRequest.refererInfo.ref,
         adUnits: adUnits,
         // TODO: please do not send internal data structures over the network
-        refererInfo: bidderRequest.refererInfo.legacy,
-      },
+        refererInfo: bidderRequest.refererInfo.legacy},
       validBidRequests: validBidRequests
     };
   },
@@ -121,7 +119,7 @@ export const spec = {
         return;
       }
 
-      let matchedResponse = find(serverResponse.body, function (res) {
+      let matchedResponse = ((serverResponse.body) || []).find(function (res) {
         let valid = false;
 
         if (res && !res.consumed) {
@@ -141,7 +139,7 @@ export const spec = {
                 if (typeof sizes[0] === 'number') { // for foramt Array[Number] check
                   valid = width === sizes[0] && height === sizes[1];
                 } else { // for format Array[Array[Number]] check
-                  valid = !!find(sizes, function (size) {
+                  valid = !!((sizes) || []).find(function (size) {
                     return (width === size[0] && height === size[1]);
                   });
                 }

--- a/modules/browsiRtdProvider.js
+++ b/modules/browsiRtdProvider.js
@@ -21,7 +21,7 @@ import { submodule } from '../src/hook.js';
 import { ajaxBuilder } from '../src/ajax.js';
 import { loadExternalScript } from '../src/adloader.js';
 import { getStorageManager } from '../src/storageManager.js';
-import { includes } from '../src/polyfill.js';
+
 import { getGlobal } from '../src/prebidGlobal.js';
 import * as events from '../src/events.js';
 import { EVENTS } from '../src/constants.js';
@@ -313,7 +313,7 @@ function getAdUnitCodes(bidObj) {
   let adUnitCodes = bidObj.adUnitCodes;
   let adUnits = bidObj.adUnits || getGlobal().adUnits || [];
   if (adUnitCodes) {
-    adUnits = adUnits.filter(au => includes(adUnitCodes, au.code));
+    adUnits = adUnits.filter(au => adUnitCodes.includes(au.code));
   } else {
     adUnitCodes = adUnits.map(au => au.code);
   }

--- a/modules/cadentApertureMXBidAdapter.js
+++ b/modules/cadentApertureMXBidAdapter.js
@@ -11,7 +11,7 @@ import {
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {parseDomain} from '../src/refererDetection.js';
 
 const BIDDER_CODE = 'cadent_aperture_mx';
@@ -61,7 +61,7 @@ export const cadentAdapter = {
   formatVideoResponse: (bidResponse, cadentBid, bidRequest) => {
     bidResponse.vastXml = cadentBid.adm;
     if (bidRequest.bidderRequest && bidRequest.bidderRequest.bids && bidRequest.bidderRequest.bids.length > 0) {
-      const matchingBid = find(bidRequest.bidderRequest.bids, bid => bidResponse.requestId && bid.bidId && bidResponse.requestId === bid.bidId && bid.mediaTypes && bid.mediaTypes.video && bid.mediaTypes.video.context === 'outstream');
+      const matchingBid = ((bidRequest.bidderRequest.bids) || []).find(bid => bidResponse.requestId && bid.bidId && bidResponse.requestId === bid.bidId && bid.mediaTypes && bid.mediaTypes.video && bid.mediaTypes.video.context === 'outstream');
       if (matchingBid) {
         bidResponse.renderer = cadentAdapter.createRenderer(bidResponse, {
           id: cadentBid.id,
@@ -85,8 +85,7 @@ export const cadentAdapter = {
       h: screen.height,
       w: screen.width,
       devicetype: cadentAdapter.isMobile() ? 1 : cadentAdapter.isConnectedTV() ? 3 : 2,
-      language: (navigator.language || navigator.browserLanguage || navigator.userLanguage || navigator.systemLanguage),
-    };
+      language: (navigator.language || navigator.browserLanguage || navigator.userLanguage || navigator.systemLanguage)};
   },
   cleanProtocols: (video) => {
     if (video.protocols && includes(video.protocols, 7)) {

--- a/modules/cadentApertureMXBidAdapter.js
+++ b/modules/cadentApertureMXBidAdapter.js
@@ -11,7 +11,7 @@ import {
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {parseDomain} from '../src/refererDetection.js';
 
 const BIDDER_CODE = 'cadent_aperture_mx';
@@ -89,7 +89,7 @@ export const cadentAdapter = {
     };
   },
   cleanProtocols: (video) => {
-    if (video.protocols && includes(video.protocols, 7)) {
+    if (video.protocols && video.protocols.includes(7)) {
       // not supporting VAST protocol 7 (VAST 4.0);
       logWarn(BIDDER_CODE + ': VAST 4.0 is currently not supported. This protocol has been filtered out of the request.');
       video.protocols = video.protocols.filter(protocol => protocol !== 7);

--- a/modules/cleanmedianetBidAdapter.js
+++ b/modules/cleanmedianetBidAdapter.js
@@ -14,7 +14,7 @@ import {
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {includes} from '../src/polyfill.js';
+
 
 const ENDPOINTS = {
   'cleanmedianet': 'https://bidder.cleanmediaads.com'
@@ -127,7 +127,7 @@ export const spec = {
       };
 
       const hasFavoredMediaType =
-        params.favoredMediaType && includes(this.supportedMediaTypes, params.favoredMediaType);
+        params.favoredMediaType && this.supportedMediaTypes.includes(params.favoredMediaType);
 
       if (!mediaTypes || mediaTypes.banner) {
         if (!hasFavoredMediaType || params.favoredMediaType === BANNER) {

--- a/modules/connectIdSystem.js
+++ b/modules/connectIdSystem.js
@@ -7,7 +7,7 @@
 
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
-import {includes} from '../src/polyfill.js';
+
 import {getRefererInfo} from '../src/refererDetection.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {formatQS, isNumber, isPlainObject, logError, parseUrl} from '../src/utils.js';
@@ -221,7 +221,7 @@ export const connectIdSubmodule = {
     const uspString = consentData.usp || '';
     const data = {
       v: '1',
-      '1p': includes([1, '1', true], params['1p']) ? '1' : '0',
+      '1p': [1, '1', true].includes(params['1p']) ? '1' : '0',
       gdpr: connectIdSubmodule.isEUConsentRequired(consentData?.gdpr) ? '1' : '0',
       gdpr_consent: connectIdSubmodule.isEUConsentRequired(consentData?.gdpr) ? consentData.gdpr.consentString : '',
       us_privacy: uspString

--- a/modules/craftBidAdapter.js
+++ b/modules/craftBidAdapter.js
@@ -1,7 +1,7 @@
 import {getBidRequest} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {ajax} from '../src/ajax.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
@@ -71,7 +71,7 @@ export const spec = {
     try {
       const bids = interpretResponseUtil(serverResponse, {bidderRequest}, serverBid => {
         const rtbBid = getRtbBid(serverBid);
-        if (rtbBid && rtbBid.cpm !== 0 && includes(this.supportedMediaTypes, rtbBid.ad_type)) {
+        if (rtbBid && rtbBid.cpm !== 0 && this.supportedMediaTypes.includes(rtbBid.ad_type)) {
           const bid = newBid(serverBid, rtbBid, bidderRequest);
           bid.mediaType = parseMediaType(rtbBid);
           return bid;

--- a/modules/craftBidAdapter.js
+++ b/modules/craftBidAdapter.js
@@ -1,7 +1,7 @@
 import {getBidRequest} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {ajax} from '../src/ajax.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
@@ -52,8 +52,7 @@ export const spec = {
           // TODO: this collects everything it finds, except for the canonical URL
           rd_ref: bidderRequest.refererInfo.topmostLocation,
           rd_top: bidderRequest.refererInfo.reachedTop,
-          rd_ifs: bidderRequest.refererInfo.numIframes,
-        };
+          rd_ifs: bidderRequest.refererInfo.numIframes};
         if (bidderRequest.refererInfo.stack) {
           refererinfo.rd_stk = bidderRequest.refererInfo.stack.join(',');
         }
@@ -160,7 +159,7 @@ function bidToTag(bid) {
 }
 
 function getRtbBid(tag) {
-  return tag && tag.ads && tag.ads.length && find(tag.ads, ad => ad.rtb);
+  return tag && tag.ads && tag.ads.length && ((tag.ads) || []).find(ad => ad.rtb);
 }
 
 function parseMediaType(rtbBid) {

--- a/modules/dailyhuntBidAdapter.js
+++ b/modules/dailyhuntBidAdapter.js
@@ -2,7 +2,6 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import * as mediaTypes from '../src/mediaTypes.js';
 import {_map, deepAccess, isEmpty} from '../src/utils.js';
 import {ajax} from '../src/ajax.js';
-import {find} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
 
@@ -68,8 +67,7 @@ const ORTB_NATIVE_PARAMS = {
     id: 4,
     name: 'data',
     type: 10
-  },
-};
+  }};
 
 // Encode URI.
 const _encodeURIComponent = function (a) {
@@ -412,7 +410,7 @@ export const spec = {
 
     seatBids.forEach(ortbResponseBid => {
       let bidId = ortbResponseBid.impid;
-      let actualBid = find(bids, (bid) => bid.bidId === bidId);
+      let actualBid = ((bids) || []).find((bid) => bid.bidId === bidId);
       let bidMediaType = ortbResponseBid.ext.prebid.type
       switch (bidMediaType) {
         case mediaTypes.BANNER:

--- a/modules/dchain.js
+++ b/modules/dchain.js
@@ -1,4 +1,4 @@
-import {includes} from '../src/polyfill.js';
+
 import {config} from '../src/config.js';
 import {getHook} from '../src/hook.js';
 import {_each, deepAccess, deepClone, isArray, isPlainObject, isStr, logError, logWarn} from '../src/utils.js';
@@ -36,7 +36,7 @@ export function checkDchainSyntax(bid, mode) {
 
   let dchainProps = Object.keys(dchainObj);
   dchainProps.forEach(prop => {
-    if (!includes(dchainPropList, prop)) {
+    if (!dchainPropList.includes(prop)) {
       appendFailMsg(`dchain.${prop}` + shouldBeValid);
     }
   });
@@ -67,7 +67,7 @@ export function checkDchainSyntax(bid, mode) {
       } else {
         let nodeProps = Object.keys(node);
         nodeProps.forEach(prop => {
-          if (!includes(nodesPropList, prop)) {
+          if (!nodesPropList.includes(prop)) {
             appendFailMsg(`dchain.nodes[${index}].${prop}` + shouldBeValid);
           }
 

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -1,7 +1,7 @@
 import {deepAccess, logMessage, getBidIdParameter, logError, logWarn} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {includes} from '../src/polyfill.js';
+
 import {
   fillUsersIds,
   handleSyncUrls,
@@ -125,7 +125,7 @@ export const spec = {
         payload.vpl = {};
         let videoParams = deepAccess(bidRequest, 'mediaTypes.video');
         Object.keys(videoParams)
-          .filter(key => includes(VIDEO_ORTB_PARAMS, key))
+          .filter(key => VIDEO_ORTB_PARAMS.includes(key))
           .forEach(key => payload.vpl[key] = videoParams[key]);
       }
 

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -14,7 +14,7 @@ import {
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {includes} from '../src/polyfill.js';
+
 
 const ENDPOINTS = {
   'gamoshi': 'https://rtb.gamoshi.io',
@@ -130,7 +130,7 @@ export const spec = {
       };
 
       const hasFavoredMediaType =
-        params.favoredMediaType && includes(this.supportedMediaTypes, params.favoredMediaType);
+        params.favoredMediaType && this.supportedMediaTypes.includes(params.favoredMediaType);
 
       if (!mediaTypes || mediaTypes.banner) {
         if (!hasFavoredMediaType || params.favoredMediaType === BANNER) {

--- a/modules/glomexBidAdapter.js
+++ b/modules/glomexBidAdapter.js
@@ -1,5 +1,4 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {find} from '../src/polyfill.js';
 import {BANNER} from '../src/mediaTypes.js';
 
 const ENDPOINT = 'https://prebid.mes.glomex.cloud/request-bid'
@@ -33,8 +32,7 @@ export const spec = {
           isAmp: refererInfo.isAmp,
           numIframes: refererInfo.numIframes,
           reachedTop: refererInfo.reachedTop,
-          referer: refererInfo.topmostLocation,
-        },
+          referer: refererInfo.topmostLocation},
         gdprConsent: {
           consentString: gdprConsent.consentString,
           gdprApplies: gdprConsent.gdprApplies
@@ -62,7 +60,7 @@ export const spec = {
         return
       }
 
-      const matchedBid = find(serverResponse.body.bids, function (bid) {
+      const matchedBid = ((serverResponse.body.bids) || []).find(function (bid) {
         return String(bidRequest.bidId) === String(bid.id)
       })
 

--- a/modules/gptPreAuction.js
+++ b/modules/gptPreAuction.js
@@ -3,7 +3,6 @@ import { auctionManager } from '../src/auctionManager.js';
 import { config } from '../src/config.js';
 import { TARGETING_KEYS } from '../src/constants.js';
 import { getHook } from '../src/hook.js';
-import { find } from '../src/polyfill.js';
 import {
   deepAccess,
   deepSetValue,
@@ -79,7 +78,7 @@ export const appendGptSlots = adUnits => {
   const adUnitPaths = {};
 
   window.googletag.pubads().getSlots().forEach(slot => {
-    const matchingAdUnitCode = find(Object.keys(adUnitMap), customGptSlotMatching
+    const matchingAdUnitCode = Object.keys(adUnitMap).find(customGptSlotMatching
       ? customGptSlotMatching(slot)
       : isAdUnitCodeMatchingSlot(slot));
 

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -3,7 +3,7 @@ import {_each, deepAccess, getWinDimensions, logError, logWarn, parseSizesInput}
 
 import {config} from '../src/config.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {includes} from '../src/polyfill.js';
+
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 
 /**
@@ -643,10 +643,10 @@ function interpretResponse(serverResponse, bidRequest) {
   let sizes = parseSizesInput(bidRequest.sizes);
   if (maxw && maxh) {
     sizes = [`${maxw}x${maxh}`];
-  } else if (product === 5 && includes(sizes, '1x1')) {
+  } else if (product === 5 && sizes.includes('1x1')) {
     sizes = ['1x1'];
   // added logic for in-slot multi-szie
-  } else if ((product === 2 && includes(sizes, '1x1')) || product === 3) {
+  } else if ((product === 2 && sizes.includes('1x1')) || product === 3) {
     const requestSizesThatMatchResponse = (bidRequest.sizes && bidRequest.sizes.reduce((result, current) => {
       const [ width, height ] = current;
       if (responseWidth === width && responseHeight === height) result.push(current.join('x'));

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -277,6 +277,7 @@ function _getDeviceData(ortb2Data) {
     ip: _device.ip,
     ipv6: _device.ipv6,
     ua: _device.ua,
+    sua: _device.sua ? JSON.stringify(_device.sua) : undefined,
     dnt: _device.dnt,
     os: _device.os,
     osv: _device.osv,

--- a/modules/hybridBidAdapter.js
+++ b/modules/hybridBidAdapter.js
@@ -2,7 +2,6 @@ import {_map, deepAccess, isArray, logWarn} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';
-import {find} from '../src/polyfill.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -86,8 +85,7 @@ function buildBid(bidData) {
     netRevenue: true,
     ttl: TTL,
     meta: {
-      advertiserDomains: bidData.advertiserDomains || [],
-    }
+      advertiserDomains: bidData.advertiserDomains || []}
   };
 
   if (bidData.placement === PLACEMENT_TYPE_VIDEO) {
@@ -245,7 +243,7 @@ export const spec = {
 
     if (serverBody && serverBody.bids && isArray(serverBody.bids)) {
       return _map(serverBody.bids, function(bid) {
-        let rawBid = find(bidRequests, function (item) {
+        let rawBid = ((bidRequests) || []).find(function (item) {
           return item.bidId === bid.bidId;
         });
         bid.placement = rawBid.placement;

--- a/modules/hybridBidAdapter.md
+++ b/modules/hybridBidAdapter.md
@@ -154,7 +154,7 @@ var adUnits = [{
 	<meta charset="UTF-8">
 	<title>Prebid.js Banner Example</title>
 	<script async src="prebid.js"></script>
-	<script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+        <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
 	<style>
 		.banner-block {
 			position: absolute;

--- a/modules/imdsBidAdapter.js
+++ b/modules/imdsBidAdapter.js
@@ -3,7 +3,7 @@
 import {deepAccess, deepSetValue, isFn, isPlainObject, logWarn, mergeDeep} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {includes} from '../src/polyfill.js';
+
 import {config} from '../src/config.js';
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
 
@@ -215,7 +215,7 @@ export const spec = {
 
   setValidVideoParams: function (sourceObj, destObj) {
     Object.keys(sourceObj)
-      .filter(param => includes(VIDEO_PARAMS, param) && sourceObj[param] !== null && (!isNaN(parseInt(sourceObj[param], 10)) || !(sourceObj[param].length < 1)))
+      .filter(param => VIDEO_PARAMS.includes(param) && sourceObj[param] !== null && (!isNaN(parseInt(sourceObj[param], 10)) || !(sourceObj[param].length < 1)))
       .forEach(param => destObj[param] = Array.isArray(sourceObj[param]) ? sourceObj[param] : parseInt(sourceObj[param], 10));
   },
   interpretResponse: function(serverResponse, bidRequest) {

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -3,7 +3,6 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {deepAccess, generateUUID, logError, isArray, isInteger, isArrayOfNums, deepSetValue, isFn, logWarn, getWinDimensions} from '../src/utils.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {find} from '../src/polyfill.js';
 
 const BIDDER_CODE = 'insticator';
 const ENDPOINT = 'https://ex.ingage.tech/v1/openrtb'; // production endpoint
@@ -30,8 +29,7 @@ export const OPTIONAL_VIDEO_PARAMS = {
   'playbackend': (value) => isInteger(value) && [1, 2, 3].includes(value),
   'delivery': (value) => isArrayOfNums(value),
   'pos': (value) => isInteger(value) && [0, 1, 2, 3, 4, 5, 6, 7].includes(value),
-  'api': (value) => isArrayOfNums(value),
-};
+  'api': (value) => isArrayOfNums(value)};
 
 const ORTB_SITE_FIRST_PARTY_DATA = {
   'cat': v => Array.isArray(v) && v.every(c => typeof c === 'string'),
@@ -444,7 +442,7 @@ function buildRequest(validBidRequests, bidderRequest) {
 }
 
 function buildBid(bid, bidderRequest) {
-  const originalBid = find(bidderRequest.bids, (b) => b.bidId === bid.impid);
+  const originalBid = ((bidderRequest.bids) || []).find((b) => b.bidId === bid.impid);
   let meta = {}
 
   if (bid.ext && bid.ext.meta) {

--- a/modules/intentIqAnalyticsAdapter.js
+++ b/modules/intentIqAnalyticsAdapter.js
@@ -7,15 +7,16 @@ import {config} from '../src/config.js';
 import {EVENTS} from '../src/constants.js';
 import {MODULE_TYPE_ANALYTICS} from '../src/activities/modules.js';
 import {detectBrowser} from '../libraries/intentIqUtils/detectBrowserUtils.js';
+import {appendSPData} from '../libraries/intentIqUtils/urlUtils.js';
 import {appendVrrefAndFui, getReferrer} from '../libraries/intentIqUtils/getRefferer.js';
 import {getCmpData} from '../libraries/intentIqUtils/getCmpData.js'
-import {CLIENT_HINTS_KEY, FIRST_PARTY_KEY, VERSION} from '../libraries/intentIqConstants/intentIqConstants.js';
+import {CLIENT_HINTS_KEY, FIRST_PARTY_KEY, VERSION, PREBID} from '../libraries/intentIqConstants/intentIqConstants.js';
 import {readData, defineStorageType} from '../libraries/intentIqUtils/storageUtils.js';
+import {reportingServerAddress} from '../libraries/intentIqUtils/intentIqConfig.js';
+import { handleAdditionalParams } from '../libraries/intentIqUtils/handleAdditionalParams.js';
 
 const MODULE_NAME = 'iiqAnalytics'
 const analyticsType = 'endpoint';
-const REPORT_ENDPOINT = 'https://reports.intentiq.com/report';
-const REPORT_ENDPOINT_GDPR = 'https://reports-gdpr.intentiq.com/report';
 const storage = getStorageManager({moduleType: MODULE_TYPE_ANALYTICS, moduleName: MODULE_NAME});
 const prebidVersion = '$prebid.version$';
 export const REPORTER_ID = Date.now() + '_' + getRandom(0, 1000);
@@ -59,7 +60,21 @@ const PARAMS_NAMES = {
   adType: 'adType'
 };
 
-let iiqAnalyticsAnalyticsAdapter = Object.assign(adapter({defaultUrl: REPORT_ENDPOINT, analyticsType}), {
+function getIntentIqConfig() {
+  return config.getConfig('userSync.userIds')?.find(m => m.name === 'intentIqId');
+}
+
+const DEFAULT_URL = 'https://reports.intentiq.com/report'
+
+const getDataForDefineURL = () => {
+  const iiqConfig = getIntentIqConfig()
+  const cmpData = getCmpData();
+  const gdprDetected = cmpData.gdprString;
+
+  return [iiqConfig, gdprDetected]
+}
+
+let iiqAnalyticsAnalyticsAdapter = Object.assign(adapter({url: DEFAULT_URL, analyticsType}), {
   initOptions: {
     lsValueInitialized: false,
     partner: null,
@@ -69,7 +84,10 @@ let iiqAnalyticsAnalyticsAdapter = Object.assign(adapter({defaultUrl: REPORT_END
     eidl: null,
     lsIdsInitialized: false,
     manualWinReportEnabled: false,
-    domainName: null
+    domainName: null,
+    siloEnabled: false,
+    reportMethod: null,
+    additionalParams: null
   },
   track({eventType, args}) {
     switch (eventType) {
@@ -91,11 +109,7 @@ const {
   BID_REQUESTED
 } = EVENTS;
 
-function getIntentIqConfig() {
-  return config.getConfig('userSync.userIds')?.find(m => m.name === 'intentIqId');
-}
-
-function initLsValues() {
+function initAdapterConfig() {
   if (iiqAnalyticsAnalyticsAdapter.initOptions.lsValueInitialized) return;
   let iiqConfig = getIntentIqConfig()
 
@@ -108,16 +122,24 @@ function initLsValues() {
       typeof iiqConfig.params?.browserBlackList === 'string' ? iiqConfig.params.browserBlackList.toLowerCase() : '';
     iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled = iiqConfig.params?.manualWinReportEnabled || false;
     iiqAnalyticsAnalyticsAdapter.initOptions.domainName = iiqConfig.params?.domainName || '';
+    iiqAnalyticsAnalyticsAdapter.initOptions.siloEnabled =
+      typeof iiqConfig.params?.siloEnabled === 'boolean' ? iiqConfig.params.siloEnabled : false;
+    iiqAnalyticsAnalyticsAdapter.initOptions.reportMethod = parseReportingMethod(iiqConfig.params?.reportMethod);
+    iiqAnalyticsAnalyticsAdapter.initOptions.additionalParams = iiqConfig.params?.additionalParams || null;
   } else {
     iiqAnalyticsAnalyticsAdapter.initOptions.lsValueInitialized = false;
     iiqAnalyticsAnalyticsAdapter.initOptions.partner = -1;
+    iiqAnalyticsAnalyticsAdapter.initOptions.reportMethod = 'GET';
   }
 }
 
 function initReadLsIds() {
   try {
     iiqAnalyticsAnalyticsAdapter.initOptions.dataInLs = null;
-    iiqAnalyticsAnalyticsAdapter.initOptions.fpid = JSON.parse(readData(FIRST_PARTY_KEY, allowedStorage, storage));
+    iiqAnalyticsAnalyticsAdapter.initOptions.fpid = JSON.parse(readData(
+      `${FIRST_PARTY_KEY}${iiqAnalyticsAnalyticsAdapter.initOptions.siloEnabled ? '_p_' + iiqAnalyticsAnalyticsAdapter.initOptions.partner : ''}`,
+      allowedStorage, storage
+    ));
     if (iiqAnalyticsAnalyticsAdapter.initOptions.fpid) {
       iiqAnalyticsAnalyticsAdapter.initOptions.currentGroup = iiqAnalyticsAnalyticsAdapter.initOptions.fpid.group;
     }
@@ -144,7 +166,7 @@ function initReadLsIds() {
 
 function bidWon(args, isReportExternal) {
   if (!iiqAnalyticsAnalyticsAdapter.initOptions.lsValueInitialized) {
-    initLsValues();
+    initAdapterConfig();
   }
 
   if (isNaN(iiqAnalyticsAnalyticsAdapter.initOptions.partner) || iiqAnalyticsAnalyticsAdapter.initOptions.partner == -1) return;
@@ -159,11 +181,30 @@ function bidWon(args, isReportExternal) {
     initReadLsIds();
   }
   if ((isReportExternal && iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled) || (!isReportExternal && !iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled)) {
-    ajax(constructFullUrl(preparePayload(args, true)), undefined, null, {method: 'GET'});
-    logInfo('IIQ ANALYTICS -> BID WON')
+    const { url, method, payload } = constructFullUrl(preparePayload(args, true));
+    if (method === 'POST') {
+      ajax(url, undefined, payload, {method, contentType: 'application/x-www-form-urlencoded'});
+    } else {
+      ajax(url, undefined, null, {method});
+    }
+    logInfo('IIQ ANALYTICS -> BID WON');
     return true;
   }
   return false;
+}
+
+function parseReportingMethod(reportMethod) {
+  if (typeof reportMethod === 'string') {
+      switch (reportMethod.toUpperCase()) {
+          case 'GET':
+              return 'GET';
+          case 'POST':
+              return 'POST';
+          default:
+              return 'GET';
+      }
+    }
+  return 'GET';
 }
 
 function defineGlobalVariableName() {
@@ -302,12 +343,13 @@ function getDefaultDataObject() {
 
 function constructFullUrl(data) {
   let report = [];
+  const reportMethod = iiqAnalyticsAnalyticsAdapter.initOptions.reportMethod;
+  const currentBrowserLowerCase = detectBrowser();
   data = btoa(JSON.stringify(data));
   report.push(data);
 
   const cmpData = getCmpData();
-  const gdprDetected = cmpData.gdprString;
-  const baseUrl = gdprDetected ? REPORT_ENDPOINT_GDPR : REPORT_ENDPOINT;
+  const baseUrl = reportingServerAddress(...getDataForDefineURL());
 
   let url = baseUrl + '?pid=' + iiqAnalyticsAnalyticsAdapter.initOptions.partner +
     '&mct=1' +
@@ -315,17 +357,22 @@ function constructFullUrl(data) {
       ? '&iiqid=' + encodeURIComponent(iiqAnalyticsAnalyticsAdapter.initOptions.fpid.pcid) : '') +
     '&agid=' + REPORTER_ID +
     '&jsver=' + VERSION +
-    '&source=pbjs' +
-    '&payload=' + JSON.stringify(report) +
+    '&source=' + PREBID +
     '&uh=' + encodeURIComponent(iiqAnalyticsAnalyticsAdapter.initOptions.clientsHints) +
     (cmpData.uspString ? '&us_privacy=' + encodeURIComponent(cmpData.uspString) : '') +
     (cmpData.gppString ? '&gpp=' + encodeURIComponent(cmpData.gppString) : '') +
     (cmpData.gdprString
       ? '&gdpr_consent=' + encodeURIComponent(cmpData.gdprString) + '&gdpr=1'
       : '&gdpr=0');
-
+  url = appendSPData(url, iiqAnalyticsAnalyticsAdapter.initOptions.fpid)
   url = appendVrrefAndFui(url, iiqAnalyticsAnalyticsAdapter.initOptions.domainName);
-  return url;
+
+  if (reportMethod === 'POST') {
+    return { url, method: 'POST', payload: JSON.stringify(report) };
+  }
+  url += '&payload=' + encodeURIComponent(JSON.stringify(report));
+  url = handleAdditionalParams(currentBrowserLowerCase, url, 2, iiqAnalyticsAnalyticsAdapter.initOptions.additionalParams);
+  return { url, method: 'GET' };
 }
 
 iiqAnalyticsAnalyticsAdapter.originEnableAnalytics = iiqAnalyticsAnalyticsAdapter.enableAnalytics;

--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -5,26 +5,29 @@
  * @requires module:modules/userId
  */
 
-import {logError, isPlainObject, getWinDimensions} from '../src/utils.js';
+import {logError, isPlainObject, isStr, isNumber, getWinDimensions} from '../src/utils.js';
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js'
 import AES from 'crypto-js/aes.js';
 import Utf8 from 'crypto-js/enc-utf8.js';
 import {detectBrowser} from '../libraries/intentIqUtils/detectBrowserUtils.js';
+import {appendSPData} from '../libraries/intentIqUtils/urlUtils.js';
 import {appendVrrefAndFui} from '../libraries/intentIqUtils/getRefferer.js';
 import { getCmpData } from '../libraries/intentIqUtils/getCmpData.js';
-import {readData, storeData, defineStorageType, removeDataByKey} from '../libraries/intentIqUtils/storageUtils.js';
+import {readData, storeData, defineStorageType, removeDataByKey, tryParse} from '../libraries/intentIqUtils/storageUtils.js';
 import {
   FIRST_PARTY_KEY,
   WITH_IIQ, WITHOUT_IIQ,
   NOT_YET_DEFINED,
-  BLACK_LIST,
   CLIENT_HINTS_KEY,
   EMPTY,
   GVLID,
-  VERSION, INVALID_ID, GDPR_ENDPOINT, VR_ENDPOINT, SYNC_ENDPOINT, SCREEN_PARAMS, GDPR_SYNC_ENDPOINT, SYNC_REFRESH_MILL
+  VERSION, INVALID_ID, SCREEN_PARAMS, SYNC_REFRESH_MILL, META_DATA_CONSTANT, PREBID,
+  HOURS_24
 } from '../libraries/intentIqConstants/intentIqConstants.js';
 import {SYNC_KEY} from '../libraries/intentIqUtils/getSyncKey.js';
+import {iiqPixelServerAddress, iiqServerAddress} from '../libraries/intentIqUtils/intentIqConfig.js';
+import { handleAdditionalParams } from '../libraries/intentIqUtils/handleAdditionalParams.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -45,6 +48,14 @@ const encoderCH = {
   wow64: 7,
   fullVersionList: 8
 };
+let sourceMetaData;
+let sourceMetaDataExternal;
+
+let FIRST_PARTY_KEY_FINAL = FIRST_PARTY_KEY;
+let PARTNER_DATA_KEY;
+let callCount = 0;
+let failCount = 0;
+let noDataCount = 0;
 
 export let firstPartyData;
 
@@ -82,12 +93,13 @@ export function decryptData(encryptedText) {
 }
 
 function collectDeviceInfo() {
+  const windowDimensions = getWinDimensions();
   return {
-    windowInnerHeight: getWinDimensions().innerHeight,
-    windowInnerWidth: getWinDimensions().innerWidth,
-    devicePixelRatio: window.devicePixelRatio,
-    windowScreenHeight: window.screen.height,
-    windowScreenWidth: window.screen.width,
+    windowInnerHeight: windowDimensions.innerHeight,
+    windowInnerWidth: windowDimensions.innerWidth,
+    devicePixelRatio: windowDimensions.devicePixelRatio,
+    windowScreenHeight: windowDimensions.screen.height,
+    windowScreenWidth: windowDimensions.screen.width,
     language: navigator.language
   }
 }
@@ -117,6 +129,23 @@ function appendFirstPartyData (url, firstPartyData, partnerData) {
   return url
 }
 
+function verifyIdType(value) {
+  if (value === 0 || value === 1 || value === 3 || value === 4) return value;
+  return -1;
+}
+
+function appendPartnersFirstParty (url, configParams) {
+  let partnerClientId = typeof configParams.partnerClientId === 'string' ? encodeURIComponent(configParams.partnerClientId) : '';
+  let partnerClientIdType = typeof configParams.partnerClientIdType === 'number' ? verifyIdType(configParams.partnerClientIdType) : -1;
+
+  if (partnerClientIdType === -1) return url;
+  if (partnerClientId !== '') {
+      url = url + '&pcid=' + partnerClientId;
+      url = url + '&idtype=' + partnerClientIdType;
+  }
+  return url;
+}
+
 function appendCMPData (url, cmpData) {
   url += cmpData.uspString ? '&us_privacy=' + encodeURIComponent(cmpData.uspString) : '';
   url += cmpData.gppString ? '&gpp=' + encodeURIComponent(cmpData.gppString) : '';
@@ -126,20 +155,58 @@ function appendCMPData (url, cmpData) {
   return url
 }
 
-export function createPixelUrl(firstPartyData, clientHints, configParams, partnerData, cmpData) {
-  const deviceInfo = collectDeviceInfo()
+function appendCounters (url) {
+  url += '&jaesc=' + encodeURIComponent(callCount);
+  url += '&jafc=' + encodeURIComponent(failCount);
+  url += '&jaensc=' + encodeURIComponent(noDataCount);
+  return url
+}
 
-  let url = cmpData.gdprString ? GDPR_SYNC_ENDPOINT : SYNC_ENDPOINT;
-  url += '/profiles_engine/ProfilesEngineServlet?at=20&mi=10&secure=1'
+/**
+ * Translate and validate sourceMetaData
+ */
+export function translateMetadata(data) {
+  try {
+    const d = data.split('.');
+    return (
+      ((+d[0] * META_DATA_CONSTANT + +d[1]) * META_DATA_CONSTANT + +d[2]) * META_DATA_CONSTANT +
+      +d[3]
+    );
+  } catch (e) {
+    return NaN;
+  }
+}
+
+/**
+ * Add sourceMetaData to URL if valid
+ */
+function addMetaData(url, data) {
+  if (typeof data !== 'number' || isNaN(data)) {
+    return url;
+  }
+  return url + '&fbp=' + data;
+}
+
+export function createPixelUrl(firstPartyData, clientHints, configParams, partnerData, cmpData) {
+  const deviceInfo = collectDeviceInfo();
+  const browser = detectBrowser();
+
+  let url = iiqPixelServerAddress(configParams, cmpData.gdprString);
+  url += '/profiles_engine/ProfilesEngineServlet?at=20&mi=10&secure=1';
   url += '&dpi=' + configParams.partner;
   url = appendFirstPartyData(url, firstPartyData, partnerData);
+  url = appendPartnersFirstParty(url, configParams);
   url = addUniquenessToUrl(url);
   url += partnerData?.clientType ? '&idtype=' + partnerData.clientType : '';
-  if (deviceInfo) url = appendDeviceInfoToUrl(url, deviceInfo)
+  if (deviceInfo) url = appendDeviceInfoToUrl(url, deviceInfo);
   url += VERSION ? '&jsver=' + VERSION : '';
   if (clientHints) url += '&uh=' + encodeURIComponent(clientHints);
   url = appendVrrefAndFui(url, configParams.domainName);
-  url = appendCMPData(url, cmpData)
+  url = appendCMPData(url, cmpData);
+  url = addMetaData(url, sourceMetaDataExternal || sourceMetaData);
+  url = handleAdditionalParams(browser, url, 0, configParams.additionalParams);
+  url = appendSPData(url, firstPartyData)
+  url += '&source=' + PREBID;
   return url;
 }
 
@@ -154,26 +221,13 @@ function sendSyncRequest(allowedStorage, url, partner, firstPartyData, newUser) 
       }, undefined, {method: 'GET', withCredentials: true});
       if (firstPartyData?.date) {
         firstPartyData.date = Date.now()
-        storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+        storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
       }
     }
   } else if (!lastSyncDate || lastSyncElapsedTime > SYNC_REFRESH_MILL) {
     storeData(SYNC_KEY(partner), Date.now() + '', allowedStorage);
     ajax(url, () => {
     }, undefined, {method: 'GET', withCredentials: true});
-  }
-}
-
-/**
- * Parse json if possible, else return null
- * @param data
- */
-function tryParse(data) {
-  try {
-    return JSON.parse(data);
-  } catch (err) {
-    logError(err);
-    return null;
   }
 }
 
@@ -226,6 +280,30 @@ export function isCMPStringTheSame(fpData, cmpData) {
   return firstPartyDataCPString === cmpDataString;
 }
 
+function updateCountersAndStore(runtimeEids, allowedStorage, partnerData) {
+  if (!runtimeEids?.eids?.length) {
+    noDataCount++;
+  } else {
+    callCount++;
+  }
+  storeCounters(allowedStorage, partnerData);
+}
+
+function clearCountersAndStore(allowedStorage, partnerData) {
+  callCount = 0;
+  failCount = 0;
+  noDataCount = 0;
+  storeCounters(allowedStorage, partnerData);
+}
+
+function storeCounters(storage, partnerData) {
+  partnerData.callCount = callCount;
+  partnerData.failCount = failCount;
+  partnerData.noDataCounter = noDataCount;
+  storeData(PARTNER_DATA_KEY, JSON.stringify(partnerData), storage, firstPartyData);
+}
+
+
 /** @type {Submodule} */
 export const intentIqIdSubmodule = {
   /**
@@ -252,44 +330,53 @@ export const intentIqIdSubmodule = {
    */
   getId(config) {
     const configParams = (config?.params) || {};
-    let decryptedData, callbackTimeoutID;
-    let callbackFired = false;
-    let runtimeEids = { eids: [] };
-
-    let gamObjectReference = isPlainObject(configParams.gamObjectReference) ? configParams.gamObjectReference : undefined;
-    let gamParameterName = configParams.gamParameterName ? configParams.gamParameterName : 'intent_iq_group';
-
-    const allowedStorage = defineStorageType(config.enabledStorageTypes);
-
-    let rrttStrtTime = 0;
-    let partnerData = {};
-    let shouldCallServer = false;
-    const FIRST_PARTY_DATA_KEY = `${FIRST_PARTY_KEY}_${configParams.partner}`;
-    const cmpData = getCmpData();
-    const gdprDetected = cmpData.gdprString;
-    firstPartyData = tryParse(readData(FIRST_PARTY_KEY, allowedStorage));
-    const isGroupB = firstPartyData?.group === WITHOUT_IIQ;
-    setGamReporting(gamObjectReference, gamParameterName, firstPartyData?.group)
 
     const firePartnerCallback = () => {
       if (configParams.callback && !callbackFired) {
         callbackFired = true;
         if (callbackTimeoutID) clearTimeout(callbackTimeoutID);
         if (isGroupB) runtimeEids = { eids: [] };
-        configParams.callback(runtimeEids, firstPartyData?.group || NOT_YET_DEFINED);
+        configParams.callback(runtimeEids);
       }
     }
-
-    callbackTimeoutID = setTimeout(() => {
-      firePartnerCallback();
-    }, configParams.timeoutInMillis || 500
-    );
 
     if (typeof configParams.partner !== 'number') {
       logError('User ID - intentIqId submodule requires a valid partner to be defined');
       firePartnerCallback()
       return;
     }
+
+    let decryptedData, callbackTimeoutID;
+    let callbackFired = false;
+    let runtimeEids = { eids: [] };
+
+    let gamObjectReference = isPlainObject(configParams.gamObjectReference) ? configParams.gamObjectReference : undefined;
+    let gamParameterName = configParams.gamParameterName ? configParams.gamParameterName : 'intent_iq_group';
+    let groupChanged = typeof configParams.groupChanged === 'function' ? configParams.groupChanged : undefined;
+    let siloEnabled = typeof configParams.siloEnabled === 'boolean' ? configParams.siloEnabled : false;
+    sourceMetaData = isStr(configParams.sourceMetaData) ? translateMetadata(configParams.sourceMetaData) : '';
+    sourceMetaDataExternal = isNumber(configParams.sourceMetaDataExternal) ? configParams.sourceMetaDataExternal : undefined;
+    let additionalParams = configParams.additionalParams ? configParams.additionalParams : undefined;
+    PARTNER_DATA_KEY = `${FIRST_PARTY_KEY}_${configParams.partner}`;
+
+    const allowedStorage = defineStorageType(config.enabledStorageTypes);
+
+    let rrttStrtTime = 0;
+    let partnerData = {};
+    let shouldCallServer = false;
+    FIRST_PARTY_KEY_FINAL = `${FIRST_PARTY_KEY}${siloEnabled ? '_p_' + configParams.partner : ''}`;
+    const cmpData = getCmpData();
+    const gdprDetected = cmpData.gdprString;
+    firstPartyData = tryParse(readData(FIRST_PARTY_KEY_FINAL, allowedStorage));
+    const isGroupB = firstPartyData?.group === WITHOUT_IIQ;
+    setGamReporting(gamObjectReference, gamParameterName, firstPartyData?.group);
+
+    if (groupChanged) groupChanged(firstPartyData?.group || NOT_YET_DEFINED);
+
+    callbackTimeoutID = setTimeout(() => {
+      firePartnerCallback();
+    }, configParams.timeoutInMillis || 500
+    );
 
     const currentBrowserLowerCase = detectBrowser();
     const browserBlackList = typeof configParams.browserBlackList === 'string' ? configParams.browserBlackList.toLowerCase() : '';
@@ -301,17 +388,16 @@ export const intentIqIdSubmodule = {
         pcid: firstPartyId,
         pcidDate: Date.now(),
         group: NOT_YET_DEFINED,
-        cttl: 0,
         uspString: EMPTY,
         gppString: EMPTY,
         gdprString: EMPTY,
         date: Date.now()
       };
       newUser = true;
-      storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+      storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
     } else if (!firstPartyData.pcidDate) {
       firstPartyData.pcidDate = Date.now();
-      storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+      storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
     }
 
     if (gdprDetected && !('isOptedOut' in firstPartyData)) {
@@ -341,13 +427,17 @@ export const intentIqIdSubmodule = {
         });
     }
 
-    const savedData = tryParse(readData(FIRST_PARTY_DATA_KEY, allowedStorage))
+    const savedData = tryParse(readData(PARTNER_DATA_KEY, allowedStorage))
     if (savedData) {
       partnerData = savedData;
 
+      if (typeof partnerData.callCount === 'number') callCount = partnerData.callCount;
+      if (typeof partnerData.failCount === 'number') failCount = partnerData.failCount;
+      if (typeof partnerData.noDataCounter === 'number') noDataCount = partnerData.noDataCounter;
+
       if (partnerData.wsrvcll) {
         partnerData.wsrvcll = false;
-        storeData(FIRST_PARTY_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
+        storeData(PARTNER_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
       }
     }
 
@@ -358,14 +448,23 @@ export const intentIqIdSubmodule = {
       }
     }
 
-    if (!firstPartyData.cttl || Date.now() - firstPartyData.date > firstPartyData.cttl || !isCMPStringTheSame(firstPartyData, cmpData)) {
+    if (!isCMPStringTheSame(firstPartyData, cmpData) ||
+          !firstPartyData.sCal ||
+          (savedData && (!partnerData.cttl || !partnerData.date || Date.now() - partnerData.date > partnerData.cttl))) {
       firstPartyData.uspString = cmpData.uspString;
       firstPartyData.gppString = cmpData.gppString;
       firstPartyData.gdprString = cmpData.gdprString;
       shouldCallServer = true;
-      storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
-      storeData(FIRST_PARTY_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
-    } else if (firstPartyData.isOptedOut) {
+      storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+      storeData(PARTNER_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
+    }
+    if (!shouldCallServer) {
+      if (!savedData && !firstPartyData.isOptedOut) {
+        shouldCallServer = true;
+      } else shouldCallServer = Date.now() > firstPartyData.sCal + HOURS_24;
+    }
+
+    if (firstPartyData.isOptedOut) {
       partnerData.data = runtimeEids = { eids: [] };
       firePartnerCallback()
     }
@@ -377,7 +476,7 @@ export const intentIqIdSubmodule = {
     // Check if current browser is in blacklist
     if (browserBlackList?.includes(currentBrowserLowerCase)) {
       logError('User ID - intentIqId submodule: browser is in blacklist! Data will be not provided.');
-      if (configParams.callback) configParams.callback('', BLACK_LIST);
+      if (configParams.callback) configParams.callback('');
       const url = createPixelUrl(firstPartyData, clientHints, configParams, partnerData, cmpData)
       sendSyncRequest(allowedStorage, url, configParams.partner, firstPartyData, newUser)
       return
@@ -386,28 +485,35 @@ export const intentIqIdSubmodule = {
     if (!shouldCallServer) {
       if (isGroupB) runtimeEids = { eids: [] };
       firePartnerCallback();
+      updateCountersAndStore(runtimeEids, allowedStorage, partnerData);
       return { id: runtimeEids.eids };
     }
 
     // use protocol relative urls for http or https
-    let url = `${gdprDetected ? GDPR_ENDPOINT : VR_ENDPOINT}/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=${configParams.partner}&pt=17&dpn=1`;
-    url += configParams.pcid ? '&pcid=' + encodeURIComponent(configParams.pcid) : '';
+    let url = `${iiqServerAddress(configParams, gdprDetected)}/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=${configParams.partner}&pt=17&dpn=1`;
     url += configParams.pai ? '&pai=' + encodeURIComponent(configParams.pai) : '';
     url = appendFirstPartyData(url, firstPartyData, partnerData);
+    url = appendPartnersFirstParty(url, configParams);
     url += (partnerData.cttl) ? '&cttl=' + encodeURIComponent(partnerData.cttl) : '';
     url += (partnerData.rrtt) ? '&rrtt=' + encodeURIComponent(partnerData.rrtt) : '';
-    url = appendCMPData(url, cmpData)
+    url = appendCMPData(url, cmpData);
+    url += '&japs=' + encodeURIComponent(configParams.siloEnabled === true);
+    url = appendCounters(url);
     url += clientHints ? '&uh=' + encodeURIComponent(clientHints) : '';
     url += VERSION ? '&jsver=' + VERSION : '';
     url += firstPartyData?.group ? '&testGroup=' + encodeURIComponent(firstPartyData.group) : '';
+    url = addMetaData(url, sourceMetaDataExternal || sourceMetaData);
+    url = handleAdditionalParams(currentBrowserLowerCase, url, 1, additionalParams);
+    url = appendSPData(url, firstPartyData)
+    url += '&source=' + PREBID;
 
     // Add vrref and fui to the URL
     url = appendVrrefAndFui(url, configParams.domainName);
 
     const storeFirstPartyData = () => {
       partnerData.eidl = runtimeEids?.eids?.length || -1
-      storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
-      storeData(FIRST_PARTY_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
+      storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+      storeData(PARTNER_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
     }
 
     const resp = function (callback) {
@@ -417,7 +523,7 @@ export const intentIqIdSubmodule = {
           // If response is a valid json and should save is true
           if (respJson) {
             partnerData.date = Date.now();
-            firstPartyData.date = Date.now();
+            firstPartyData.sCal = Date.now();
             const defineEmptyDataAndFireCallback = () => {
               respJson.data = partnerData.data = runtimeEids = { eids: [] };
               storeFirstPartyData()
@@ -426,20 +532,22 @@ export const intentIqIdSubmodule = {
             }
             if (callbackTimeoutID) clearTimeout(callbackTimeoutID)
             if ('cttl' in respJson) {
-              firstPartyData.cttl = respJson.cttl;
-            } else firstPartyData.cttl = 86400000;
+              partnerData.cttl = respJson.cttl;
+            } else partnerData.cttl = HOURS_24;
 
             if ('tc' in respJson) {
               partnerData.terminationCause = respJson.tc;
               if (respJson.tc == 41) {
                 firstPartyData.group = WITHOUT_IIQ;
-                storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+                storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+                if (groupChanged) groupChanged(firstPartyData.group);
                 defineEmptyDataAndFireCallback();
                 if (gamObjectReference) setGamReporting(gamObjectReference, gamParameterName, firstPartyData.group);
                 return
               } else {
                 firstPartyData.group = WITH_IIQ;
                 if (gamObjectReference) setGamReporting(gamObjectReference, gamParameterName, firstPartyData.group);
+                if (groupChanged) groupChanged(firstPartyData.group);
               }
             }
             if ('isOptedOut' in respJson) {
@@ -450,13 +558,13 @@ export const intentIqIdSubmodule = {
                 respJson.data = partnerData.data = runtimeEids = { eids: [] };
 
                 const keysToRemove = [
-                  FIRST_PARTY_DATA_KEY,
+                  PARTNER_DATA_KEY,
                   CLIENT_HINTS_KEY
                 ];
 
                 keysToRemove.forEach(key => removeDataByKey(key, allowedStorage));
 
-                storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
+                storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
                 firePartnerCallback();
                 callback(runtimeEids);
                 return
@@ -464,6 +572,9 @@ export const intentIqIdSubmodule = {
             }
             if ('pid' in respJson) {
               firstPartyData.pid = respJson.pid;
+            }
+            if ('dbsaved' in respJson) {
+              firstPartyData.dbsaved = respJson.dbsaved;
             }
             if ('ls' in respJson) {
               if (respJson.ls === false) {
@@ -490,6 +601,11 @@ export const intentIqIdSubmodule = {
               partnerData.siteId = respJson.sid;
             }
 
+            if ('spd' in respJson) {
+              // server provided data
+              firstPartyData.spd = respJson.spd;
+            }
+
             if (rrttStrtTime && rrttStrtTime > 0) {
               partnerData.rrtt = Date.now() - rrttStrtTime;
             }
@@ -504,6 +620,7 @@ export const intentIqIdSubmodule = {
               callback(runtimeEids);
               firePartnerCallback()
             }
+            updateCountersAndStore(runtimeEids, allowedStorage, partnerData);
             storeFirstPartyData();
           } else {
             callback(runtimeEids);
@@ -512,13 +629,17 @@ export const intentIqIdSubmodule = {
         },
         error: error => {
           logError(MODULE_NAME + ': ID fetch encountered an error', error);
+          failCount++;
+          updateCountersAndStore(runtimeEids, allowedStorage, partnerData);
           callback(runtimeEids);
         }
       };
       rrttStrtTime = Date.now();
 
       partnerData.wsrvcll = true;
-      storeData(FIRST_PARTY_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
+      storeData(PARTNER_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
+      clearCountersAndStore(allowedStorage, partnerData);
+
       ajax(url, callbacks, undefined, {method: 'GET', withCredentials: true});
     };
     const respObj = {callback: resp};

--- a/modules/intentIqIdSystem.md
+++ b/modules/intentIqIdSystem.md
@@ -10,16 +10,16 @@ gpp_sids: usnat
 
 By leveraging the Intent IQ identity graph, our module helps publishers, SSPs, and DSPs overcome the challenges of monetizing cookie-less inventory and preparing for a future without 3rd-party cookies. Our solution implements 1st-party data clustering and provides Intent IQ person IDs with over 90% coverage and unmatched accuracy in supported countries while remaining privacy-friendly and CCPA compliant. This results in increased CPMs, higher fill rates, and, ultimately, lifting overall revenue
 
-# All you need is a few basic steps to start using our solution.
+# All you need is a few basic steps to start using our solution
 
 ## Registration
 
-Navigate to [our portal ](https://www.intentiq.com/) and contact our team for partner ID.
+Navigate to [our portal](https://www.intentiq.com/) and contact our team for partner ID.
 check our [documentation](https://pbmodule.documents.intentiq.com/) to get more information about our solution and how utilze it's full potential
 
 ## Integration
 
-```
+```bash
 gulp build –modules=intentIqIdSystem
 ```
 
@@ -29,8 +29,9 @@ We recommend including the Intent IQ Analytics adapter module for improved visib
 
 ### Parameters
 
-Please find below list of paramters that could be used in configuring Intent IQ Universal ID module
+Please find below list of parameters that could be used in configuring Intent IQ Universal ID module
 
+{: .table .table-bordered .table-striped }
 | Param under userSync.userIds[] | Scope    | Type     | Description                                                                                                                                                                                                                                                                                                                               | Example                                       |
 | ------------------------------ | -------- |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
 | name                           | Required | String   | The name of this module: "intentIqId"                                                                                                                                                                                                                                                                                                     | `"intentIqId"`                                |
@@ -38,14 +39,26 @@ Please find below list of paramters that could be used in configuring Intent IQ 
 | params.partner                 | Required | Number   | This is the partner ID value obtained from registering with IntentIQ.                                                                                                                                                                                                                                                                     | `1177538`                                     |
 | params.pcid                    | Optional | String   | This is the partner cookie ID, it is a dynamic value attached to the request.                                                                                                                                                                                                                                                             | `"g3hC52b"`                                   |
 | params.pai                     | Optional | String   | This is the partner customer ID / advertiser ID, it is a dynamic value attached to the request.                                                                                                                                                                                                                                           | `"advertiser1"`                               |
-| params.callback                | Optional | Function | This is a callback which is trigered with data and AB group                                                                                                                                                                                                                                                                               | `(data, group) => console.log({ data, group })` |
+| params.callback                | Optional | Function | This is a callback which is triggered with data                                                                                                                                                                                                                                                                               | `(data) => console.log({ data })` |
 | params.timeoutInMillis         | Optional | Number   | This is the timeout in milliseconds, which defines the maximum duration before the callback is triggered. The default value is 500.                                                                                                                                                                                                       | `450`                                         |
-| params.browserBlackList        | Optional |  String  | This is the name of a browser that can be added to a blacklist.                                                                                                                                                                                                                                                                           | `"chrome"`                                    |
+| params.browserBlackList        | Optional | String   | This is the name of a browser that can be added to a blacklist.                                                                                                                                                                                                                                                                           | `"chrome"`                                    |
 | params.manualWinReportEnabled  | Optional | Boolean  | This variable determines whether the bidWon event is triggered automatically. If set to false, the event will occur automatically, and manual reporting with reportExternalWin will be disabled. If set to true, the event will not occur automatically, allowing manual reporting through reportExternalWin. The default value is false. | `true`                                        |
 | params.domainName              | Optional | String   | Specifies the domain of the page in which the IntentIQ object is currently running and serving the impression. This domain will be used later in the revenue reporting breakdown by domain. For example, cnn.com. It identifies the primary source of requests to the IntentIQ servers, even within nested web pages.                     | `"currentDomain.com"`                         |
 | params.gamObjectReference      | Optional | Object   | This is a reference to the Google Ad Manager (GAM) object, which will be used to set targeting. If this parameter is not provided, the group reporting will not be configured.                                                                                                                                                            | `googletag`                                   |
 | params.gamParameterName        | Optional | String   | The name of the targeting parameter that will be used to pass the group. If not specified, the default value is `intent_iq_group`.                                                                                                                                                                                                        | `"intent_iq_group"`                           |
-| params.adUnitConfig                   | Optional | Number   | Determines how the placementId parameter is extracted in the report (default is 1). Possible values: 1 – adUnitCode first, 2 – placementId first, 3 – only adUnitCode, 4 – only placementId                                                                                                                                                    | `1`                                           |
+| params.adUnitConfig            | Optional | Number   | Determines how the `placementId` parameter is extracted in the report (default is 1). Possible values: 1 – adUnitCode first, 2 – placementId first, 3 – only adUnitCode, 4 – only placementId                                                                                                                                             | `1`                                           |
+| params.sourceMetaData          | Optional | String   | This metadata can be provided by the partner and will be included in the requests URL as a query parameter                                                                                                                                                                                                                                | `"123.123.123.123"`                           |
+| params.sourceMetaDataExternal  | Optional | Number   | This metadata can be provided by the partner and will be included in the requests URL as a query parameter                                                                                                                                                                                                                                | `123456`                                      |
+| params.iiqServerAddress        | Optional | String   | The base URL for the IntentIQ API server. If parameter is provided in `configParams`, it will be used.                                                                                                                                                                                                                                    | `"https://domain.com"`                        |
+| params.iiqPixelServerAddress   | Optional | String   | The base URL for the IntentIQ pixel synchronization server. If parameter is provided in `configParams`, it will be used.                                                                                                                                                                                                                  | `"https://domain.com"`                        |
+| params.reportingServerAddress  | Optional | String   | The base URL for the IntentIQ reporting server. If parameter is provided in `configParams`, it will be used.                                                                                                                                                                                                                              | `"https://domain.com"`                        |
+| params.reportMethod            | Optional | String   | Defines the HTTP method used to send the analytics report. If set to `"POST"`, the report payload will be sent in the body of the request. If set to `"GET"` (default), the payload will be included as a query parameter in the request URL.                                                                                             |`"GET"`                                        |
+| params.siloEnabled             | Optional | Boolean  | Determines if first-party data is stored in a siloed storage key. When set to `true`, first-party data is stored under a modified key that appends `_p_` plus the partner value rather than using the default storage key. The default value is `false`.                                                                          | `true`                                        |
+| params.groupChanged            | Optional | Function | A callback that is triggered every time the user’s A/B group is set or updated.                                                                                         |`(group) => console.log('Group changed:', group)` |
+| params.additionalParameters | Optional | Array | This parameter allows sending additional custom key-value parameters with specific destination logic (sync, VR, winreport). Each custom parameter is defined as an object in the array. | `[ { parameterName: “abc”, parameterValue: 123, destination: [1,1,0] } ]` |
+| params.additionalParameters [0].parameterName | Required | String | Name of the custom parameter. This will be sent as a query parameter. | `"abc"` |
+| params.additionalParameters [0].parameterValue | Required | String / Number | Value to assign to the parameter. | `123` |
+| params.additionalParameters [0].destination | Required | Array | Array of numbers either `1` or `0`. Controls where this parameter is sent `[sendWithSync, sendWithVr, winreport]`. | `[1, 0, 0]` |
 
 ### Configuration example
 
@@ -58,10 +71,28 @@ pbjs.setConfig({
                 partner: 123456,     // valid partner id
                 timeoutInMillis: 500,
                 browserBlackList: "chrome",
-                callback: (data, group) => window.pbjs.requestBids(),
-                manualWinReportEnabled: true,
+                callback: (data) => {...}, // your logic here
+                groupChanged: (group) => console.log('Group is', group),
+                manualWinReportEnabled: true, // Optional parameter
                 domainName: "currentDomain.com",
-                adUnitConfig: 1 // Extracting placementId strategy (adUnitCode or placementId order of priorities)
+                gamObjectReference: googletag, // Optional parameter
+                gamParameterName: "intent_iq_group", // Optional parameter
+                adUnitConfig: 1, // Extracting placementId strategy (adUnitCode or placementId order of priorities)
+                sourceMetaData: "123.123.123.123", // Optional parameter
+                sourceMetaDataExternal: 123456, // Optional parameter
+                reportMethod: "GET", // Optional parameter
+                additionalParameters: [ // Optional parameter
+                    {
+                      parameterName: "abc",
+                      parameterValue: 123,
+                      destination: [1, 1, 0] // sendWithSync: true, sendWithVr: true, winreport: false
+                    },
+                    {
+                      parameterName: "xyz",
+                      parameterValue: 111,
+                      destination: [0, 1, 1] // sendWithSync: false, sendWithVr: true, winreport: true
+                    }
+                ]
             },
             storage: {
                 type: "html5",

--- a/modules/intersectionRtdProvider.js
+++ b/modules/intersectionRtdProvider.js
@@ -2,7 +2,7 @@ import {submodule} from '../src/hook.js';
 import {isFn, logError} from '../src/utils.js';
 import {config} from '../src/config.js';
 import {getGlobal} from '../src/prebidGlobal.js';
-import {includes} from '../src/polyfill.js';
+
 import '../src/adapterManager.js';
 
 let observerAvailable = true;
@@ -17,7 +17,7 @@ function getIntersectionData(requestBidsObject, onDone, providerConfig, userCons
   const waitForIt = providerConfig.waitForIt;
   let adUnits = requestBidsObject.adUnits || getGlobal().adUnits || [];
   if (adUnitCodes.length) {
-    adUnits = adUnits.filter(unit => includes(adUnitCodes, unit.code));
+    adUnits = adUnits.filter(unit => adUnitCodes.includes(unit.code));
   }
   let checkTimeoutId;
   findAndObservePlaceholders();

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -19,7 +19,6 @@ import {
 import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
-import { find } from '../src/polyfill.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { INSTREAM, OUTSTREAM } from '../src/video.js';
 import { Renderer } from '../src/Renderer.js';
@@ -980,8 +979,7 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
         banner: {
           topframe,
           format: bannerImps.map(({ banner: { w, h }, ext }) => ({ w, h, ext }))
-        },
-      };
+        }};
 
       for (let i = 0; i < _bannerImpression.banner.format.length; i++) {
         // We add sid and externalID in imp.ext therefore, remove from banner.format[].ext

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -19,6 +19,7 @@ import {
 import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
+import { find } from '../src/polyfill.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { INSTREAM, OUTSTREAM } from '../src/video.js';
 import { Renderer } from '../src/Renderer.js';

--- a/modules/justIdSystem.js
+++ b/modules/justIdSystem.js
@@ -8,7 +8,7 @@
 import * as utils from '../src/utils.js'
 import { submodule } from '../src/hook.js'
 import { loadExternalScript } from '../src/adloader.js'
-import {includes} from '../src/polyfill.js';
+
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 /**
@@ -141,7 +141,7 @@ export const ConfigWrapper = function(config) {
   }
 
   // validation
-  if (!includes([MODE_BASIC, MODE_COMBINED], this.getMode())) {
+  if (![MODE_BASIC, MODE_COMBINED].includes(this.getMode())) {
     throw EX_INVALID_MODE;
   }
 

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -13,7 +13,6 @@ import {submodule} from '../src/hook.js';
 import {config} from '../src/config.js';
 import {ajaxBuilder} from '../src/ajax.js';
 import { deepAccess, logError, logWarn } from '../src/utils.js'
-import {find} from '../src/polyfill.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 
 /**
@@ -55,7 +54,7 @@ export const jwplayerSubmodule = {
 
 config.getConfig('realTimeData', ({realTimeData}) => {
   const providers = realTimeData.dataProviders;
-  const jwplayerProvider = providers && find(providers, pr => pr.name && pr.name.toLowerCase() === SUBMODULE_NAME);
+  const jwplayerProvider = providers && ((providers) || []).find(pr => pr.name && pr.name.toLowerCase() === SUBMODULE_NAME);
   const params = jwplayerProvider && jwplayerProvider.params;
   if (!params) {
     return;
@@ -268,7 +267,7 @@ export function getVatFromPlayer(playerDivId, mediaID) {
     return null;
   }
 
-  const item = mediaID ? find(player.getPlaylist(), item => item.mediaid === mediaID) : player.getPlaylistItem();
+  const item = mediaID ? ((player.getPlaylist()) || []).find(item => item.mediaid === mediaID) : player.getPlaylistItem();
   if (!item) {
     return null;
   }

--- a/modules/livewrappedBidAdapter.js
+++ b/modules/livewrappedBidAdapter.js
@@ -1,7 +1,6 @@
 import {deepAccess, getWindowTop, isSafariBrowser, mergeDeep, isFn, isPlainObject, getWinDimensions} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
-import {find} from '../src/polyfill.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {getStorageManager} from '../src/storageManager.js';
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
@@ -52,18 +51,18 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function(bidRequests, bidderRequest) {
-    const userId = find(bidRequests, hasUserId);
-    const pubcid = find(bidRequests, hasPubcid);
-    const publisherId = find(bidRequests, hasPublisherId);
-    const auctionId = find(bidRequests, hasAuctionId);
-    let bidUrl = find(bidRequests, hasBidUrl);
-    let url = find(bidRequests, hasUrl);
-    let test = find(bidRequests, hasTestParam);
-    const seats = find(bidRequests, hasSeatsParam);
-    const deviceId = find(bidRequests, hasDeviceIdParam);
-    const ifa = find(bidRequests, hasIfaParam);
-    const bundle = find(bidRequests, hasBundleParam);
-    const tid = find(bidRequests, hasTidParam);
+    const userId = ((bidRequests) || []).find(hasUserId);
+    const pubcid = ((bidRequests) || []).find(hasPubcid);
+    const publisherId = ((bidRequests) || []).find(hasPublisherId);
+    const auctionId = ((bidRequests) || []).find(hasAuctionId);
+    let bidUrl = ((bidRequests) || []).find(hasBidUrl);
+    let url = ((bidRequests) || []).find(hasUrl);
+    let test = ((bidRequests) || []).find(hasTestParam);
+    const seats = ((bidRequests) || []).find(hasSeatsParam);
+    const deviceId = ((bidRequests) || []).find(hasDeviceIdParam);
+    const ifa = ((bidRequests) || []).find(hasIfaParam);
+    const bundle = ((bidRequests) || []).find(hasBundleParam);
+    const tid = ((bidRequests) || []).find(hasTidParam);
     const schain = bidRequests[0].schain;
     let ortb2 = bidderRequest.ortb2;
     const eids = handleEids(bidRequests);
@@ -113,8 +112,7 @@ export const spec = {
     return {
       method: 'POST',
       url: bidUrl,
-      data: payloadString,
-    };
+      data: payloadString};
   },
 
   /**

--- a/modules/mediafuseBidAdapter.js
+++ b/modules/mediafuseBidAdapter.js
@@ -20,7 +20,7 @@ import {Renderer} from '../src/Renderer.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {ADPOD, BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {bidderSettings} from '../src/bidderSettings.js';
@@ -116,7 +116,7 @@ export const spec = {
     // convert Native ORTB definition to old-style prebid native definition
     bidRequests = convertOrtbRequestToProprietaryNative(bidRequests);
     const tags = bidRequests.map(bidToTag);
-    const userObjBid = find(bidRequests, hasUserInfo);
+    const userObjBid = ((bidRequests) || []).find(hasUserInfo);
     let userObj = {};
     if (config.getConfig('coppa') === true) {
       userObj = { 'coppa': true };
@@ -142,7 +142,7 @@ export const spec = {
         });
     }
 
-    const appDeviceObjBid = find(bidRequests, hasAppDeviceInfo);
+    const appDeviceObjBid = ((bidRequests) || []).find(hasAppDeviceInfo);
     let appDeviceObj;
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
@@ -151,7 +151,7 @@ export const spec = {
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
-    const appIdObjBid = find(bidRequests, hasAppId);
+    const appIdObjBid = ((bidRequests) || []).find(hasAppId);
     let appIdObj;
     if (appIdObjBid && appIdObjBid.params && appDeviceObjBid.params.app && appDeviceObjBid.params.app.id) {
       appIdObj = {
@@ -171,7 +171,7 @@ export const spec = {
         logError('MediaFuse Debug Auction Cookie Error:\n\n' + e);
       }
     } else {
-      const debugBidRequest = find(bidRequests, hasDebug);
+      const debugBidRequest = ((bidRequests) || []).find(hasDebug);
       if (debugBidRequest && debugBidRequest.debug) {
         debugObj = debugBidRequest.debug;
       }
@@ -185,10 +185,10 @@ export const spec = {
         });
     }
 
-    const memberIdBid = find(bidRequests, hasMemberId);
+    const memberIdBid = ((bidRequests) || []).find(hasMemberId);
     const member = memberIdBid ? parseInt(memberIdBid.params.member, 10) : 0;
     const schain = bidRequests[0].schain;
-    const omidSupport = find(bidRequests, hasOmidSupport);
+    const omidSupport = ((bidRequests) || []).find(hasOmidSupport);
 
     const payload = {
       tags: [...tags],
@@ -260,7 +260,7 @@ export const spec = {
       payload.referrer_detection = refererinfo;
     }
 
-    const hasAdPodBid = find(bidRequests, hasAdPod);
+    const hasAdPodBid = ((bidRequests) || []).find(hasAdPod);
     if (hasAdPodBid) {
       bidRequests.filter(hasAdPod).forEach(adPodBid => {
         const adPodTags = createAdPodRequest(tags, adPodBid);
@@ -558,8 +558,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
       complete: 0,
       nodes: [{
         bsid: rtbBid.buyer_member_id.toString()
-      }],
-    };
+      }]};
 
     return dchain;
   }
@@ -600,7 +599,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
         bid.vastXml = rtbBid.rtb.video.content;
 
         if (rtbBid.renderer_url) {
-          const videoBid = find(bidderRequest.bids, bid => bid.bidId === serverBid.uuid);
+          const videoBid = ((bidderRequest.bids) || []).find(bid => bid.bidId === serverBid.uuid);
           const rendererOptions = deepAccess(videoBid, 'renderer.options');
           bid.renderer = newRenderer(bid.adUnitCode, rtbBid, rendererOptions);
         }
@@ -971,7 +970,7 @@ function setVideoProperty(tag, key, value) {
 }
 
 function getRtbBid(tag) {
-  return tag && tag.ads && tag.ads.length && find(tag.ads, ad => ad.rtb);
+  return tag && tag.ads && tag.ads.length && ((tag.ads) || []).find(ad => ad.rtb);
 }
 
 function buildNativeRequest(params) {

--- a/modules/mediafuseBidAdapter.js
+++ b/modules/mediafuseBidAdapter.js
@@ -20,7 +20,7 @@ import {Renderer} from '../src/Renderer.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {ADPOD, BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {bidderSettings} from '../src/bidderSettings.js';
@@ -123,7 +123,7 @@ export const spec = {
     }
     if (userObjBid) {
       Object.keys(userObjBid.params.user)
-        .filter(param => includes(USER_PARAMS, param))
+        .filter(param => USER_PARAMS.includes(param))
         .forEach((param) => {
           let uparam = convertCamelToUnderscore(param);
           if (param === 'segments' && isArray(userObjBid.params.user[param])) {
@@ -147,7 +147,7 @@ export const spec = {
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
       Object.keys(appDeviceObjBid.params.app)
-        .filter(param => includes(APP_DEVICE_PARAMS, param))
+        .filter(param => APP_DEVICE_PARAMS.includes(param))
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
@@ -179,7 +179,7 @@ export const spec = {
 
     if (debugObj && debugObj.enabled) {
       Object.keys(debugObj)
-        .filter(param => includes(DEBUG_PARAMS, param))
+        .filter(param => DEBUG_PARAMS.includes(param))
         .forEach(param => {
           debugObjParams[param] = debugObj[param];
         });
@@ -313,7 +313,7 @@ export const spec = {
         const rtbBid = getRtbBid(serverBid);
         if (rtbBid) {
           const cpmCheck = (bidderSettings.get(bidderRequest.bidderCode, 'allowZeroCpmBids') === true) ? rtbBid.cpm >= 0 : rtbBid.cpm > 0;
-          if (cpmCheck && includes(this.supportedMediaTypes, rtbBid.ad_type)) {
+          if (cpmCheck && this.supportedMediaTypes.includes(rtbBid.ad_type)) {
             const bid = newBid(serverBid, rtbBid, bidderRequest);
             bid.mediaType = parseMediaType(rtbBid);
             bids.push(bid);
@@ -767,7 +767,7 @@ function bidToTag(bid) {
     tag.video = {};
     // place any valid video params on the tag
     Object.keys(bid.params.video)
-      .filter(param => includes(VIDEO_TARGETING, param))
+      .filter(param => VIDEO_TARGETING.includes(param))
       .forEach(param => {
         switch (param) {
           case 'context':
@@ -793,7 +793,7 @@ function bidToTag(bid) {
   if (videoMediaType) {
     tag.video = tag.video || {};
     Object.keys(videoMediaType)
-      .filter(param => includes(VIDEO_RTB_TARGETING, param))
+      .filter(param => VIDEO_RTB_TARGETING.includes(param))
       .forEach(param => {
         switch (param) {
           case 'minduration':
@@ -914,10 +914,10 @@ function hasOmidSupport(bid) {
   const bidderParams = bid.params;
   const videoParams = bid.params.video;
   if (bidderParams.frameworks && isArray(bidderParams.frameworks)) {
-    hasOmid = includes(bid.params.frameworks, 6);
+    hasOmid = bid.params.frameworks.includes(6);
   }
   if (!hasOmid && videoParams && videoParams.frameworks && isArray(videoParams.frameworks)) {
-    hasOmid = includes(bid.params.video.frameworks, 6);
+    hasOmid = bid.params.video.frameworks.includes(6);
   }
   return hasOmid;
 }

--- a/modules/mediakeysBidAdapter.js
+++ b/modules/mediakeysBidAdapter.js
@@ -1,4 +1,3 @@
-import {find} from '../src/polyfill.js';
 import {
   cleanObj,
   deepAccess,
@@ -82,8 +81,7 @@ const ORTB_VIDEO_PARAMS = {
   playbackend: value => [1, 2, 3].indexOf(value) !== -1,
   delivery: value => [1, 2, 3].indexOf(value) !== -1,
   pos: value => [0, 1, 2, 3, 4, 5, 6, 7].indexOf(value) !== -1,
-  api: value => Array.isArray(value) && value.every(v => [1, 2, 3, 4, 5, 6].indexOf(v) !== -1),
-};
+  api: value => Array.isArray(value) && value.every(v => [1, 2, 3, 4, 5, 6].indexOf(v) !== -1)};
 
 /**
  * Returns the OpenRtb deviceType id detected from User Agent
@@ -305,7 +303,7 @@ function createNativeImp(bid) {
 
   for (let key in nativeParams) {
     if (nativeParams.hasOwnProperty(key)) {
-      const internalNativeAsset = find(NATIVE_ASSETS_MAPPING, ref => ref.name === key);
+      const internalNativeAsset = ((NATIVE_ASSETS_MAPPING) || []).find(ref => ref.name === key);
       if (!internalNativeAsset) {
         logWarn(`${BIDDER_CODE}: the asset "${key}" has not been found in Prebid assets map. Skipped for request.`);
         continue;
@@ -540,7 +538,7 @@ function nativeBidResponseHandler(bid) {
     }
 
     if (asset.data) {
-      const internalNativeAsset = find(NATIVE_ASSETS_MAPPING, ref => ref.id === asset.id);
+      const internalNativeAsset = ((NATIVE_ASSETS_MAPPING) || []).find(ref => ref.id === asset.id);
       if (internalNativeAsset) {
         native[internalNativeAsset.name] = asset.data.value;
       }

--- a/modules/medianetRtdProvider.js
+++ b/modules/medianetRtdProvider.js
@@ -2,7 +2,7 @@ import {isEmptyStr, isFn, isStr, logError, mergeDeep} from '../src/utils.js';
 import {loadExternalScript} from '../src/adloader.js';
 import {submodule} from '../src/hook.js';
 import {getGlobal} from '../src/prebidGlobal.js';
-import {includes} from '../src/polyfill.js';
+
 import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 
 const MODULE_NAME = 'medianet';
@@ -91,7 +91,7 @@ function loadRtdScript(customerId) {
 function getAdUnits(adUnits, adUnitCodes) {
   adUnits = adUnits || getGlobal().adUnits || [];
   if (adUnitCodes && adUnitCodes.length) {
-    adUnits = adUnits.filter(unit => includes(adUnitCodes, unit.code));
+    adUnits = adUnits.filter(unit => adUnitCodes.includes(unit.code));
   }
   return adUnits;
 }

--- a/modules/microadBidAdapter.js
+++ b/modules/microadBidAdapter.js
@@ -1,5 +1,5 @@
 import { deepAccess, isArray, isEmpty, isStr } from '../src/utils.js';
-import { find } from '../src/polyfill.js';
+import { } from '../src/polyfill.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
@@ -100,7 +100,7 @@ export const spec = {
           const aidParam = { type: audienceId.type, id: bidAudienceId };
           // Set ext
           if (isArray(userIdAsEids)) {
-            const targetEid = find(userIdAsEids, (eid) => eid.source === audienceId.source) || {};
+            const targetEid = ((userIdAsEids) || []).find((eid) => eid.source === audienceId.source) || {};
             if (!isEmpty(deepAccess(targetEid, 'uids.0.ext'))) {
               aidParam.ext = targetEid.uids[0].ext;
             }

--- a/modules/nextrollBidAdapter.js
+++ b/modules/nextrollBidAdapter.js
@@ -6,14 +6,12 @@ import {
   isPlainObject,
   isStr,
   parseUrl,
-  replaceAuctionPrice,
-} from '../src/utils.js';
+  replaceAuctionPrice} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE} from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { getOsVersion } from '../libraries/advangUtils/index.js';
 
-import {find} from '../src/polyfill.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -338,7 +336,7 @@ function _getOs(userAgent) {
     'windows': /windows/i
   };
 
-  return find(Object.keys(osTable), os => {
+  return ((Object.keys(osTable)) || []).find(os => {
     if (userAgent.match(osTable[os])) {
       return os;
     }

--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -3,7 +3,7 @@
 import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
 import { INSTREAM, OUTSTREAM } from '../src/video.js';
 import { Renderer } from '../src/Renderer.js';
-import { find } from '../src/polyfill.js';
+import { } from '../src/polyfill.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { deepClone, logError, deepAccess, getWinDimensions } from '../src/utils.js';
@@ -185,7 +185,7 @@ function interpretResponse(serverResponse, bidderRequest) {
     if (bid.mediaType === BANNER) {
       responseBid.ad = bid.ad;
     } else if (bid.mediaType === VIDEO) {
-      const { context, adUnitCode } = find(requestData.bids, (item) =>
+      const { context, adUnitCode } = ((requestData.bids) || []).find((item) =>
         item.bidId === bid.requestId &&
         item.type === VIDEO
       );
@@ -209,8 +209,7 @@ function interpretResponse(serverResponse, bidderRequest) {
     const fledgeAuctionConfigs = body.fledgeAuctionConfigs
     return {
       bids,
-      paapi: fledgeAuctionConfigs,
-    }
+      paapi: fledgeAuctionConfigs}
   } else {
     return bids;
   }

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -9,7 +9,7 @@ import {getGlobal} from '../src/prebidGlobal.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {deepAccess, deepSetValue, isFn, logError, mergeDeep, isPlainObject, safeJSONParse, prefixLog} from '../src/utils.js';
-import {includes} from '../src/polyfill.js';
+
 import {MODULE_TYPE_RTD} from '../src/activities/modules.js';
 
 /**
@@ -295,7 +295,7 @@ function getCustomBidderFn (moduleConfig, bidder) {
  */
 export function isAcEnabled (moduleConfig, bidder) {
   const acBidders = deepAccess(moduleConfig, 'params.acBidders') || []
-  return includes(acBidders, bidder)
+  return acBidders.includes(bidder)
 }
 
 /**

--- a/modules/pixfutureBidAdapter.js
+++ b/modules/pixfutureBidAdapter.js
@@ -2,7 +2,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {deepAccess, isArray, isFn, isNumber, isPlainObject} from '../src/utils.js';
 import {auctionManager} from '../src/auctionManager.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
@@ -54,7 +54,7 @@ export const spec = {
 
       if (userObjBid) {
         Object.keys(userObjBid.params.user)
-          .filter(param => includes(USER_PARAMS, param))
+          .filter(param => USER_PARAMS.includes(param))
           .forEach((param) => {
             let uparam = convertCamelToUnderscore(param);
             if (param === 'segments' && isArray(userObjBid.params.user[param])) {

--- a/modules/pixfutureBidAdapter.js
+++ b/modules/pixfutureBidAdapter.js
@@ -2,7 +2,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {deepAccess, isArray, isFn, isNumber, isPlainObject} from '../src/utils.js';
 import {auctionManager} from '../src/auctionManager.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
@@ -46,7 +46,7 @@ export const spec = {
         referer = bidderRequest.refererInfo.page || '';
       }
 
-      const userObjBid = find(validBidRequests, hasUserInfo);
+      const userObjBid = ((validBidRequests) || []).find(hasUserInfo);
       let userObj = {};
       if (config.getConfig('coppa') === true) {
         userObj = {'coppa': true};
@@ -289,7 +289,7 @@ function bidToTag(bid) {
     tag['banner_frameworks'] = bid.params.frameworks;
   }
   // TODO: why does this need to iterate through every adUnit?
-  let adUnit = find(auctionManager.getAdUnits(), au => bid.transactionId === au.transactionId);
+  let adUnit = ((auctionManager.getAdUnits()) || []).find(au => bid.transactionId === au.transactionId);
   if (adUnit && adUnit.mediaTypes && adUnit.mediaTypes.banner) {
     tag.ad_types.push(BANNER);
   }

--- a/modules/pixfutureBidAdapter.md
+++ b/modules/pixfutureBidAdapter.md
@@ -32,7 +32,7 @@ var adUnits = [{
 
     <head>
         <link rel="icon" type="image/png" href="/favicon.ico">
-        <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+        <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
         <script async src="https://cdn.pixfuture.com/pixfuture_prebidjs/prebid.js"></script>
         <script>
             var div_1_sizes = [

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -19,7 +19,7 @@ import adapterManager, {s2sActivityParams} from '../../src/adapterManager.js';
 import {config} from '../../src/config.js';
 import {addPaapiConfig, isValid} from '../../src/adapters/bidderFactory.js';
 import * as events from '../../src/events.js';
-import {includes} from '../../src/polyfill.js';
+
 import {S2S_VENDORS} from './config.js';
 import {ajax} from '../../src/ajax.js';
 import {hook} from '../../src/hook.js';
@@ -116,7 +116,7 @@ function updateConfigDefaults(s2sConfig) {
       // vendor keys will be set if either: the key was not specified by user
       // or if the user did not set their own distinct value (ie using the system default) to override the vendor
       Object.keys(S2S_VENDORS[vendor]).forEach((vendorKey) => {
-        if (s2sDefaultConfig[vendorKey] === s2sConfig[vendorKey] || !includes(optionKeys, vendorKey)) {
+        if (s2sDefaultConfig[vendorKey] === s2sConfig[vendorKey] || !optionKeys.includes(vendorKey)) {
           s2sConfig[vendorKey] = S2S_VENDORS[vendor][vendorKey];
         }
       });
@@ -528,7 +528,7 @@ export const processPBSRequest = hook('async', function (s2sBidRequest, bidReque
           } catch (error) {
             logError(error);
           }
-          if (!result || (result.status && includes(result.status, 'Error'))) {
+          if (!result || (result.status && result.status.includes('Error'))) {
             logError('error parsing response: ', result ? result.status : 'not valid JSON');
             onResponse(false, requestedBidders);
           } else {

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -21,7 +21,6 @@ import {ajaxBuilder} from '../src/ajax.js';
 import * as events from '../src/events.js';
 import { EVENTS, REJECTION_REASON } from '../src/constants.js';
 import {getHook} from '../src/hook.js';
-import {find} from '../src/polyfill.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {bidderSettings} from '../src/bidderSettings.js';
 import {auctionManager} from '../src/auctionManager.js';
@@ -157,7 +156,7 @@ export function getFirstMatchingFloor(floorData, bidObject, responseObject = {})
     return {...previousMatch};
   }
   let allPossibleMatches = generatePossibleEnumerations(fieldValues, deepAccess(floorData, 'schema.delimiter') || '|');
-  let matchingRule = find(allPossibleMatches, hashValue => floorData.values.hasOwnProperty(hashValue));
+  let matchingRule = ((allPossibleMatches) || []).find(hashValue => floorData.values.hasOwnProperty(hashValue));
 
   let matchingData = {
     floorMin: floorData.floorMin || 0,
@@ -282,8 +281,7 @@ export function getFloor(requestParams = {currency: 'USD', mediaType: '*', size:
   if (floorInfo.matchingFloor) {
     return {
       floor: roundUp(floorInfo.matchingFloor, 4),
-      currency,
-    };
+      currency};
   }
   return {};
 }

--- a/modules/quantcastBidAdapter.js
+++ b/modules/quantcastBidAdapter.js
@@ -3,7 +3,6 @@ import {ajax} from '../src/ajax.js';
 import {config} from '../src/config.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {find} from '../src/polyfill.js';
 import {parseDomain} from '../src/refererDetection.js';
 
 /**
@@ -275,7 +274,7 @@ export const spec = {
   getUserSyncs(syncOptions, serverResponses) {
     const syncs = []
     if (!hasUserSynced && syncOptions.pixelEnabled) {
-      const responseWithUrl = find(serverResponses, serverResponse =>
+      const responseWithUrl = ((serverResponses) || []).find(serverResponse =>
         deepAccess(serverResponse.body, 'userSync.url')
       );
 

--- a/modules/reconciliationRtdProvider.js
+++ b/modules/reconciliationRtdProvider.js
@@ -19,7 +19,6 @@
 import {submodule} from '../src/hook.js';
 import {ajaxBuilder} from '../src/ajax.js';
 import {generateUUID, isGptPubadsDefined, logError, timestamp} from '../src/utils.js';
-import {find} from '../src/polyfill.js';
 
 /**
  * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
@@ -28,8 +27,7 @@ import {find} from '../src/polyfill.js';
 /** @type {Object} */
 const MessageType = {
   IMPRESSION_REQUEST: 'rsdk:impression:req',
-  IMPRESSION_RESPONSE: 'rsdk:impression:res',
-};
+  IMPRESSION_RESPONSE: 'rsdk:impression:res'};
 /** @type {ModuleParams} */
 const DEFAULT_PARAMS = {
   initUrl: 'https://confirm.fiduciadlt.com/init',
@@ -154,8 +152,8 @@ function getSlotByCode(code) {
     return null;
   }
   return (
-    find(
-      slots,
+    ((
+      slots) || []).find(
       (s) => s.getSlotElementId() === code || s.getAdUnitPath() === code
     ) || null
   );
@@ -174,7 +172,7 @@ export function getSlotByWin(win) {
   }
 
   return (
-    find(slots, (s) => {
+    ((slots) || []).find((s) => {
       let slotElement = document.getElementById(s.getSlotElementId());
 
       if (slotElement) {

--- a/modules/relevadRtdProvider.js
+++ b/modules/relevadRtdProvider.js
@@ -9,10 +9,9 @@
 import {deepSetValue, isEmpty, logError, mergeDeep} from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {ajax} from '../src/ajax.js';
-import {findIndex} from '../src/polyfill.js';
-import {getRefererInfo} from '../src/refererDetection.js';
 import {config} from '../src/config.js';
 
+import {getRefererInfo} from '../src/refererDetection.js';
 const MODULE_NAME = 'realTimeData';
 const SUBMODULE_NAME = 'RelevadRTDModule';
 
@@ -247,7 +246,7 @@ export function addRtdData(reqBids, data, moduleConfig) {
     noWhitelists && deepSetValue(adUnit, 'ortb2Imp.ext.data.relevad_rtd', relevadList);
 
     adUnit.hasOwnProperty('bids') && adUnit.bids.forEach(bid => {
-      let bidderIndex = (moduleConfig.params.hasOwnProperty('bidders') ? findIndex(moduleConfig.params.bidders, function (i) {
+      let bidderIndex = (moduleConfig.params.hasOwnProperty('bidders') ? (moduleConfig.params.bidders || []).findIndex(function (i) {
         return i.bidder === bid.bidder;
       }) : false);
       const indexFound = !!(typeof bidderIndex == 'number' && bidderIndex >= 0);

--- a/modules/relevadRtdProvider.js
+++ b/modules/relevadRtdProvider.js
@@ -9,7 +9,7 @@
 import {deepSetValue, isEmpty, logError, mergeDeep} from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {ajax} from '../src/ajax.js';
-import {findIndex} from '../src/polyfill.js';
+
 import {getRefererInfo} from '../src/refererDetection.js';
 import {config} from '../src/config.js';
 
@@ -247,7 +247,7 @@ export function addRtdData(reqBids, data, moduleConfig) {
     noWhitelists && deepSetValue(adUnit, 'ortb2Imp.ext.data.relevad_rtd', relevadList);
 
     adUnit.hasOwnProperty('bids') && adUnit.bids.forEach(bid => {
-      let bidderIndex = (moduleConfig.params.hasOwnProperty('bidders') ? findIndex(moduleConfig.params.bidders, function (i) {
+      let bidderIndex = (moduleConfig.params.hasOwnProperty('bidders') ? moduleConfig.params.bidders.findIndex(function (i) {
         return i.bidder === bid.bidder;
       }) : false);
       const indexFound = !!(typeof bidderIndex == 'number' && bidderIndex >= 0);

--- a/modules/roxotAnalyticsAdapter.js
+++ b/modules/roxotAnalyticsAdapter.js
@@ -2,7 +2,7 @@ import {deepClone, getParameterByName, logError, logInfo} from '../src/utils.js'
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import { EVENTS } from '../src/constants.js';
 import adapterManager from '../src/adapterManager.js';
-import {includes} from '../src/polyfill.js';
+
 import {ajaxBuilder} from '../src/ajax.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_ANALYTICS} from '../src/activities/modules.js';
@@ -95,7 +95,7 @@ function isSupportedAdUnit(adUnit) {
     return true;
   }
 
-  return includes(initOptions.adUnits, adUnit);
+  return initOptions.adUnits.includes(adUnit);
 }
 
 function deleteOldAuctions() {

--- a/modules/rtbhouseBidAdapter.js
+++ b/modules/rtbhouseBidAdapter.js
@@ -2,7 +2,7 @@ import {deepAccess, deepClone, isArray, logError, logInfo, mergeDeep, isEmpty, i
 import {getOrigin} from '../libraries/getOrigin/index.js';
 import {BANNER, NATIVE} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {includes} from '../src/polyfill.js';
+
 import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
 import {config} from '../src/config.js';
 import { interpretNativeBid, OPENRTB } from '../libraries/precisoUtils/bidNativeUtils.js';
@@ -31,7 +31,7 @@ export const spec = {
   gvlid: GVLID,
 
   isBidRequestValid: function (bid) {
-    return !!(includes(REGIONS, bid.params.region) && bid.params.publisherId);
+    return !!(REGIONS.includes(bid.params.region) && bid.params.publisherId);
   },
   buildRequests: function (validBidRequests, bidderRequest) {
     // convert Native ORTB definition to old-style prebid native definition
@@ -214,7 +214,7 @@ function applyFloor(slot) {
   const floors = [];
   if (typeof slot.getFloor === 'function') {
     Object.keys(slot.mediaTypes).forEach(type => {
-      if (includes(SUPPORTED_MEDIA_TYPES, type)) {
+      if (SUPPORTED_MEDIA_TYPES.includes(type)) {
         floors.push(slot.getFloor({ currency: DEFAULT_CURRENCY_ARR[0], mediaType: type, size: slot.sizes || '*' })?.floor);
       }
     });

--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -165,7 +165,6 @@ import {logError, logInfo, logWarn} from '../../src/utils.js';
 import * as events from '../../src/events.js';
 import { EVENTS, JSON_MAPPING } from '../../src/constants.js';
 import adapterManager, {gdprDataHandler, uspDataHandler, gppDataHandler} from '../../src/adapterManager.js';
-import {find} from '../../src/polyfill.js';
 import {timedAuctionHook} from '../../src/utils/perfMetrics.js';
 import {GDPR_GVLIDS} from '../../src/consentHandler.js';
 import {MODULE_TYPE_RTD} from '../../src/activities/modules.js';
@@ -270,7 +269,7 @@ function initSubModules() {
   _userConsent = getConsentData();
   let subModulesByOrder = [];
   _dataProviders.forEach(provider => {
-    const sm = find(registeredSubModules, s => s.name === provider.name);
+    const sm = ((registeredSubModules) || []).find(s => s.name === provider.name);
     const initResponse = sm && sm.init && sm.init(provider, _userConsent);
     if (initResponse) {
       subModulesByOrder.push(Object.assign(sm, {config: provider}));

--- a/modules/s2sTesting.js
+++ b/modules/s2sTesting.js
@@ -1,5 +1,4 @@
 import {PARTITIONS, partitionBidders, filterBidsForAdUnit, getS2SBidderSet} from '../src/adapterManager.js';
-import {find} from '../src/polyfill.js';
 import {getBidderCodes, logWarn} from '../src/utils.js';
 
 const {CLIENT, SERVER} = PARTITIONS;
@@ -87,7 +86,7 @@ function isTestingServerOnly(s2sConfig) {
 }
 
 const adUnitsContainServerRequests = (adUnits, s2sConfig) => Boolean(
-  find(adUnits, adUnit => find(adUnit.bids, bid => (
+  ((adUnits) || []).find(adUnit => ((adUnit.bids) || []).find(bid => (
     bid.bidSource ||
     (s2sConfig.bidderControl && s2sConfig.bidderControl[bid.bidder])
   ) && bid.finalSource === SERVER))

--- a/modules/sirdataRtdProvider.js
+++ b/modules/sirdataRtdProvider.js
@@ -13,7 +13,7 @@ import {
   deepAccess, checkCookieSupport, deepSetValue, hasDeviceAccess, inIframe, isEmpty,
   logError, logInfo, mergeDeep
 } from '../src/utils.js';
-import { findIndex } from '../src/polyfill.js';
+
 import { getGlobal } from '../src/prebidGlobal.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 import { getStorageManager } from '../src/storageManager.js';
@@ -160,7 +160,7 @@ export function mergeEuidsArrays(euids1, euids2) {
   const processArray = (array) => {
     array.forEach(item => {
       if (item.uids) {
-        const foundIndex = findIndex(mergedArray, function (x) {
+        const foundIndex = mergedArray.findIndex(function (x) {
           return x.source === item.source;
         });
         if (foundIndex !== -1) {
@@ -686,7 +686,7 @@ export function addSegmentData(reqBids, data, adUnits, onDone) {
 
   adUnits.forEach(adUnit => {
     return adUnit.bids?.forEach(bid => {
-      const bidderIndex = findIndex(params.bidders, function (i) { return i.bidder === bid.bidder; });
+      const bidderIndex = params.bidders.findIndex(function (i) { return i.bidder === bid.bidder; });
       try {
         const aliasActualBidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
         if (aliasActualBidder === 'appnexus') {

--- a/modules/sirdataRtdProvider.js
+++ b/modules/sirdataRtdProvider.js
@@ -13,7 +13,6 @@ import {
   deepAccess, checkCookieSupport, deepSetValue, hasDeviceAccess, inIframe, isEmpty,
   logError, logInfo, mergeDeep
 } from '../src/utils.js';
-import { findIndex } from '../src/polyfill.js';
 import { getGlobal } from '../src/prebidGlobal.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 import { getStorageManager } from '../src/storageManager.js';
@@ -160,7 +159,7 @@ export function mergeEuidsArrays(euids1, euids2) {
   const processArray = (array) => {
     array.forEach(item => {
       if (item.uids) {
-        const foundIndex = findIndex(mergedArray, function (x) {
+        const foundIndex = ((mergedArray) || []).findIndex(function (x) {
           return x.source === item.source;
         });
         if (foundIndex !== -1) {
@@ -686,7 +685,7 @@ export function addSegmentData(reqBids, data, adUnits, onDone) {
 
   adUnits.forEach(adUnit => {
     return adUnit.bids?.forEach(bid => {
-      const bidderIndex = findIndex(params.bidders, function (i) { return i.bidder === bid.bidder; });
+      const bidderIndex = ((params.bidders) || []).findIndex(function (i) { return i.bidder === bid.bidder; });
       try {
         const aliasActualBidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
         if (aliasActualBidder === 'appnexus') {

--- a/modules/sizeMapping.js
+++ b/modules/sizeMapping.js
@@ -1,6 +1,6 @@
 import {config} from '../src/config.js';
 import {deepAccess, deepClone, deepSetValue, getWindowTop, logInfo, logWarn} from '../src/utils.js';
-import {includes} from '../src/polyfill.js';
+
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {setupAdUnitMediaTypes} from '../src/adapterManager.js';
 
@@ -112,11 +112,11 @@ export function resolveStatus({labels = [], labelAll = false, activeLabels = []}
         labels.length === 0 || (
           (!labelAll && (
             labels.some(label => maps.labels[label]) ||
-            labels.some(label => includes(activeLabels, label))
+            labels.some(label => activeLabels.includes(label))
           )) ||
           (labelAll && (
             labels.reduce((result, label) => !result ? result : (
-              maps.labels[label] || includes(activeLabels, label)
+              maps.labels[label] || activeLabels.includes(label)
             ), true)
           ))
         )

--- a/modules/sizeMappingV2.js
+++ b/modules/sizeMappingV2.js
@@ -14,7 +14,7 @@ import {
   logInfo,
   logWarn
 } from '../src/utils.js';
-import {includes} from '../src/polyfill.js';
+
 import {getHook} from '../src/hook.js';
 import {adUnitSetupChecks} from '../src/prebid.js';
 
@@ -90,7 +90,7 @@ export function checkAdUnitSetupHook(adUnits) {
           Verify that all config objects include 'minViewPort' and 'sizes' property.
           If they do not, return 'false'.
         */
-        if (!(includes(keys, 'minViewPort') && includes(keys, propertyName))) {
+        if (!(keys.includes('minViewPort') && keys.includes(propertyName))) {
           logError(`Ad unit ${adUnitCode}: Missing required property 'minViewPort' or 'sizes' from 'mediaTypes.${mediaType}.sizeConfig[${index}]'. ${conditionalLogMessages[mediaType]}`);
           isValid = false;
           return;
@@ -248,12 +248,12 @@ export function checkBidderSizeConfigFormat(sizeConfig) {
   if (Array.isArray(sizeConfig) && sizeConfig.length > 0) {
     sizeConfig.forEach(config => {
       const keys = Object.keys(config);
-      if ((includes(keys, 'minViewPort') &&
-        includes(keys, 'relevantMediaTypes')) &&
+      if ((keys.includes('minViewPort') &&
+        keys.includes('relevantMediaTypes')) &&
         isArrayOfNums(config.minViewPort, 2) &&
         Array.isArray(config.relevantMediaTypes) &&
         config.relevantMediaTypes.length > 0 &&
-        (config.relevantMediaTypes.length > 1 ? (config.relevantMediaTypes.every(mt => (includes(['banner', 'video', 'native'], mt))))
+        (config.relevantMediaTypes.length > 1 ? (config.relevantMediaTypes.every(mt => (['banner', 'video', 'native'].includes(mt))))
           : (['none', 'banner', 'video', 'native'].indexOf(config.relevantMediaTypes[0]) > -1))) {
         didCheckPass = didCheckPass && true;
       } else {
@@ -304,13 +304,13 @@ export function isLabelActivated(bidOrAdUnit, activeLabels, adUnitCode, adUnitIn
       logWarn(`Size Mapping V2:: Ad Unit: ${bidOrAdUnit.code}(${adUnitInstance}) => Ad unit has declared property 'labelAll' with an empty array.`);
       return true;
     }
-    return bidOrAdUnit.labelAll.every(label => includes(activeLabels, label));
+    return bidOrAdUnit.labelAll.every(label => activeLabels.includes(label));
   } else if (labelOperator === 'labelAny' && Array.isArray(bidOrAdUnit[labelOperator])) {
     if (bidOrAdUnit.labelAny.length === 0) {
       logWarn(`Size Mapping V2:: Ad Unit: ${bidOrAdUnit.code}(${adUnitInstance}) => Ad unit has declared property 'labelAny' with an empty array.`);
       return true;
     }
-    return bidOrAdUnit.labelAny.some(label => includes(activeLabels, label));
+    return bidOrAdUnit.labelAny.some(label => activeLabels.includes(label));
   }
   return true;
 }

--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -1,5 +1,4 @@
 import {deepAccess, deepSetValue, getDNT, isEmpty, isNumber, logError, logInfo} from '../src/utils.js';
-import {find} from '../src/polyfill.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {ADPOD, BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
@@ -93,8 +92,7 @@ export const spec = {
             data: JSON.stringify(data),
             options: {
               withCredentials: true,
-              crossOrigin: true,
-            },
+              crossOrigin: true},
             bidderRequest
           })
         }
@@ -420,7 +418,7 @@ const createNativeAd = (adm) => {
 };
 
 function getNativeMainImageSize(nativeRequest) {
-  const mainImage = find(nativeRequest.assets, asset => asset.hasOwnProperty('img') && asset.img.type === NATIVE_IMAGE_TYPES.MAIN)
+  const mainImage = ((nativeRequest.assets) || []).find(asset => asset.hasOwnProperty('img') && asset.img.type === NATIVE_IMAGE_TYPES.MAIN)
   if (mainImage) {
     if (isNumber(mainImage.img.w) && isNumber(mainImage.img.h)) {
       return [[mainImage.img.w, mainImage.img.h]]

--- a/modules/smarticoBidAdapter.js
+++ b/modules/smarticoBidAdapter.js
@@ -1,6 +1,5 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
-import {find} from '../src/polyfill.js';
 
 const SMARTICO_CONFIG = {
   bidRequestUrl: 'https://trmads.eu/preBidRequest',
@@ -86,7 +85,7 @@ export const spec = {
     ads = serverResponse.body
     for (i = 0; i < ads.length; i++) {
       ad = ads[i]
-      bid = find(bidRequest.bids, bid => bid.bidId === ad.bidId)
+      bid = ((bidRequest.bids) || []).find(bid => bid.bidId === ad.bidId)
       if (bid) {
         token = bid.params.token || ''
 

--- a/modules/sspBCBidAdapter.js
+++ b/modules/sspBCBidAdapter.js
@@ -2,7 +2,7 @@ import { deepAccess, getWinDimensions, getWindowTop, isArray, logInfo, logWarn }
 import { ajax } from '../src/ajax.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
-import { includes as strIncludes } from '../src/polyfill.js';
+
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
 
@@ -713,7 +713,7 @@ const spec = {
             }
           };
 
-          if (bidRequest && site.id && !strIncludes(site.id, 'bidid')) {
+          if (bidRequest && site.id && !site.id.includes('bidid')) {
             // found a matching request; add this bid
             const { adUnitCode } = bidRequest;
 

--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -1,7 +1,6 @@
 import { buildUrl, deepAccess, deepSetValue, generateUUID, getWinDimensions, getWindowSelf, getWindowTop, isEmpty, isStr, logWarn } from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {find} from '../src/polyfill.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 
 const GVL_ID = 136;
@@ -118,8 +117,7 @@ export const spec = {
           meta: {
             advertiserDomains: bidResponse.adomain,
             dsa: bidResponse.dsa,
-            campaignType: bidResponse.campaignType,
-          },
+            campaignType: bidResponse.campaignType},
           mediaType,
         };
 
@@ -265,7 +263,7 @@ const createFloorPriceObject = (mediaType, sizes, bidRequest) => {
     return {...floor, size};
   });
 
-  const floorWithCurrency = find([defaultFloor].concat(sizeFloors), floor => floor.currency);
+  const floorWithCurrency = (([defaultFloor].concat(sizeFloors)) || []).find(floor => floor.currency);
 
   if (!floorWithCurrency) {
     return undefined;

--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -1,7 +1,7 @@
 import {deepAccess, logMessage} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {includes} from '../src/polyfill.js';
+
 import {
   handleSyncUrls,
   isBannerRequest,
@@ -101,7 +101,7 @@ export const spec = {
       if (mediaTypesInfo[VIDEO] !== undefined) {
         let videoParams = deepAccess(bidRequest, 'mediaTypes.video');
         Object.keys(videoParams)
-          .filter(key => includes(Object.keys(VIDEO_ORTB_PARAMS), key) && params[VIDEO_ORTB_PARAMS[key]] === undefined)
+          .filter(key => Object.keys(VIDEO_ORTB_PARAMS).includes(key) && params[VIDEO_ORTB_PARAMS[key]] === undefined)
           .forEach(key => payload.pfilter[VIDEO_ORTB_PARAMS[key]] = videoParams[key]);
       }
       if (Object.keys(payload.pfilter).length == 0) { delete payload.pfilter }

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -4,7 +4,7 @@ import {submodule} from '../src/hook.js';
 import {PbPromise} from '../src/utils/promise.js';
 import {config} from '../src/config.js';
 import {getCoreStorageManager} from '../src/storageManager.js';
-import {includes} from '../src/polyfill.js';
+
 import {isActivityAllowed} from '../src/activities/rules.js';
 import {ACTIVITY_ENRICH_UFPD} from '../src/activities/activities.js';
 import {activityParams} from '../src/activities/activityParams.js';
@@ -158,7 +158,7 @@ export function receiveMessage(evt) {
   if (evt && evt.data) {
     try {
       let data = safeJSONParse(evt.data);
-      if (includes(getLoadedIframeURL(), evt.origin) && data && data.segment && !isEmpty(data.segment.topics)) {
+      if (getLoadedIframeURL().includes(evt.origin) && data && data.segment && !isEmpty(data.segment.topics)) {
         const {domain, topics, bidder} = data.segment;
         const iframeTopicsData = getTopicsData(domain, topics);
         iframeTopicsData && storeInLocalStorage(bidder, iframeTopicsData);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -117,7 +117,6 @@
  * @typedef {{[idKey: string]: () => SubmoduleContainer[]}} SubmodulePriorityMap
  */
 
-import {find} from '../../src/polyfill.js';
 import {config} from '../../src/config.js';
 import * as events from '../../src/events.js';
 import {getGlobal} from '../../src/prebidGlobal.js';
@@ -1139,12 +1138,12 @@ function updateSubmodules() {
   // do this to avoid reprocessing submodules
   // TODO: the logic does not match the comment - addedSubmodules is always a copy of submoduleRegistry
   // (if it did it would not be correct - it's not enough to find new modules, as others may have been removed or changed)
-  const addedSubmodules = submoduleRegistry.filter(i => !find(submodules, j => j.name === i.name));
+  const addedSubmodules = submoduleRegistry.filter(i => !(submodules || []).find(j => j.name === i.name));
 
   submodules.splice(0, submodules.length);
   // find submodule and the matching configuration, if found create and append a SubmoduleContainer
   addedSubmodules.map(i => {
-    const submoduleConfig = find(configs, j => j.name && (j.name.toLowerCase() === i.name.toLowerCase() ||
+    const submoduleConfig = (configs || []).find(j => j.name && (j.name.toLowerCase() === i.name.toLowerCase() ||
       (i.aliasName && j.name.toLowerCase() === i.aliasName.toLowerCase())));
     if (submoduleConfig && i.name !== submoduleConfig.name) submoduleConfig.name = i.name;
     return submoduleConfig ? {
@@ -1210,7 +1209,7 @@ export function requestDataDeletion(next, ...args) {
  */
 export function attachIdSystem(submodule) {
   submodule.findRootDomain = findRootDomain;
-  if (!find(submoduleRegistry, i => i.name === submodule.name)) {
+  if (!(submoduleRegistry || []).find(i => i.name === submodule.name)) {
     submoduleRegistry.push(submodule);
     GDPR_GVLIDS.register(MODULE_TYPE_UID, submodule.name, submodule.gvlid)
     updateSubmodules();

--- a/modules/ventesBidAdapter.js
+++ b/modules/ventesBidAdapter.js
@@ -1,6 +1,5 @@
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {isArray, isNumber, isPlainObject, isStr, replaceAuctionPrice} from '../src/utils.js';
-import {find} from '../src/polyfill.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import {convertCamelToUnderscore} from '../libraries/appnexusUtils/anUtils.js';
@@ -100,13 +99,12 @@ function createServerRequestFromAdUnits(adUnits, bidRequestId, adUnitContext) {
     data: generateBidRequestsFromAdUnits(adUnits, bidRequestId, adUnitContext),
     options: {
       contentType: 'application/json',
-      withCredentials: false,
-    }
+      withCredentials: false}
   }
 }
 
 function generateBidRequestsFromAdUnits(bidRequests, bidRequestId, adUnitContext) {
-  const userObjBid = find(bidRequests, hasUserInfo);
+  const userObjBid = ((bidRequests) || []).find(hasUserInfo);
   let userObj = {};
   if (userObjBid) {
     Object.keys(userObjBid.params.user)
@@ -130,7 +128,7 @@ function generateBidRequestsFromAdUnits(bidRequests, bidRequestId, adUnitContext
       });
   }
 
-  const deviceObjBid = find(bidRequests, hasDeviceInfo);
+  const deviceObjBid = ((bidRequests) || []).find(hasDeviceInfo);
   let deviceObj;
   if (deviceObjBid && deviceObjBid.params && deviceObjBid.params.device) {
     deviceObj = {};
@@ -153,7 +151,7 @@ function generateBidRequestsFromAdUnits(bidRequests, bidRequestId, adUnitContext
   payload.at = 1
   payload.cur = ['USD']
   payload.imp = bidRequests.reduce(generateImpressionsFromAdUnit, [])
-  const appDeviceObjBid = find(bidRequests, hasAppInfo);
+  const appDeviceObjBid = ((bidRequests) || []).find(hasAppInfo);
   if (!appDeviceObjBid) {
     payload.site = generateSiteFromAdUnitContext(bidRequests, adUnitContext)
   } else {

--- a/modules/verizonMediaIdSystem.js
+++ b/modules/verizonMediaIdSystem.js
@@ -8,7 +8,7 @@
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
 import {formatQS, logError} from '../src/utils.js';
-import {includes} from '../src/polyfill.js';
+
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -63,7 +63,7 @@ export const verizonMediaIdSubmodule = {
     }
 
     const data = {
-      '1p': includes([1, '1', true], params['1p']) ? '1' : '0',
+      '1p': [1, '1', true].includes(params['1p']) ? '1' : '0',
       he: params.he,
       gdpr: isEUConsentRequired(consentData) ? '1' : '0',
       gdpr_consent: isEUConsentRequired(consentData) ? consentData.gdpr.consentString : '',

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -1,5 +1,5 @@
 import { config } from '../../src/config.js';
-import { find } from '../../src/polyfill.js';
+import { } from '../../src/polyfill.js';
 import * as events from '../../src/events.js';
 import {mergeDeep, logWarn, logError} from '../../src/utils.js';
 import { getGlobal } from '../../src/prebidGlobal.js';
@@ -271,7 +271,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
     const { adUnitCode, requestId, auctionId } = bidIdentifiers;
     const bidAdId = bidIdentifiers.adId;
     const { bids } = pbGlobal.getBidResponsesForAdUnitCode(adUnitCode);
-    return find(bids, bid => bid.adId === bidAdId && bid.requestId === requestId && bid.auctionId === auctionId);
+    return ((bids) || []).find(bid => bid.adId === bidAdId && bid.requestId === requestId && bid.auctionId === auctionId);
   }
 }
 

--- a/modules/videoModule/videoImpressionVerifier.js
+++ b/modules/videoModule/videoImpressionVerifier.js
@@ -1,4 +1,4 @@
-import { find } from '../../src/polyfill.js';
+import { } from '../../src/polyfill.js';
 import { vastXmlEditorFactory } from '../../libraries/video/shared/vastXmlEditor.js';
 import { generateUUID } from '../../src/utils.js';
 
@@ -86,7 +86,7 @@ export function cachedVideoImpressionVerifier(vastXmlEditor_, bidTracker_) {
   verifier.trackBid = function (bid, globalAdUnits) {
     const adIdOverride = superTrackBid(bid);
     let { vastXml, vastUrl, adId, adUnitCode } = bid;
-    const adUnit = find(globalAdUnits, adUnit => adUnitCode === adUnit.code);
+    const adUnit = ((globalAdUnits) || []).find(adUnit => adUnitCode === adUnit.code);
     const videoConfig = adUnit && adUnit.video;
     const adServerConfig = videoConfig && videoConfig.adServer;
     const trackingConfig = adServerConfig && adServerConfig.tracking;

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -2,7 +2,6 @@ import {deepAccess, flatten, isArray, logError, parseSizesInput} from '../src/ut
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';
-import {findIndex} from '../src/polyfill.js';
 import {
   getUserSyncsFn,
   isBidRequestValid,
@@ -81,7 +80,7 @@ function parseRTBResponse(serverResponse, bidderRequest) {
   }
 
   serverResponse.bids.forEach(serverBid => {
-    const requestId = findIndex(bidderRequest.bids, (bidRequest) => {
+    const requestId = ((bidderRequest.bids) || []).findIndex((bidRequest) => {
       return bidRequest.bidId === serverBid.requestId;
     });
 

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -2,7 +2,7 @@ import {deepAccess, flatten, isArray, logError, parseSizesInput} from '../src/ut
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';
-import {findIndex} from '../src/polyfill.js';
+
 import {
   getUserSyncsFn,
   isBidRequestValid,
@@ -81,7 +81,7 @@ function parseRTBResponse(serverResponse, bidderRequest) {
   }
 
   serverResponse.bids.forEach(serverBid => {
-    const requestId = findIndex(bidderRequest.bids, (bidRequest) => {
+    const requestId = bidderRequest.bids.findIndex((bidRequest) => {
       return bidRequest.bidId === serverBid.requestId;
     });
 

--- a/modules/viouslyBidAdapter.js
+++ b/modules/viouslyBidAdapter.js
@@ -2,7 +2,6 @@ import { deepAccess, logError, parseUrl, parseSizesInput, triggerPixel } from '.
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import {find} from '../src/polyfill.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -186,7 +185,7 @@ export const spec = {
     if (responseBody.ads && responseBody.ads.length > 0) {
       responseBody.ads.forEach(function(bidResponse) {
         if (bidResponse.bid) {
-          let bidRequest = find(requests.data.placements, bid => bid.bid_id === bidResponse.bid_id);
+          let bidRequest = ((requests.data.placements) || []).find(bid => bid.bid_id === bidResponse.bid_id);
 
           if (bidRequest) {
             let sizes = bidResponse.size.split('x');

--- a/modules/voxBidAdapter.js
+++ b/modules/voxBidAdapter.js
@@ -1,7 +1,6 @@
 import {_map, deepAccess, isArray, logWarn} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {find} from '../src/polyfill.js';
 import {Renderer} from '../src/Renderer.js';
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
 
@@ -89,8 +88,7 @@ function buildBid(bidData) {
     ttl: TTL,
     content: bidData.content,
     meta: {
-      advertiserDomains: bidData.advertiserDomains || [],
-    }
+      advertiserDomains: bidData.advertiserDomains || []}
   };
 
   if (bidData.placement === 'video') {
@@ -250,7 +248,7 @@ export const spec = {
 
     if (serverBody && serverBody.bids && isArray(serverBody.bids)) {
       return _map(serverBody.bids, function(bid) {
-        let rawBid = find(bidRequests, function (item) {
+        let rawBid = ((bidRequests) || []).find(function (item) {
           return item.bidId === bid.bidId;
         });
         bid.placement = rawBid.placement;

--- a/modules/voxBidAdapter.md
+++ b/modules/voxBidAdapter.md
@@ -153,7 +153,7 @@ var adUnits = [{
 	<meta charset="UTF-8">
 	<title>Prebid.js Banner Example</title>
 	<script async src="prebid.js"></script>
-	<script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+   <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
 	<style>
 		.banner-block {
 			position: absolute;

--- a/modules/waardexBidAdapter.js
+++ b/modules/waardexBidAdapter.js
@@ -2,7 +2,6 @@ import {deepAccess, getBidIdParameter, isArray, logError} from '../src/utils.js'
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
-import {find} from '../src/polyfill.js';
 
 const ENDPOINT = `https://hb.justbidit.xyz:8843/prebid`;
 const BIDDER_CODE = 'waardex';
@@ -65,8 +64,7 @@ const buildRequests = (validBidRequests, bidderRequest) => {
 const getCommonBidsData = bidderRequest => {
   const payload = {
     ua: navigator.userAgent || '',
-    language: navigator.language && navigator.language.indexOf('-') !== -1 ? navigator.language.split('-')[0] : '',
-  };
+    language: navigator.language && navigator.language.indexOf('-') !== -1 ? navigator.language.split('-')[0] : ''};
 
   if (bidderRequest && bidderRequest.refererInfo) {
     // TODO: is 'page' the right value here?
@@ -183,7 +181,7 @@ const interpretResponse = (serverResponse, bidRequest) => {
 };
 
 const getHbRequestBid = (openRtbBid, bidRequest) => {
-  return find(bidRequest.bidRequests, x => x.bidId === openRtbBid.impid);
+  return ((bidRequest.bidRequests) || []).find(x => x.bidId === openRtbBid.impid);
 };
 
 const getHbRequestMediaType = hbRequestBid => {

--- a/modules/weboramaRtdProvider.md
+++ b/modules/weboramaRtdProvider.md
@@ -136,12 +136,8 @@ On this section we will explain the `params.weboUserDataConf` subconfiguration:
 
 ##### User Consent
 
-The WAM User-Centric configuration will check for user consent if gdpr applies. It will check for consent:
-
-* Vendor ID 284 (Weborama)
-* Purpose IDs: 1, 3, 4, 5 and 6
-
-If the user consent does not match such conditions, this module will not load, means we will not check for any data in local storage and the default profile will be ignored.
+In a user-centric configuration, the WAM module will verify user consent when GDPR is applicable. It specifically checks for consent related to the purposes declared by Weborama in the Global Vendor List (Vendor ID 284). 
+If the required consent is not provided, the module will not activate, and it will neither access local storage nor apply any default user profile.
 
 #### Sfbx LiTE Site-Centric Configuration
 

--- a/modules/widespaceBidAdapter.js
+++ b/modules/widespaceBidAdapter.js
@@ -1,7 +1,7 @@
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {deepClone, parseQueryStringParameters, parseSizesInput} from '../src/utils.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {getStorageManager} from '../src/storageManager.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 
@@ -92,7 +92,7 @@ export const spec = {
       // Include debug data when available
       if (!isInHostileIframe) {
         data.forceAdId = (find(window.top.location.hash.split('&'),
-          val => includes(val, 'WS_DEBUG_FORCEADID')
+          val => val.includes('WS_DEBUG_FORCEADID')
         ) || '').split('=')[1];
       }
 

--- a/modules/widespaceBidAdapter.js
+++ b/modules/widespaceBidAdapter.js
@@ -1,7 +1,7 @@
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {deepClone, parseQueryStringParameters, parseSizesInput} from '../src/utils.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {getStorageManager} from '../src/storageManager.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 
@@ -91,7 +91,7 @@ export const spec = {
 
       // Include debug data when available
       if (!isInHostileIframe) {
-        data.forceAdId = (find(window.top.location.hash.split('&'),
+        data.forceAdId = (((window.top.location.hash.split('&')) || []).find(
           val => includes(val, 'WS_DEBUG_FORCEADID')
         ) || '').split('=')[1];
       }

--- a/modules/winrBidAdapter.js
+++ b/modules/winrBidAdapter.js
@@ -11,7 +11,7 @@ import {
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
@@ -74,8 +74,7 @@ function wrapAd(bid, position) {
               inR: {
                 tg: ${position.domParent},
                 rf: ${position.child}
-              },
-            };
+              }};
           \`;
           var s = parent.document.head.getElementsByTagName("script")[0];
           s.parentNode.insertBefore(w, s);
@@ -146,7 +145,7 @@ export const spec = {
    */
   buildRequests: function (bidRequests, bidderRequest) {
     const tags = bidRequests.map(bidToTag);
-    const userObjBid = find(bidRequests, hasUserInfo);
+    const userObjBid = ((bidRequests) || []).find(hasUserInfo);
     let userObj = {};
     if (config.getConfig('coppa') === true) {
       userObj = { 'coppa': true };
@@ -176,7 +175,7 @@ export const spec = {
         });
     }
 
-    const appDeviceObjBid = find(bidRequests, hasAppDeviceInfo);
+    const appDeviceObjBid = ((bidRequests) || []).find(hasAppDeviceInfo);
     let appDeviceObj;
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
@@ -185,7 +184,7 @@ export const spec = {
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
-    const appIdObjBid = find(bidRequests, hasAppId);
+    const appIdObjBid = ((bidRequests) || []).find(hasAppId);
     let appIdObj;
     if (appIdObjBid && appIdObjBid.params && appDeviceObjBid.params.app && appDeviceObjBid.params.app.id) {
       appIdObj = {
@@ -193,7 +192,7 @@ export const spec = {
       };
     }
 
-    const memberIdBid = find(bidRequests, hasMemberId);
+    const memberIdBid = ((bidRequests) || []).find(hasMemberId);
     const member = memberIdBid ? parseInt(memberIdBid.params.member, 10) : 0;
     const schain = bidRequests[0].schain;
 
@@ -493,7 +492,7 @@ function hasAppId(bid) {
 }
 
 function getRtbBid(tag) {
-  return tag && tag.ads && tag.ads.length && find(tag.ads, (ad) => ad.rtb);
+  return tag && tag.ads && tag.ads.length && ((tag.ads) || []).find((ad) => ad.rtb);
 }
 
 function parseMediaType(rtbBid) {

--- a/modules/winrBidAdapter.js
+++ b/modules/winrBidAdapter.js
@@ -11,7 +11,7 @@ import {
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
@@ -154,7 +154,7 @@ export const spec = {
 
     if (userObjBid) {
       Object.keys(userObjBid.params.user)
-        .filter((param) => includes(USER_PARAMS, param))
+        .filter((param) => USER_PARAMS.includes(param))
         .forEach((param) => {
           let uparam = convertCamelToUnderscore(param);
           if (
@@ -181,7 +181,7 @@ export const spec = {
     if (appDeviceObjBid && appDeviceObjBid.params && appDeviceObjBid.params.app) {
       appDeviceObj = {};
       Object.keys(appDeviceObjBid.params.app)
-        .filter(param => includes(APP_DEVICE_PARAMS, param))
+        .filter(param => APP_DEVICE_PARAMS.includes(param))
         .forEach(param => appDeviceObj[param] = appDeviceObjBid.params.app[param]);
     }
 
@@ -289,7 +289,7 @@ export const spec = {
         if (rtbBid) {
           if (
             rtbBid.cpm !== 0 &&
-            includes(this.supportedMediaTypes, rtbBid.ad_type)
+            this.supportedMediaTypes.includes(rtbBid.ad_type)
           ) {
             const bid = newBid(serverBid, rtbBid, bidderRequest);
             bid.mediaType = parseMediaType(rtbBid);

--- a/modules/winrBidAdapter.md
+++ b/modules/winrBidAdapter.md
@@ -288,7 +288,7 @@ var adUnits = [
     <script async src="prebid.js"></script>
     <script
       async
-      src="https://www.googletagservices.com/tag/js/gpt.js"
+      src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
     ></script>
 
     <script>

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -1,6 +1,6 @@
 import { _each, deepAccess, isArray, isEmptyStr, isFn, isPlainObject, timestamp } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { find } from '../src/polyfill.js';
+import { } from '../src/polyfill.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
@@ -53,8 +53,7 @@ export const spec = {
     const timestamp = Date.now();
     const query = {
       ts: timestamp,
-      json: true,
-    };
+      json: true};
 
     _each(validBidRequests, function (bid) {
       adslotIds.push(bid.params.adslotId);
@@ -174,7 +173,7 @@ export const spec = {
         return;
       }
 
-      const matchedBid = find(serverResponse.body, function (bidResponse) {
+      const matchedBid = ((serverResponse.body) || []).find(function (bidResponse) {
         return bidRequest.params.adslotId == bidResponse.id;
       });
 
@@ -234,11 +233,11 @@ export const spec = {
           const { assets } = native;
           bidResponse.adUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}`;
           bidResponse.mediaType = NATIVE;
-          const nativeIconAssetObj = find(assets, isImageAssetOfType(IMG_TYPE_ICON));
-          const nativeImageAssetObj = find(assets, isImageAssetOfType(IMG_TYPE_MAIN));
+          const nativeIconAssetObj = ((assets) || []).find(isImageAssetOfType(IMG_TYPE_ICON));
+          const nativeImageAssetObj = ((assets) || []).find(isImageAssetOfType(IMG_TYPE_MAIN));
           const nativeImageAsset = nativeImageAssetObj ? nativeImageAssetObj.img : { url: '', w: 0, h: 0 };
-          const nativeTitleAsset = find(assets, asset => hasValidProperty(asset, 'title'));
-          const nativeBodyAsset = find(assets, asset => hasValidProperty(asset, 'data'));
+          const nativeTitleAsset = ((assets) || []).find(asset => hasValidProperty(asset, 'title'));
+          const nativeBodyAsset = ((assets) || []).find(asset => hasValidProperty(asset, 'data'));
           bidResponse.native = {
             title: nativeTitleAsset ? nativeTitleAsset.title.text : '',
             body: nativeBodyAsset ? nativeBodyAsset.data.value : '',

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -17,7 +17,7 @@ import {
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
-import {includes} from '../src/polyfill.js';
+import {find, includes} from '../src/polyfill.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -326,7 +326,7 @@ function createNewBannerBid(response) {
  * @param bidRequest server request
  */
 function createNewVideoBid(response, bidRequest) {
-  const imp = (((deepAccess(bidRequest) || []).find('data.imp') || []), imp => imp.id === response.impid);
+  const imp = find((deepAccess(bidRequest, 'data.imp') || []), imp => imp.id === response.impid);
 
   let result = {
     dealId: response.dealid,

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -17,7 +17,7 @@ import {
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -500,12 +500,12 @@ function openRtbImpression(bidRequest) {
 
   const mediaTypesParams = deepAccess(bidRequest, 'mediaTypes.video', {});
   Object.keys(mediaTypesParams)
-    .filter(param => includes(OPENRTB_VIDEO_BIDPARAMS, param))
+    .filter(param => OPENRTB_VIDEO_BIDPARAMS.includes(param))
     .forEach(param => imp.video[param] = mediaTypesParams[param]);
 
   const videoParams = deepAccess(bidRequest, 'params.video', {});
   Object.keys(videoParams)
-    .filter(param => includes(OPENRTB_VIDEO_BIDPARAMS, param))
+    .filter(param => OPENRTB_VIDEO_BIDPARAMS.includes(param))
     .forEach(param => imp.video[param] = videoParams[param]);
 
   if (imp.video.skippable) {
@@ -577,7 +577,7 @@ function openRtbSite(bidRequest, bidderRequest) {
   const siteParams = deepAccess(bidRequest, 'params.site');
   if (siteParams) {
     Object.keys(siteParams)
-      .filter(param => includes(OPENRTB_VIDEO_SITEPARAMS, param))
+      .filter(param => OPENRTB_VIDEO_SITEPARAMS.includes(param))
       .forEach(param => result[param] = siteParams[param]);
   }
   return result;

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -17,7 +17,7 @@ import {
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
-import {find, includes} from '../src/polyfill.js';
+import {includes} from '../src/polyfill.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -96,8 +96,7 @@ export const spec = {
           cmp: deepAccess(bidderRequest, 'gdprConsent.consentString') || '',
           gpp: deepAccess(bidderRequest, 'gppConsent.gppString') || '',
           gpp_sid:
-            deepAccess(bidderRequest, 'gppConsent.applicableSections') || [],
-        }),
+            deepAccess(bidderRequest, 'gppConsent.applicableSections') || []}),
         us_privacy: deepAccess(bidderRequest, 'uspConsent') || '',
       };
       if (topicsData) {
@@ -327,7 +326,7 @@ function createNewBannerBid(response) {
  * @param bidRequest server request
  */
 function createNewVideoBid(response, bidRequest) {
-  const imp = find((deepAccess(bidRequest, 'data.imp') || []), imp => imp.id === response.impid);
+  const imp = (((deepAccess(bidRequest) || []).find('data.imp') || []), imp => imp.id === response.impid);
 
   let result = {
     dealId: response.dealid,

--- a/modules/yuktamediaAnalyticsAdapter.js
+++ b/modules/yuktamediaAnalyticsAdapter.js
@@ -5,7 +5,7 @@ import adapterManager from '../src/adapterManager.js';
 import { EVENTS, STATUS } from '../src/constants.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {getRefererInfo} from '../src/refererDetection.js';
-import {includes as strIncludes} from '../src/polyfill.js';
+
 import {MODULE_TYPE_ANALYTICS} from '../src/activities/modules.js';
 
 const MODULE_CODE = 'yuktamedia';
@@ -155,7 +155,7 @@ var yuktamediaAnalyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoin
               bidResponse.responseTimestamp = args.responseTimestamp;
               bidResponse.bidForSize = args.size;
               for (const [adserverTargetingKey, adserverTargetingValue] of Object.entries(args.adserverTargeting)) {
-                if (['body', 'icon', 'image', 'linkurl', 'host', 'path'].every((ele) => !strIncludes(adserverTargetingKey, ele))) {
+                if (['body', 'icon', 'image', 'linkurl', 'host', 'path'].every((ele) => !adserverTargetingKey.includes(ele))) {
                   bidResponse['adserverTargeting-' + adserverTargetingKey] = adserverTargetingValue;
                 }
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8022,9 +8022,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001633",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001633.tgz",
-      "integrity": "sha512-6sT0yf/z5jqf8tISAgpJDrmwOpLsrpnyCdD/lOZKvKkkJK4Dn0X5i7KF7THEZhOq+30bmhwBlNEaqPUiHiKtZg==",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8038,7 +8038,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -34114,9 +34115,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001633",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001633.tgz",
-      "integrity": "sha512-6sT0yf/z5jqf8tISAgpJDrmwOpLsrpnyCdD/lOZKvKkkJK4Dn0X5i7KF7THEZhOq+30bmhwBlNEaqPUiHiKtZg=="
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw=="
     },
     "caseless": {
       "version": "0.12.0",

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -27,7 +27,7 @@ import {newBidder} from './adapters/bidderFactory.js';
 import {ajaxBuilder} from './ajax.js';
 import {config, RANDOM} from './config.js';
 import {hook} from './hook.js';
-import {find, includes} from './polyfill.js';
+import {find} from './polyfill.js';
 import {
   getAuctionsCounter,
   getBidderRequestsCounter,
@@ -523,8 +523,8 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
 
 function getSupportedMediaTypes(bidderCode) {
   let supportedMediaTypes = [];
-  if (FEATURES.VIDEO && includes(adapterManager.videoAdapters, bidderCode)) supportedMediaTypes.push('video');
-  if (FEATURES.NATIVE && includes(nativeAdapters, bidderCode)) supportedMediaTypes.push('native');
+  if (FEATURES.VIDEO && adapterManager.videoAdapters.includes(bidderCode)) supportedMediaTypes.push('video');
+  if (FEATURES.NATIVE && nativeAdapters.includes(bidderCode)) supportedMediaTypes.push('native');
   return supportedMediaTypes;
 }
 
@@ -536,10 +536,10 @@ adapterManager.registerBidAdapter = function (bidAdapter, bidderCode, {supported
       _bidderRegistry[bidderCode] = bidAdapter;
       GDPR_GVLIDS.register(MODULE_TYPE_BIDDER, bidderCode, bidAdapter.getSpec?.().gvlid);
 
-      if (FEATURES.VIDEO && includes(supportedMediaTypes, 'video')) {
+      if (FEATURES.VIDEO && supportedMediaTypes.includes('video')) {
         adapterManager.videoAdapters.push(bidderCode);
       }
-      if (FEATURES.NATIVE && includes(supportedMediaTypes, 'native')) {
+      if (FEATURES.NATIVE && supportedMediaTypes.includes('native')) {
         nativeAdapters.push(bidderCode);
       }
     } else {
@@ -561,7 +561,7 @@ adapterManager.aliasBidAdapter = function (bidderCode, alias, options) {
       _s2sConfigs.forEach(s2sConfig => {
         if (s2sConfig.bidders && s2sConfig.bidders.length) {
           const s2sBidders = s2sConfig && s2sConfig.bidders;
-          if (!(s2sConfig && includes(s2sBidders, alias))) {
+          if (!(s2sConfig && s2sBidders.includes(alias))) {
             nonS2SAlias.push(bidderCode);
           } else {
             _aliasRegistry[alias] = bidderCode;

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -7,7 +7,7 @@ import {nativeBidIsValid} from '../native.js';
 import {isValidVideoBid} from '../video.js';
 import {EVENTS, REJECTION_REASON, STATUS, DEBUG_MODE} from '../constants.js';
 import * as events from '../events.js';
-import {includes} from '../polyfill.js';
+
 import {
   delayExecution,
   isArray,
@@ -605,7 +605,7 @@ function validBidSize(adUnitCode, bid, {index = auctionManager.index} = {}) {
 export function isValid(adUnitCode, bid, {index = auctionManager.index} = {}) {
   function hasValidKeys() {
     let bidKeys = Object.keys(bid);
-    return COMMON_BID_RESPONSE_KEYS.every(key => includes(bidKeys, key) && !includes([undefined, null], bid[key]));
+    return COMMON_BID_RESPONSE_KEYS.every(key => bidKeys.includes(key) && ![undefined, null].includes(bid[key]));
   }
 
   function errorMessage(msg) {

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -1,7 +1,7 @@
 import { LOAD_EXTERNAL_SCRIPT } from './activities/activities.js';
 import { activityParams } from './activities/activityParams.js';
 import { isActivityAllowed } from './activities/rules.js';
-import { includes } from './polyfill.js';
+
 import { insertElement, logError, logWarn, setScriptAttributes } from './utils.js';
 
 const _requestCache = new WeakMap();
@@ -63,7 +63,7 @@ export function loadExternalScript(url, moduleType, moduleCode, callback, doc, a
     logError('cannot load external script without url and moduleCode');
     return;
   }
-  if (!includes(_approvedLoadExternalJSList, moduleCode)) {
+  if (!_approvedLoadExternalJSList.includes(moduleCode)) {
     logError(`${moduleCode} not whitelisted for loading external JavaScript`);
     return;
   }

--- a/src/auction.js
+++ b/src/auction.js
@@ -84,7 +84,7 @@ import {Renderer} from './Renderer.js';
 import {config} from './config.js';
 import {userSync} from './userSync.js';
 import {hook, ignoreCallbackArg} from './hook.js';
-import {find, includes} from './polyfill.js';
+import {find} from './polyfill.js';
 import {OUTSTREAM} from './video.js';
 import {VIDEO} from './mediaTypes.js';
 import {auctionManager} from './auctionManager.js';
@@ -509,8 +509,8 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
 
     if (auctionOptionsConfig && !isEmpty(auctionOptionsConfig)) {
       const secondaryBidders = auctionOptionsConfig.secondaryBidders;
-      if (secondaryBidders && !bidderRequests.every(bidder => includes(secondaryBidders, bidder.bidderCode))) {
-        bidderRequests = bidderRequests.filter(request => !includes(secondaryBidders, request.bidderCode));
+      if (secondaryBidders && !bidderRequests.every(bidder => secondaryBidders.includes(bidder.bidderCode))) {
+        bidderRequests = bidderRequests.filter(request => !secondaryBidders.includes(request.bidderCode));
       }
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@
  */
 
 import {isValidPriceConfig} from './cpmBucketManager.js';
-import {find, includes} from './polyfill.js';
+import {find} from './polyfill.js';
 import {
   deepAccess,
   deepClone,
@@ -439,7 +439,7 @@ export function newConfig() {
 
     // call subscribers of a specific topic, passing only that configuration
     listeners
-      .filter(listener => includes(TOPICS, listener.topic))
+      .filter(listener => TOPICS.includes(listener.topic))
       .forEach(listener => {
         listener.callback({ [listener.topic]: options[listener.topic] });
       });

--- a/src/native.js
+++ b/src/native.js
@@ -10,7 +10,7 @@ import {
   pick,
   triggerPixel
 } from './utils.js';
-import {includes} from './polyfill.js';
+
 import {auctionManager} from './auctionManager.js';
 import {NATIVE_ASSET_TYPES, NATIVE_IMAGE_TYPES, PREBID_NATIVE_DATA_KEYS_TO_ORTB, NATIVE_KEYS_THAT_ARE_NOT_ASSETS, NATIVE_KEYS} from './constants.js';
 import {NATIVE} from './mediaTypes.js';
@@ -184,7 +184,7 @@ function isOpenRTBAssetValid(asset) {
  * Check if the native type specified in the adUnit is supported by Prebid.
  */
 function typeIsSupported(type) {
-  if (!(type && includes(Object.keys(SUPPORTED_TYPES), type))) {
+  if (!(type && Object.keys(SUPPORTED_TYPES).includes(type))) {
     logError(`${type} nativeParam is not supported`);
     return false;
   }
@@ -202,7 +202,7 @@ export const nativeAdUnit = adUnit => {
   const mediaTypes = adUnit?.mediaTypes?.native;
   return mediaType || mediaTypes;
 }
-export const nativeBidder = bid => includes(nativeAdapters, bid.bidder);
+export const nativeBidder = bid => nativeAdapters.includes(bid.bidder);
 export const hasNonNativeBidder = adUnit =>
   adUnit.bids.filter(bid => !nativeBidder(bid)).length;
 
@@ -230,7 +230,7 @@ export function isNativeOpenRTBBidValid(bidORTB, bidRequestORTB) {
   let requiredAssetIds = bidRequestORTB.assets.filter(asset => asset.required === 1).map(a => a.id);
   let returnedAssetIds = bidORTB.assets.map(asset => asset.id);
 
-  const match = requiredAssetIds.every(assetId => includes(returnedAssetIds, assetId));
+  const match = requiredAssetIds.every(assetId => returnedAssetIds.includes(assetId));
   if (!match) {
     logError(`didn't receive a bid with all required assets. Required ids: ${requiredAssetIds}, but received ids in response: ${returnedAssetIds}`);
   }

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -5,3 +5,6 @@ export function includes(target, elem, start) {
   return (target && target.includes(elem, start)) || false;
 }
 
+export function find(arr, pred, thisArg) {
+  return arr && arr.find(pred, thisArg);
+}

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -5,10 +5,3 @@ export function includes(target, elem, start) {
   return (target && target.includes(elem, start)) || false;
 }
 
-export function find(arr, pred, thisArg) {
-  return arr && arr.find(pred, thisArg);
-}
-
-export function findIndex(arr, pred, thisArg) {
-  return arr && arr.findIndex(pred, thisArg);
-}

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -8,3 +8,7 @@ export function includes(target, elem, start) {
 export function find(arr, pred, thisArg) {
   return arr && arr.find(pred, thisArg);
 }
+
+export function findIndex(arr, pred, thisArg) {
+  return arr && arr.findIndex(pred, thisArg);
+}

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -30,7 +30,7 @@ import {auctionManager} from './auctionManager.js';
 import {isBidUsable, targeting} from './targeting.js';
 import {hook, wrapHook} from './hook.js';
 import {loadSession} from './debugging.js';
-import {includes} from './polyfill.js';
+
 import {createBid} from './bidfactory.js';
 import {storageCallbacks} from './storageManager.js';
 import {default as adapterManager, getS2SBidderSet} from './adapterManager.js';
@@ -584,7 +584,7 @@ pbjsInstance.requestBids = (function() {
     }
     if (adUnitCodes && adUnitCodes.length) {
       // if specific adUnitCodes supplied filter adUnits for those codes
-      adUnits = adUnits.filter(unit => includes(adUnitCodes, unit.code));
+      adUnits = adUnits.filter(unit => adUnitCodes.includes(unit.code));
     } else {
       // otherwise derive adUnitCodes from adUnits
       adUnitCodes = adUnits && adUnits.map(unit => unit.code);
@@ -671,7 +671,7 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
       const bidderMediaTypes = (spec && spec.supportedMediaTypes) || ['banner'];
 
       // check if the bidder's mediaTypes are not in the adUnit's mediaTypes
-      const bidderEligible = adUnitMediaTypes.some(type => includes(bidderMediaTypes, type));
+      const bidderEligible = adUnitMediaTypes.some(type => bidderMediaTypes.includes(type));
       if (!bidderEligible) {
         // drop the bidder from the ad unit if it's not compatible
         logWarn(unsupportedBidderMessage(adUnit, bidder));

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -6,7 +6,7 @@
 import {getAllAssetsMessage, getAssetMessage} from './native.js';
 import {BID_STATUS, MESSAGES} from './constants.js';
 import {isApnGetTagDefined, isGptPubadsDefined, logError, logWarn} from './utils.js';
-import {find, includes} from './polyfill.js';
+import {find} from './polyfill.js';
 import {
   deferRendering,
   getBidToRender,
@@ -174,7 +174,7 @@ export function resizeRemoteCreative({instl, adId, adUnitCode, width, height}) {
   function getDfpElementId(adId) {
     const slot = find(window.googletag.pubads().getSlots(), slot => {
       return find(slot.getTargetingKeys(), key => {
-        return includes(slot.getTargeting(key), adId);
+        return slot.getTargeting(key).includes(adId);
       });
     });
     return slot ? slot.getSlotElementId() : null;

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -15,7 +15,7 @@ import * as events from './events.js';
 import { hook } from './hook.js';
 import { ADPOD } from './mediaTypes.js';
 import { NATIVE_TARGETING_KEYS } from './native.js';
-import { find, includes } from './polyfill.js';
+import {find} from './polyfill.js';
 import {
   deepAccess,
   deepClone,
@@ -51,7 +51,7 @@ export const TARGETING_KEYS_ARR = Object.keys(TARGETING_KEYS).map(
 const isBidNotExpired = (bid) => (bid.responseTimestamp + getBufferedTTL(bid) * 1000) > timestamp();
 
 // return bids whose status is not set. Winning bids can only have a status of `rendered`.
-const isUnusedBid = (bid) => bid && ((bid.status && !includes([BID_STATUS.RENDERED], bid.status)) || !bid.status);
+const isUnusedBid = (bid) => bid && ((bid.status && ![BID_STATUS.RENDERED].includes(bid.status)) || !bid.status);
 
 export let filters = {
   isActualBid(bid) {
@@ -198,7 +198,7 @@ export function newTargeting(auctionManager) {
         const currentKeywords = Object.keys(astTag.keywords);
         const newKeywords = {};
         currentKeywords.forEach((key) => {
-          if (!includes(pbTargetingKeys, key.toLowerCase())) {
+          if (!pbTargetingKeys.includes(key.toLowerCase())) {
             newKeywords[key] = astTag.keywords[key];
           }
         })
@@ -361,7 +361,7 @@ export function newTargeting(auctionManager) {
     const alwaysIncludeDeals = config.getConfig('targetingControls.alwaysIncludeDeals');
 
     bidsReceived.forEach(bid => {
-      const adUnitIsEligible = includes(adUnitCodes, bid.adUnitCode);
+      const adUnitIsEligible = adUnitCodes.includes(bid.adUnitCode);
       const cpmAllowed = bidderSettings.get(bid.bidderCode, 'allowZeroCpmBids') === true ? bid.cpm >= 0 : bid.cpm > 0;
       const isPreferredDeal = alwaysIncludeDeals && bid.dealId;
 
@@ -581,7 +581,7 @@ export function newTargeting(auctionManager) {
     const adUnitCodes = getAdUnitCodes(adUnitCode);
 
     return bidsReceived
-      .filter(bid => includes(adUnitCodes, bid.adUnitCode))
+      .filter(bid => adUnitCodes.includes(bid.adUnitCode))
       .filter(bid => (bidderSettings.get(bid.bidderCode, 'allowZeroCpmBids') === true) ? bid.cpm >= 0 : bid.cpm > 0)
       .map(bid => bid.adUnitCode)
       .filter(uniques)

--- a/src/userSync.js
+++ b/src/userSync.js
@@ -3,7 +3,7 @@ import {
   logWarn, isStr, isSafariBrowser
 } from './utils.js';
 import { config } from './config.js';
-import {includes} from './polyfill.js';
+
 import { getCoreStorageManager } from './storageManager.js';
 import {isActivityAllowed, registerActivityControl} from './activities/rules.js';
 import {ACTIVITY_SYNC_USER} from './activities/activities.js';
@@ -257,8 +257,8 @@ export function newUserSync(deps) {
 
       // return true if the bidder is either: not part of the include (ie outside the whitelist) or part of the exclude (ie inside the blacklist)
       const checkForFiltering = {
-        'include': (bidders, bidder) => !includes(bidders, bidder),
-        'exclude': (bidders, bidder) => includes(bidders, bidder)
+        'include': (bidders, bidder) => !bidders.includes(bidder),
+        'exclude': (bidders, bidder) => bidders.includes(bidder)
       }
       return checkForFiltering[filterType](biddersToFilter, bidder);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import {config} from './config.js';
 import {klona} from 'klona/json';
-import {includes} from './polyfill.js';
+
 import {EVENTS} from './constants.js';
 import {PbPromise} from './utils/promise.js';
 import {getGlobal} from './prebidGlobal.js';
@@ -875,12 +875,12 @@ export function isValidMediaTypes(mediaTypes) {
 
   const types = Object.keys(mediaTypes);
 
-  if (!types.every(type => includes(SUPPORTED_MEDIA_TYPES, type))) {
+  if (!types.every(type => SUPPORTED_MEDIA_TYPES.includes(type))) {
     return false;
   }
 
   if (FEATURES.VIDEO && mediaTypes.video && mediaTypes.video.context) {
-    return includes(SUPPORTED_STREAM_TYPES, mediaTypes.video.context);
+    return SUPPORTED_STREAM_TYPES.includes(mediaTypes.video.context);
   }
 
   return true;

--- a/test/spec/e2e/longform/basic_w_bidderSettings.spec.js
+++ b/test/spec/e2e/longform/basic_w_bidderSettings.spec.js
@@ -1,4 +1,3 @@
-import {includes} from 'src/polyfill.js';
 const expect = require('chai').expect;
 const { host, protocol, waitForElement } = require('../../../helpers/testing-utils');
 
@@ -35,9 +34,9 @@ describe('longform ads not using requireExactDuration field', function() {
       let cpm = listOfCpms[i].getText();
       let cat = listOfCats[i].getText();
       let dura = listOfDuras[i].getText();
-      expect(includes(validCpms, cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
-      expect(includes(validCats, cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
-      expect(includes(validDurations, dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
+      expect(validCpms.includes(cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
+      expect(validCats.includes(cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
+      expect(validDurations.includes(dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
     }
   });
 

--- a/test/spec/e2e/longform/basic_w_custom_adserver_translation.spec.js
+++ b/test/spec/e2e/longform/basic_w_custom_adserver_translation.spec.js
@@ -1,4 +1,3 @@
-import {includes} from 'src/polyfill.js';
 const expect = require('chai').expect;
 const { host, protocol, waitForElement } = require('../../../helpers/testing-utils');
 
@@ -35,9 +34,9 @@ describe('longform ads using custom adserver translation file', function() {
       let cpm = listOfCpms[i].getText();
       let cat = listOfCats[i].getText();
       let dura = listOfDuras[i].getText();
-      expect(includes(validCpms, cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
-      expect(includes(validCats, cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
-      expect(includes(validDurations, dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
+      expect(validCpms.includes(cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
+      expect(validCats.includes(cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
+      expect(validDurations.includes(dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
     }
   });
 

--- a/test/spec/e2e/longform/basic_w_priceGran.spec.js
+++ b/test/spec/e2e/longform/basic_w_priceGran.spec.js
@@ -1,4 +1,3 @@
-import {includes} from 'src/polyfill.js';
 const expect = require('chai').expect;
 const { host, protocol, waitForElement } = require('../../../helpers/testing-utils');
 
@@ -35,9 +34,9 @@ describe('longform ads not using requireExactDuration field', function() {
       let cpm = listOfCpms[i].getText();
       let cat = listOfCats[i].getText();
       let dura = listOfDuras[i].getText();
-      expect(includes(validCpms, cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
-      expect(includes(validCats, cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
-      expect(includes(validDurations, dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
+      expect(validCpms.includes(cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
+      expect(validCats.includes(cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
+      expect(validDurations.includes(dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
     }
   });
 

--- a/test/spec/e2e/longform/basic_w_requireExactDuration.spec.js
+++ b/test/spec/e2e/longform/basic_w_requireExactDuration.spec.js
@@ -1,4 +1,3 @@
-import {includes} from 'src/polyfill.js';
 const expect = require('chai').expect;
 const { host, protocol, waitForElement } = require('../../../helpers/testing-utils');
 
@@ -35,9 +34,9 @@ describe('longform ads using requireExactDuration field', function() {
       let cpm = listOfCpms[i].getText();
       let cat = listOfCats[i].getText();
       let dura = listOfDuras[i].getText();
-      expect(includes(validCpms, cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
-      expect(includes(validCats, cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
-      expect(includes(validDurations, dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
+      expect(validCpms.includes(cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
+      expect(validCats.includes(cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
+      expect(validDurations.includes(dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
     }
   });
 

--- a/test/spec/e2e/longform/basic_wo_brandCategoryExclusion.spec.js
+++ b/test/spec/e2e/longform/basic_wo_brandCategoryExclusion.spec.js
@@ -1,4 +1,3 @@
-import {includes} from 'src/polyfill.js';
 const expect = require('chai').expect;
 const { host, protocol, waitForElement } = require('../../../helpers/testing-utils');
 
@@ -31,8 +30,8 @@ describe('longform ads without using brandCategoryExclusion', function() {
     for (let i = 0; i < listOfCpms.length; i++) {
       let cpm = listOfCpms[i].getText();
       let dura = listOfDuras[i].getText();
-      expect(includes(validCpms, cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
-      expect(includes(validDurations, dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
+      expect(validCpms.includes(cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
+      expect(validDurations.includes(dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
     }
   });
 

--- a/test/spec/e2e/longform/basic_wo_requireExactDuration.spec.js
+++ b/test/spec/e2e/longform/basic_wo_requireExactDuration.spec.js
@@ -1,4 +1,3 @@
-import {includes} from 'src/polyfill.js';
 const expect = require('chai').expect;
 const { host, protocol, waitForElement } = require('../../../helpers/testing-utils');
 
@@ -35,9 +34,9 @@ describe('longform ads not using requireExactDuration field', function() {
       let cpm = listOfCpms[i].getText();
       let cat = listOfCats[i].getText();
       let dura = listOfDuras[i].getText();
-      expect(includes(validCpms, cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
-      expect(includes(validCats, cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
-      expect(includes(validDurations, dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
+      expect(validCpms.includes(cpm), `Could not find CPM ${cpm} in accepted list`).to.equal(true);
+      expect(validCats.includes(cat), `Could not find Category ${cat} in accepted list`).to.equal(true);
+      expect(validDurations.includes(dura), `Could not find Duration ${dura} in accepted list`).to.equal(true);
     }
   });
 

--- a/test/spec/modules/afpBidAdapter_spec.js
+++ b/test/spec/modules/afpBidAdapter_spec.js
@@ -221,7 +221,7 @@ describe('AFP Adapter', function() {
             expect(bid.sizes).to.equal(sizes)
           })
 
-          if (includes([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE], validBidRequests[index].params.placeType)) {
+          if ([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE].includes(validBidRequests[index].params.placeType)) {
             it('imageUrl should be correct', function() {
               expect(bid.imageUrl).to.equal(imageUrl)
             })

--- a/test/spec/modules/fintezaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fintezaAnalyticsAdapter_spec.js
@@ -1,5 +1,4 @@
 import fntzAnalyticsAdapter from 'modules/fintezaAnalyticsAdapter.js';
-import {includes} from 'src/polyfill.js';
 import { expect } from 'chai';
 import { parseUrl } from 'src/utils.js';
 import { server } from 'test/mocks/xhr.js';

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -812,6 +812,30 @@ describe('gumgumAdapter', function () {
     });
 
     it('should handle ORTB2 device data', function () {
+      const suaObject = {
+        source: 2,
+        platform: {
+          brand: 'macOS',
+          version: ['15', '5', '0']
+        },
+        browsers: [
+          {
+            brand: 'Google Chrome',
+            version: ['137', '0', '7151', '41']
+          },
+          {
+            brand: 'Chromium',
+            version: ['137', '0', '7151', '41']
+          },
+          {
+            brand: 'Not/A)Brand',
+            version: ['24', '0', '0', '0']
+          }
+        ],
+        mobile: 0,
+        model: '',
+        architecture: 'arm'
+      };
       const ortb2 = {
         device: {
           w: 980,
@@ -827,6 +851,8 @@ describe('gumgumAdapter', function () {
           ext: {fiftyonedegrees_deviceId: '17595-133085-133468-18092'},
           ip: '127.0.0.1',
           ipv6: '51dc:5e20:fd6a:c955:66be:03b4:dfa3:35b2',
+          sua: suaObject
+
         },
       };
 
@@ -843,6 +869,9 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.foddid).to.equal(ortb2.device.ext.fiftyonedegrees_deviceId);
       expect(bidRequest.data.ip).to.equal(ortb2.device.ip);
       expect(bidRequest.data.ipv6).to.equal(ortb2.device.ipv6);
+      expect(bidRequest.data).to.have.property('sua');
+      expect(() => JSON.parse(bidRequest.data.sua)).to.not.throw();
+      expect(JSON.parse(bidRequest.data.sua)).to.deep.equal(suaObject);
     });
 
     it('should set tId from ortb2Imp.ext.tid if available', function () {

--- a/test/spec/modules/intentIqAnalyticsAdapter_spec.js
+++ b/test/spec/modules/intentIqAnalyticsAdapter_spec.js
@@ -8,7 +8,7 @@ import * as events from 'src/events.js';
 import { getStorageManager } from 'src/storageManager.js';
 import sinon from 'sinon';
 import { REPORTER_ID, preparePayload } from '../../../modules/intentIqAnalyticsAdapter';
-import {FIRST_PARTY_KEY, VERSION} from '../../../libraries/intentIqConstants/intentIqConstants.js';
+import {FIRST_PARTY_KEY, PREBID, VERSION} from '../../../libraries/intentIqConstants/intentIqConstants.js';
 import * as detectBrowserUtils from '../../../libraries/intentIqUtils/detectBrowserUtils.js';
 import {getReferrer, appendVrrefAndFui} from '../../../libraries/intentIqUtils/getRefferer.js';
 import { gppDataHandler, uspDataHandler, gdprDataHandler } from '../../../src/consentHandler.js';
@@ -18,6 +18,8 @@ const defaultData = '{"pcid":"f961ffb1-a0e1-4696-a9d2-a21d815bd344", "group": "A
 const version = VERSION;
 const REPORT_ENDPOINT = 'https://reports.intentiq.com/report';
 const REPORT_ENDPOINT_GDPR = 'https://reports-gdpr.intentiq.com/report';
+const REPORT_SERVER_ADDRESS = 'https://test-reports.intentiq.com/report';
+
 
 const storage = getStorageManager({ moduleType: 'analytics', moduleName: 'iiqAnalytics' });
 
@@ -27,7 +29,25 @@ const getUserConfig = () => [
     'params': {
       'partner': partner,
       'unpack': null,
-      'manualWinReportEnabled': false
+      'manualWinReportEnabled': false,
+    },
+    'storage': {
+      'type': 'html5',
+      'name': 'intentIqId',
+      'expires': 60,
+      'refreshInSeconds': 14400
+    }
+  }
+];
+
+const getUserConfigWithReportingServerAddress = () => [
+  {
+    'name': 'intentIqId',
+    'params': {
+      'partner': partner,
+      'unpack': null,
+      'manualWinReportEnabled': false,
+      'reportingServerAddress': REPORT_SERVER_ADDRESS
     },
     'storage': {
       'type': 'html5',
@@ -118,18 +138,62 @@ describe('IntentIQ tests all', function () {
     server.reset();
   });
 
+  it('should send POST request with payload in request body if reportMethod is POST', function () {
+    const [userConfig] = getUserConfig();
+    userConfig.params.reportMethod = 'POST';
+  
+    config.getConfig.restore();
+    sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns([userConfig]);
+  
+    localStorage.setItem(FIRST_PARTY_KEY, defaultData);
+  
+    events.emit(EVENTS.BID_WON, wonRequest);
+  
+    const request = server.requests[0];
+  
+    const expectedData = preparePayload(wonRequest);
+    const expectedPayload = `["${btoa(JSON.stringify(expectedData))}"]`;
+  
+    expect(request.method).to.equal('POST');
+    expect(request.requestBody).to.equal(expectedPayload);
+  });
+
+  it('should send GET request with payload in query string if reportMethod is NOT provided', function () {
+    const [userConfig] = getUserConfig();
+    config.getConfig.restore();
+    sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns([userConfig]);
+  
+    localStorage.setItem(FIRST_PARTY_KEY, defaultData);
+    events.emit(EVENTS.BID_WON, wonRequest);
+  
+    const request = server.requests[0];
+  
+    expect(request.method).to.equal('GET');
+  
+    const url = new URL(request.url);
+    const payloadEncoded = url.searchParams.get('payload');
+    const decoded = JSON.parse(atob(JSON.parse(payloadEncoded)[0]));
+  
+    const expected = preparePayload(wonRequest);
+  
+    expect(decoded.partnerId).to.equal(expected.partnerId);
+    expect(decoded.adType).to.equal(expected.adType);
+    expect(decoded.prebidAuctionId).to.equal(expected.prebidAuctionId);
+  });
+  
   it('IIQ Analytical Adapter bid win report', function () {
     localStorage.setItem(FIRST_PARTY_KEY, defaultData);
-    getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns({href: 'http://localhost:9876/'});
-    const expectedVrref = encodeURIComponent(getWindowLocationStub().href);
-
+    getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns({href: 'http://localhost:9876'});
+    const expectedVrref = getWindowLocationStub().href;
     events.emit(EVENTS.BID_WON, wonRequest);
 
     expect(server.requests.length).to.be.above(0);
     const request = server.requests[0];
+    const parsedUrl = new URL(request.url);
+    const vrref = parsedUrl.searchParams.get('vrref');
     expect(request.url).to.contain(REPORT_ENDPOINT + '?pid=' + partner + '&mct=1');
     expect(request.url).to.contain(`&jsver=${version}`);
-    expect(request.url).to.contain(`&vrref=${expectedVrref}`);
+    expect(`&vrref=${decodeURIComponent(vrref)}`).to.contain(`&vrref=${expectedVrref}`);
     expect(request.url).to.contain('&payload=');
     expect(request.url).to.contain('iiqid=f961ffb1-a0e1-4696-a9d2-a21d815bd344');
   });
@@ -217,11 +281,13 @@ describe('IntentIQ tests all', function () {
     const request = server.requests[0];
     const dataToSend = preparePayload(wonRequest);
     const base64String = btoa(JSON.stringify(dataToSend));
-    const payload = `[%22${base64String}%22]`;
+    const payload = encodeURIComponent(JSON.stringify([base64String]));
     const expectedUrl = appendVrrefAndFui(REPORT_ENDPOINT +
-      `?pid=${partner}&mct=1&iiqid=${defaultDataObj.pcid}&agid=${REPORTER_ID}&jsver=${version}&source=pbjs&payload=${payload}&uh=&gdpr=0`, iiqAnalyticsAnalyticsAdapter.initOptions.domainName
+      `?pid=${partner}&mct=1&iiqid=${defaultDataObj.pcid}&agid=${REPORTER_ID}&jsver=${version}&source=pbjs&uh=&gdpr=0`, iiqAnalyticsAnalyticsAdapter.initOptions.domainName
     );
-    expect(request.url).to.equal(expectedUrl);
+    const urlWithPayload = expectedUrl + `&payload=${payload}`;
+
+    expect(request.url).to.equal(urlWithPayload);
     expect(dataToSend.pcid).to.equal(defaultDataObj.pcid)
   });
 
@@ -345,6 +411,114 @@ describe('IntentIQ tests all', function () {
     expect(request.url).to.contain(`&vrref=${encodeURIComponent('http://localhost:9876/')}`);
     expect(request.url).to.contain('&payload=');
     expect(request.url).to.contain('iiqid=f961ffb1-a0e1-4696-a9d2-a21d815bd344');
+  });
+
+  it('should send request in reportingServerAddress no gdpr', function () {
+    const USERID_CONFIG_BROWSER = [...getUserConfigWithReportingServerAddress()];
+    USERID_CONFIG_BROWSER[0].params.browserBlackList = 'chrome,firefox';
+
+    config.getConfig.restore();
+    sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns(USERID_CONFIG_BROWSER);
+    detectBrowserStub = sinon.stub(detectBrowserUtils, 'detectBrowser').returns('safari');
+
+    localStorage.setItem(FIRST_PARTY_KEY, defaultData);
+    events.emit(EVENTS.BID_WON, wonRequest);
+
+    expect(server.requests.length).to.be.above(0);
+    const request = server.requests[0];
+    expect(request.url).to.contain(REPORT_SERVER_ADDRESS);
+  });
+
+  it('should include source parameter in report URL', function () {
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify(defaultData));  
+    
+    events.emit(EVENTS.BID_WON, wonRequest);
+    const request = server.requests[0];
+
+    expect(server.requests.length).to.be.above(0);
+    expect(request.url).to.include(`&source=${PREBID}`);
+  });
+
+  it('should use correct key if siloEnabled is true', function () {
+    const siloEnabled = true;
+    const USERID_CONFIG = [...getUserConfig()];
+    USERID_CONFIG[0].params.siloEnabled = siloEnabled;
+
+    config.getConfig.restore();
+    sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns(USERID_CONFIG);
+
+    localStorage.setItem(FIRST_PARTY_KEY, `${FIRST_PARTY_KEY}${siloEnabled ? '_p_' + partner : ''}`);
+    events.emit(EVENTS.BID_WON, wonRequest);
+
+    expect(server.requests.length).to.be.above(0);
+    const request = server.requests[0];
+    expect(request.url).to.contain(REPORT_ENDPOINT + '?pid=' + partner + '&mct=1');
+  });
+
+  it('should send additionalParams in report if valid and small enough', function () {
+    const userConfig = getUserConfig();
+    userConfig[0].params.additionalParams = [{
+      parameterName: 'general',
+      parameterValue: 'Lee',
+      destination: [0, 0, 1]
+    }];
+  
+    config.getConfig.restore();
+    sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns(userConfig);
+  
+    localStorage.setItem(FIRST_PARTY_KEY, defaultData);
+    events.emit(EVENTS.BID_WON, wonRequest);
+  
+    const request = server.requests[0];
+    expect(request.url).to.include('general=Lee');
+  });
+  
+  it('should not send additionalParams in report if value is too large', function () {
+    const longVal = 'x'.repeat(5000000);
+    const userConfig = getUserConfig();
+    userConfig[0].params.additionalParams = [{
+      parameterName: 'general',
+      parameterValue: longVal,
+      destination: [0, 0, 1]
+    }];
+  
+    config.getConfig.restore();
+    sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns(userConfig);
+  
+    localStorage.setItem(FIRST_PARTY_KEY, defaultData);
+    events.emit(EVENTS.BID_WON, wonRequest);
+  
+    const request = server.requests[0];
+    expect(request.url).not.to.include('general');
+  });  
+  it('should include spd parameter from LS in report URL', function () {
+    const spdObject = { foo: 'bar', value: 42 };
+    const expectedSpdEncoded = encodeURIComponent(JSON.stringify(spdObject));
+
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({...defaultData, spd: spdObject}));  
+    getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns({ href: 'http://localhost:9876/' });
+
+    events.emit(EVENTS.BID_WON, wonRequest);
+
+    const request = server.requests[0];
+
+    expect(server.requests.length).to.be.above(0);
+    expect(request.url).to.include(`&spd=${expectedSpdEncoded}`);
+  });
+
+  it('should include spd parameter string from LS in report URL', function () {
+    const spdObject = 'server provided data';
+    const expectedSpdEncoded = encodeURIComponent(spdObject);
+
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({...defaultData, spd: spdObject}));  
+    getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns({ href: 'http://localhost:9876/' });
+
+    events.emit(EVENTS.BID_WON, wonRequest);
+
+    const request = server.requests[0];
+
+    expect(server.requests.length).to.be.above(0);
+    expect(request.url).to.include(`&spd=${expectedSpdEncoded}`);
   });
 
   const testCasesVrref = [

--- a/test/spec/modules/intentIqIdSystem_spec.js
+++ b/test/spec/modules/intentIqIdSystem_spec.js
@@ -6,21 +6,23 @@ import {
   decryptData,
   handleClientHints,
   firstPartyData as moduleFPD,
-  isCMPStringTheSame, createPixelUrl
+  isCMPStringTheSame, createPixelUrl, translateMetadata
 } from '../../../modules/intentIqIdSystem';
-import {storage, readData} from '../../../libraries/intentIqUtils/storageUtils.js';
+import { storage, readData, storeData } from '../../../libraries/intentIqUtils/storageUtils.js';
 import { gppDataHandler, uspDataHandler, gdprDataHandler } from '../../../src/consentHandler';
 import { clearAllCookies } from '../../helpers/cookies';
-import { detectBrowserFromUserAgent, detectBrowserFromUserAgentData } from '../../../libraries/intentIqUtils/detectBrowserUtils';
-import {CLIENT_HINTS_KEY, FIRST_PARTY_KEY, NOT_YET_DEFINED, WITH_IIQ} from '../../../libraries/intentIqConstants/intentIqConstants.js';
+import { detectBrowser, detectBrowserFromUserAgent, detectBrowserFromUserAgentData } from '../../../libraries/intentIqUtils/detectBrowserUtils';
+import {CLIENT_HINTS_KEY, FIRST_PARTY_KEY, NOT_YET_DEFINED, PREBID, WITH_IIQ, WITHOUT_IIQ} from '../../../libraries/intentIqConstants/intentIqConstants.js';
 
 const partner = 10;
 const pai = '11';
-const pcid = '12';
-const defaultConfigParams = { params: { partner: partner } };
-const paiConfigParams = { params: { partner: partner, pai: pai } };
-const pcidConfigParams = { params: { partner: partner, pcid: pcid } };
-const allConfigParams = { params: { partner: partner, pai: pai, pcid: pcid } };
+const partnerClientId = '12';
+const partnerClientIdType = 0;
+const sourceMetaData = '1.1.1.1';
+const defaultConfigParams = { params: { partner } };
+const paiConfigParams = { params: { partner, pai } };
+const pcidConfigParams = { params: { partner, partnerClientIdType, partnerClientId } };
+const allConfigParams = { params: { partner, pai, partnerClientIdType, partnerClientId, sourceMetaData } };
 const responseHeader = { 'Content-Type': 'application/json' }
 
 export const testClientHints = {
@@ -52,6 +54,9 @@ export const testClientHints = {
   platformVersion: '6.5.0',
   wow64: false
 };
+
+const testAPILink = 'https://new-test-api.intentiq.com'
+const syncTestAPILink = 'https://new-test-sync.intentiq.com'
 
 const mockGAM = () => {
   const targetingObject = {};
@@ -147,7 +152,7 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId({ ...allConfigParams, enabledStorageTypes: ['cookie'] }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pcid=12&pai=11&iiqidtype=2&iiqpcid=');
+    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pai=11&iiqidtype=2&iiqpcid=');
     request.respond(
       200,
       responseHeader,
@@ -180,6 +185,33 @@ describe('IntentIQ tests', function () {
     expect(intentIqIdSubmodule.decode(undefined)).to.equal(undefined);
   });
 
+  it('should send AT=20 request and send source in it', function () {
+    const usedBrowser = 'chrome';
+    intentIqIdSubmodule.getId({params: {
+      partner: 10,
+      browserBlackList: usedBrowser
+      }
+    });
+    const currentBrowserLowerCase = detectBrowser();
+    
+    if (currentBrowserLowerCase === usedBrowser) {
+      const at20request = server.requests[0];   
+      expect(at20request.url).to.contain(`&source=${PREBID}`);
+      expect(at20request.url).to.contain(`at=20`);
+    }
+  });
+
+
+  it('should send at=39 request and send source in it', function () {
+    const callBackSpy = sinon.spy();
+    const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
+  
+    submoduleCallback(callBackSpy);
+    const request = server.requests[0];
+  
+    expect(request.url).to.contain(`&source=${PREBID}`);
+  });
+
   it('should call the IntentIQ endpoint with only partner, pai', function () {
     let callBackSpy = sinon.spy();
     let submoduleCallback = intentIqIdSubmodule.getId(paiConfigParams).callback;
@@ -199,7 +231,8 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId(pcidConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pcid=12&iiqidtype=2&iiqpcid=');
+    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1');
+    expect(request.url).to.contain('&pcid=12');
     request.respond(
       200,
       responseHeader,
@@ -213,7 +246,8 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId(allConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pcid=12&pai=11&iiqidtype=2&iiqpcid=');
+    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pai=11&iiqidtype=2&iiqpcid=');
+    expect(request.url).to.contain('&pcid=12');
     request.respond(
       200,
       responseHeader,
@@ -316,7 +350,7 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId(allConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pcid=12&pai=11&iiqidtype=2&iiqpcid=');
+    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pai=11&iiqidtype=2&iiqpcid=');
     request.respond(
       200,
       responseHeader,
@@ -331,7 +365,7 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId(allConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pcid=12&pai=11&iiqidtype=2&iiqpcid=');
+    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pai=11&iiqidtype=2&iiqpcid=');
     request.respond(
       200,
       responseHeader,
@@ -348,7 +382,7 @@ describe('IntentIQ tests', function () {
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
 
-    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pcid=12&pai=11&iiqidtype=2&iiqpcid=');
+    expect(request.url).to.contain('https://api.intentiq.com/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=10&pt=17&dpn=1&pai=11&iiqidtype=2&iiqpcid=');
     expect(request.url).to.contain('cttl=' + testLSValue.cttl);
     expect(request.url).to.contain('rrtt=' + testLSValue.rrtt);
     request.respond(
@@ -390,6 +424,92 @@ describe('IntentIQ tests', function () {
     );
     expect(callBackSpy.calledOnce).to.be.true;
     expect(logErrorStub.called).to.be.true;
+  });
+
+  it('should send AT=20 request and send spd in it', function () {
+    const spdValue = { foo: 'bar', value: 42 };
+    const encodedSpd = encodeURIComponent(JSON.stringify(spdValue));
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({pcid: '123', spd: spdValue}));
+
+    intentIqIdSubmodule.getId({params: {
+      partner: 10,
+      browserBlackList: 'chrome'
+      }
+    });
+    
+    const at20request = server.requests[0];
+    expect(at20request.url).to.contain(`&spd=${encodedSpd}`);
+    expect(at20request.url).to.contain(`at=20`);
+  });
+
+  it('should send AT=20 request and send spd string in it ', function () {
+    const spdValue = 'server provided data';
+    const encodedSpd = encodeURIComponent(spdValue);
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({pcid: '123', spd: spdValue}));
+
+    intentIqIdSubmodule.getId({params: {
+      partner: 10,
+      browserBlackList: 'chrome'
+      }
+    });
+    
+    const at20request = server.requests[0];   
+    expect(at20request.url).to.contain(`&spd=${encodedSpd}`);
+    expect(at20request.url).to.contain(`at=20`);
+  });
+  
+  it('should send spd from firstPartyData in localStorage in at=39 request', function () {
+    const spdValue = { foo: 'bar', value: 42 };
+    const encodedSpd = encodeURIComponent(JSON.stringify(spdValue));
+
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({ pcid: '123', spd: spdValue }));
+
+    const callBackSpy = sinon.spy();
+    const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
+  
+    submoduleCallback(callBackSpy);
+    const request = server.requests[0];
+    
+    expect(request.url).to.contain(`&spd=${encodedSpd}`);
+    expect(request.url).to.contain(`at=39`);
+  });
+
+  it('should send spd string from firstPartyData in localStorage in at=39 request', function () {
+    const spdValue = 'spd string';
+    const encodedSpd = encodeURIComponent(spdValue);
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({ pcid: '123', spd: spdValue }));
+
+    const callBackSpy = sinon.spy();
+    const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
+  
+    submoduleCallback(callBackSpy);
+    const request = server.requests[0];
+
+    expect(request.url).to.contain(`&spd=${encodedSpd}`);
+    expect(request.url).to.contain(`at=39`);
+  });
+
+  it('should save spd to firstPartyData in localStorage if present in response', function () {
+    const spdValue = { foo: 'bar', value: 42 };
+    let callBackSpy = sinon.spy();
+    const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
+  
+    submoduleCallback(callBackSpy);
+    const request = server.requests[0];
+  
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({ pid: 'test_pid', data: 'test_personid', ls: true, spd: spdValue })
+    );
+  
+    const storedLs = readData(FIRST_PARTY_KEY, ['html5', 'cookie'], storage);
+    const parsedLs = JSON.parse(storedLs);
+    
+    expect(storedLs).to.not.be.null;
+    expect(callBackSpy.calledOnce).to.be.true;
+    expect(parsedLs).to.have.property('spd');
+    expect(parsedLs.spd).to.deep.equal(spdValue);
   });
 
   describe('detectBrowserFromUserAgent', function () {
@@ -444,6 +564,46 @@ describe('IntentIQ tests', function () {
       const result = detectBrowserFromUserAgentData(userAgentData);
       expect(result).to.equal('unknown');
     });
+
+    it("Should call the server for new partner if FPD has been updated by other partner, and 24 hours have not yet passed.", () => {
+      const allowedStorage = ['html5']
+      const newPartnerId = 12345
+      const FPD = {
+        pcid: 'c869aa1f-fe40-47cb-810f-4381fec28fc9',
+        pcidDate: 1747720820757,
+        group: 'A',
+        sCal: Date.now(),
+        gdprString: null,
+        gppString: null,
+        uspString: null
+      };     
+
+      storeData(FIRST_PARTY_KEY, JSON.stringify(FPD), allowedStorage, storage)
+      const callBackSpy = sinon.spy()
+      const submoduleCallback = intentIqIdSubmodule.getId({...allConfigParams, params: {...allConfigParams.params, partner: newPartnerId}}).callback;
+      submoduleCallback(callBackSpy);
+      const request = server.requests[0];
+      expect(request.url).contain("ProfilesEngineServlet?at=39") // server was called
+    })
+    it("Should NOT call the server if FPD has been updated user Opted Out, and 24 hours have not yet passed.", () => {
+      const allowedStorage = ['html5']
+      const newPartnerId = 12345
+      const FPD = {
+        pcid: 'c869aa1f-fe40-47cb-810f-4381fec28fc9',
+        pcidDate: 1747720820757,
+        group: 'A',
+        isOptedOut: true,
+        sCal: Date.now(),
+        gdprString: null,
+        gppString: null,
+        uspString: null
+      };     
+
+      storeData(FIRST_PARTY_KEY, JSON.stringify(FPD), allowedStorage, storage)
+      const returnedObject = intentIqIdSubmodule.getId({...allConfigParams, params: {...allConfigParams.params, partner: newPartnerId}});
+      expect(returnedObject.callback).to.be.undefined
+      expect(server.requests.length).to.equal(0) // no server requests
+    })
   });
 
   describe('IntentIQ consent management within getId', function () {
@@ -580,6 +740,36 @@ describe('IntentIQ tests', function () {
 
       expect(request.url).to.contain(ENDPOINT_GDPR);
     });
+
+    it('should make request to correct address with iiqServerAddress parameter', function() {
+      defaultConfigParams.params.iiqServerAddress = testAPILink
+      let callBackSpy = sinon.spy();
+      let submoduleCallback = intentIqIdSubmodule.getId({...defaultConfigParams}).callback;
+
+      submoduleCallback(callBackSpy);
+      let request = server.requests[0];
+
+      expect(request.url).to.contain(testAPILink);
+    });
+
+    it('should make request to correct address with iiqPixelServerAddress parameter', function() {
+      let wasCallbackCalled = false
+      const callbackConfigParams = { params: { partner: partner,
+        pai,
+        partnerClientIdType,
+        partnerClientId,
+        browserBlackList: 'Chrome',
+        iiqPixelServerAddress: syncTestAPILink,
+        callback: () => {
+          wasCallbackCalled = true
+        } } };
+
+      intentIqIdSubmodule.getId({...callbackConfigParams});
+
+      let request = server.requests[0];
+
+      expect(request.url).to.contain(syncTestAPILink);
+    });
   });
 
   it('should get and save client hints to storage', async () => {
@@ -677,8 +867,9 @@ describe('IntentIQ tests', function () {
   it('should run callback from params', async () => {
     let wasCallbackCalled = false
     const callbackConfigParams = { params: { partner: partner,
-      pai: pai,
-      pcid: pcid,
+      pai,
+      partnerClientIdType,
+      partnerClientId,
       browserBlackList: 'Chrome',
       callback: () => {
         wasCallbackCalled = true
@@ -687,4 +878,369 @@ describe('IntentIQ tests', function () {
     await intentIqIdSubmodule.getId(callbackConfigParams);
     expect(wasCallbackCalled).to.equal(true);
   });
+
+  it('should send sourceMetaData in AT=39 if it exists in configParams', function () {
+    let translatedMetaDataValue = translateMetadata(sourceMetaData)
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = intentIqIdSubmodule.getId(allConfigParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).to.include(`fbp=${translatedMetaDataValue}`)
+  });
+
+  it('should NOT send sourceMetaData and sourceMetaDataExternal in AT=39 if it is undefined', function () {
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, sourceMetaData: undefined} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).not.to.include('fbp=')
+  });
+
+  it('should NOT send sourceMetaData in AT=39 if value is NAN', function () {
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, sourceMetaData: NaN} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).not.to.include('fbp=')
+  });
+
+  it('should send sourceMetaData in AT=20 if it exists in configParams', function () {
+    let translatedMetaDataValue = translateMetadata(sourceMetaData)
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome'} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).to.include(`fbp=${translatedMetaDataValue}`)
+  });
+
+  it('should NOT send sourceMetaData in AT=20 if value is NAN', function () {
+    const configParams = { params: {...allConfigParams.params, sourceMetaData: NaN, browserBlackList: 'chrome'} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).to.not.include('&fbp=');
+  });
+
+  it('should send pcid and idtype in AT=20 if it provided in config', function () {
+    let partnerClientId = 'partnerClientId 123';
+    let partnerClientIdType = 0;
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', partnerClientId, partnerClientIdType} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).to.include(`&pcid=${encodeURIComponent(partnerClientId)}`);
+    expect(request.url).to.include(`&idtype=${partnerClientIdType}`);
+  });
+
+  it('should NOT send pcid and idtype in AT=20 if partnerClientId is NOT a string', function () {
+    let partnerClientId = 123;
+    let partnerClientIdType = 0;
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', partnerClientId, partnerClientIdType} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).not.to.include(`&pcid=`);
+    expect(request.url).not.to.include(`&idtype=`);
+  });
+
+  it('should NOT send pcid and idtype in AT=20 if partnerClientIdType is NOT a number', function () {
+    let partnerClientId = 'partnerClientId 123';
+    let partnerClientIdType = 'wrong';
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', partnerClientId, partnerClientIdType} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).not.to.include(`&pcid=`);
+    expect(request.url).not.to.include(`&idtype=`);
+  });
+
+  it('should send partnerClientId and partnerClientIdType in AT=39 if it provided in config', function () {
+    let partnerClientId = 'partnerClientId 123';
+    let partnerClientIdType = 0;
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, partnerClientId, partnerClientIdType} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).to.include(`&pcid=${encodeURIComponent(partnerClientId)}`);
+    expect(request.url).to.include(`&idtype=${partnerClientIdType}`);
+  });
+
+  it('should NOT send partnerClientId and partnerClientIdType in AT=39 if partnerClientId is not a string', function () {
+    let partnerClientId = 123;
+    let partnerClientIdType = 0;
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, partnerClientId, partnerClientIdType} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).not.to.include(`&pcid=${partnerClientId}`);
+    expect(request.url).not.to.include(`&idtype=${partnerClientIdType}`);
+  });
+
+  it('should NOT send partnerClientId and partnerClientIdType in AT=39 if partnerClientIdType is not a number', function () {
+    let partnerClientId = 'partnerClientId-123';
+    let partnerClientIdType = 'wrong';
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, partnerClientId, partnerClientIdType} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).not.to.include(`&pcid=${partnerClientId}`);
+    expect(request.url).not.to.include(`&idtype=${partnerClientIdType}`);
+  });
+
+  it('should NOT send sourceMetaData in AT=20 if sourceMetaDataExternal provided', function () {
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', sourceMetaDataExternal: 123} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).to.include('&fbp=123');
+  });
+
+  it('should store first party data under the silo key when siloEnabled is true', function () {
+    const configParams = { params: {...allConfigParams.params, siloEnabled: true} };
+    
+    intentIqIdSubmodule.getId(configParams);
+    const expectedKey = FIRST_PARTY_KEY + '_p_' + configParams.params.partner;
+    const storedData = localStorage.getItem(expectedKey);
+    expect(storedData).to.be.a('string');
+    expect(localStorage.getItem(FIRST_PARTY_KEY)).to.be.null;
+
+    const parsed = JSON.parse(storedData);
+    expect(parsed).to.have.property('pcid');
+  });
+
+  it('should send siloEnabled value in the request', function () {
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, siloEnabled: true} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.contain(`&japs=${configParams.params.siloEnabled}`);
+  });
+
+  it('should increment callCount when valid eids are returned', function () {
+    const firstPartyDataKey = '_iiq_fdata_' + partner;
+    const partnerData = { callCount: 0, failCount: 0, noDataCounter: 0 };
+    localStorage.setItem(firstPartyDataKey, JSON.stringify(partnerData));
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({ pcid: 'abc', cttl: 9999999, group: 'with_iiq' }));
+
+    const responseData = { data: { eids: ['abc'] }, ls: true };
+
+    const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
+    const callBackSpy = sinon.spy();
+
+    submoduleCallback(callBackSpy);
+    const request = server.requests[0];
+    request.respond(200, responseHeader, JSON.stringify(responseData));
+
+    const updatedData = JSON.parse(localStorage.getItem(firstPartyDataKey));
+    expect(updatedData.callCount).to.equal(1);
+  });
+
+  it('should increment failCount when request fails', function () {
+    const firstPartyDataKey = '_iiq_fdata_' + partner;
+    const partnerData = { callCount: 0, failCount: 0, noDataCounter: 0 };
+    localStorage.setItem(firstPartyDataKey, JSON.stringify(partnerData));
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({ pcid: 'abc', cttl: 9999999, group: 'with_iiq' }));
+
+    const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
+    const callBackSpy = sinon.spy();
+
+    submoduleCallback(callBackSpy);
+    const request = server.requests[0];
+    request.respond(503, responseHeader, 'Service Unavailable');
+
+    const updatedData = JSON.parse(localStorage.getItem(firstPartyDataKey));
+    expect(updatedData.failCount).to.equal(1);
+  });
+
+  it('should increment noDataCounter when eids are empty', function () {
+    const firstPartyDataKey = '_iiq_fdata_' + partner;
+    const partnerData = { callCount: 0, failCount: 0, noDataCounter: 0 };
+    localStorage.setItem(firstPartyDataKey, JSON.stringify(partnerData));
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({ pcid: 'abc', cttl: 9999999, group: 'with_iiq' }));
+
+    const responseData = { data: { eids: [] }, ls: true };
+
+    const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
+    const callBackSpy = sinon.spy();
+
+    submoduleCallback(callBackSpy);
+    const request = server.requests[0];
+    request.respond(200, responseHeader, JSON.stringify(responseData));
+
+    const updatedData = JSON.parse(localStorage.getItem(firstPartyDataKey));
+    expect(updatedData.noDataCounter).to.equal(1);
+  });
+
+  it('should send additional parameters in sync request due to configuration', function () {
+    const configParams = {
+      params: {
+        ...defaultConfigParams.params,
+        browserBlackList: 'chrome',
+        additionalParams: [{
+          parameterName: 'general',
+          parameterValue: 'Lee',
+          destination: [1, 0, 0]
+        }]
+      }
+    };
+  
+    intentIqIdSubmodule.getId(configParams);
+    const syncRequest = server.requests[0];
+  
+    expect(syncRequest.url).to.include('general=Lee');
+  });
+  it('should send additionalParams in VR request', function () {
+    const configParams = {
+      params: {
+        ...defaultConfigParams.params,
+        additionalParams: [{
+          parameterName: 'general',
+          parameterValue: 'Lee',
+          destination: [0, 1, 0]
+        }]
+      }
+    };
+
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+    const vrRequest = server.requests[0];
+  
+    expect(vrRequest.url).to.include('general=Lee');
+  });
+  
+  it('should not send additionalParams in case it is not an array', function () {
+    const configParams = {
+      params: {
+        ...defaultConfigParams.params,
+        additionalParams: {
+          parameterName: 'general',
+          parameterValue: 'Lee',
+          destination: [0, 1, 0]
+        }
+      }
+    };
+
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+    const vrRequest = server.requests[0];
+  
+    expect(vrRequest.url).not.to.include('general=');
+  });
+  
+  it('should not send additionalParams in case request url is too long', function () {
+    const longValue = 'x'.repeat(5000000); // simulate long parameter
+    const configParams = {
+      params: {
+        ...defaultConfigParams.params,
+        additionalParams: [{
+          parameterName: 'general',
+          parameterValue: longValue,
+          destination: [0, 1, 0]
+        }]
+      }
+    };
+
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+    const vrRequest = server.requests[0];
+  
+    expect(vrRequest.url).not.to.include('general=');
+  });
+
+  it('should call groupChanged with "withoutIIQ" when terminationCause is 41', function () {
+    const groupChangedSpy = sinon.spy();
+    const callBackSpy = sinon.spy();
+    const configParams = {
+      params: {
+        ...defaultConfigParams.params,
+        groupChanged: groupChangedSpy
+      }
+    };
+  
+    const submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+  
+    const request = server.requests[0];
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({
+        tc: 41,
+        isOptedOut: false,
+        data: { eids: [] }
+      })
+    );
+  
+    expect(callBackSpy.calledOnce).to.be.true;
+    expect(groupChangedSpy.calledWith(WITHOUT_IIQ)).to.be.true;
+  });
+
+  it('should call groupChanged with "withIIQ" when terminationCause is NOT 41', function () {
+    const groupChangedSpy = sinon.spy();
+    const callBackSpy = sinon.spy();
+    const configParams = {
+      params: {
+        ...defaultConfigParams.params,
+        groupChanged: groupChangedSpy
+      }
+    };
+  
+    const submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+  
+    const request = server.requests[0];
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({
+        tc: 35,
+        isOptedOut: false,
+        data: { eids: [] }
+      })
+    );
+  
+    expect(callBackSpy.calledOnce).to.be.true;
+    expect(groupChangedSpy.calledWith(WITH_IIQ)).to.be.true;
+  });  
 });

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -72,7 +72,7 @@ describe('weboramaRtdProvider', function() {
         }
         expect(weboramaSubmodule.init(moduleConfig, userConsent)).to.equal(true);
       });
-      it('should initialize if gdpr applies and consent is ok', function() {
+      it('should initialize if gdpr applies and consent / legitimate interests / vendor are ok', function() {
         const moduleConfig = {
           params: {
             weboUserDataConf: {}
@@ -89,7 +89,14 @@ describe('weboramaRtdProvider', function() {
                   4: true,
                   5: true,
                   6: true,
+                },
+                legitimateInterests: {
+                  2: true,
+                  7: true,
+                  8: true,
                   9: true,
+                  10: true,
+                  11: true,
                 },
               },
               specialFeatureOptins: {
@@ -99,11 +106,100 @@ describe('weboramaRtdProvider', function() {
                 consents: {
                   284: true,
                 },
+                legitimateInterests: {
+                  284: true,
+                },
               }
             },
           },
         }
         expect(weboramaSubmodule.init(moduleConfig, userConsent)).to.equal(true);
+      });
+      it('should NOT initialize if gdpr applies and consent is nok: miss legitimate interests vendor id', function() {
+        const moduleConfig = {
+          params: {
+            weboUserDataConf: {}
+          }
+        };
+        const userConsent = {
+          gdpr: {
+            gdprApplies: true,
+            vendorData: {
+              purpose: {
+                consents: {
+                  1: true,
+                  3: true,
+                  4: true,
+                  5: true,
+                  6: true,
+                },
+                legitimateInterests: {
+                  2: true,
+                  7: true,
+                  8: true,
+                  9: true,
+                  10: true,
+                  11: true,
+                },
+              },
+              specialFeatureOptins: {
+                1: true,
+              },
+              vendor: {
+                consents: {
+                  284: true,
+                },
+                legitimateInterests: {
+                  284: false,
+                },
+              }
+            },
+          },
+        }
+        expect(weboramaSubmodule.init(moduleConfig, userConsent)).to.equal(false);
+      });
+      it('should NOT initialize if gdpr applies and consent is nok: miss legitimate interest purpose id', function() {
+        const moduleConfig = {
+          params: {
+            weboUserDataConf: {}
+          }
+        };
+        const userConsent = {
+          gdpr: {
+            gdprApplies: true,
+            vendorData: {
+              purpose: {
+                consents: {
+                  1: true,
+                  3: true,
+                  4: true,
+                  5: true,
+                  6: true,
+                },
+                legitimateInterests: {
+                  2: true,
+                  7: true,
+                  8: true,
+                  9: false,
+                  10: true,
+                  11: true,
+                },
+              },
+              specialFeatureOptins: {
+                1: true,
+              },
+              vendor: {
+                consents: {
+                  284: true,
+                },
+                legitimateInterests: {
+                  284: true,
+                },
+              }
+            },
+          },
+        }
+        expect(weboramaSubmodule.init(moduleConfig, userConsent)).to.equal(false);
       });
       it('should NOT initialize if gdpr applies and consent is nok: miss consent vendor id', function() {
         const moduleConfig = {

--- a/test/spec/modules/widespaceBidAdapter_spec.js
+++ b/test/spec/modules/widespaceBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {spec, storage} from 'modules/widespaceBidAdapter.js';
-import {includes} from 'src/polyfill.js';
 
 describe('+widespaceAdatperTest', function () {
   // Dummy bid request
@@ -218,7 +217,7 @@ describe('+widespaceAdatperTest', function () {
       ];
       const resultKeys = Object.keys(result[0]);
       requiredKeys.forEach((key) => {
-        expect(includes(resultKeys, key)).to.equal(true);
+        expect(resultKeys.includes(key)).to.equal(true);
       });
 
       // Each value except referrer should not be empty|null|undefined


### PR DESCRIPTION
## Summary
- drop `find` and `findIndex` stubs from `src/polyfill.js`
- replace usages with native `.find()` and `.findIndex()`

## Testing
- `npm test` *(fails: Karma tests require unavailable browsers)*