### PR TITLE
Fix RTD provider warning in tests

### DIFF
--- a/test/test_deps.js
+++ b/test/test_deps.js
@@ -34,3 +34,4 @@ require('test/mocks/adloaderStub.js');
 require('test/mocks/xhr.js');
 require('test/mocks/analyticsStub.js');
 require('test/mocks/ortbConverter.js')
+require('modules/rtdModule/index.js');


### PR DESCRIPTION
## Summary
- ensure RTD module is loaded before provider tests

## Testing
- `npm test`