### PR TITLE
Fix more uses of sinon.reset

### DIFF
--- a/test/spec/modules/automatadAnalyticsAdapter_spec.js
+++ b/test/spec/modules/automatadAnalyticsAdapter_spec.js
@@ -146,7 +146,7 @@ describe('Automatad Analytics Adapter', () => {
     });
     after(() => {
       const handlers = global.window.atmtdAnalytics
-      Object.keys(handlers).forEach((handler) => global.window.atmtdAnalytics[handler].reset())
+      Object.keys(handlers).forEach((handler) => global.window.atmtdAnalytics[handler].resetHistory())
       global.window.atmtdAnalytics = undefined;
       spec.disableAnalytics();
       exports.qBeingUsed = false
@@ -355,7 +355,7 @@ describe('Automatad Analytics Adapter', () => {
       events.emit(AUCTION_INIT, {type: AUCTION_INIT})
       global.window.atmtdAnalytics = {...obj}
       const handlers = global.window.atmtdAnalytics
-      Object.keys(handlers).forEach((handler) => global.window.atmtdAnalytics[handler].reset())
+      Object.keys(handlers).forEach((handler) => global.window.atmtdAnalytics[handler].resetHistory())
       expect(exports.__atmtdAnalyticsQueue.push.called).to.equal(true)
       expect(exports.__atmtdAnalyticsQueue).to.be.an('array').to.have.lengthOf(1)
       expect(exports.__atmtdAnalyticsQueue[0]).to.have.lengthOf(2)

--- a/test/spec/modules/consentManagementGpp_spec.js
+++ b/test/spec/modules/consentManagementGpp_spec.js
@@ -538,7 +538,7 @@ describe('consentManagementGpp', function () {
         await didHookRun();
         triggerCMPEvent('sectionChange', {signalStatus: 'ready'});
         await consentConfig.loadConsentData();
-        window.__gpp.reset();
+        window.__gpp.resetHistory();
         didHookRun = startHook();
         await consentConfig.loadConsentData();
         expect(await didHookRun()).to.be.true;

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -581,7 +581,7 @@ describe('consentManagement', function () {
           sinon.assert.notCalled(utils.logWarn);
           sinon.assert.notCalled(utils.logError);
 
-          [utils.logWarn, utils.logError].forEach((stub) => stub.reset());
+          [utils.logWarn, utils.logError].forEach((stub) => stub.resetHistory());
 
           expect(await runHook({bidsBackHandler: () => bidsBackHandlerReturn = true})).to.be.false;
           let consent = gdprDataHandler.getConsentData();


### PR DESCRIPTION
## Summary
- use resetHistory instead of sinon.reset
- update more analytics tests

## Testing
- `npm run lint`
- `npm test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*