### PR TITLE
Fix Pubmatic config error logging

### DIFF
--- a/modules/pubmaticRtdProvider.js
+++ b/modules/pubmaticRtdProvider.js
@@ -181,7 +181,7 @@ export const fetchData = async (publisherId, profileId, type) => {
 
       return await response.json();
     } catch (error) {
-      logError(`${CONSTANTS.LOG_PRE_FIX} Error while fetching ${type}:`, error);
+      logError(`${CONSTANTS.LOG_PRE_FIX} Error while fetching ${type}: ${error}`);
     }
 };
 


### PR DESCRIPTION
## Summary
- improve Pubmatic RTD error logging when JSON parse fails

## Testing
- `npm -s run test -- --file "test/spec/modules/pubmaticRtdProvider_spec.js"`
- `npm -s run lint`
