### PR TITLE
Enable caching for webpack builds

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -6,6 +6,8 @@ const babelConfig = require('./babelConfig.js');
 var _ = require('lodash');
 var webpackConf = require('./webpack.conf.js');
 var karmaConstants = require('karma').constants;
+var path = require('path');
+const cacheDir = path.resolve(__dirname, '.cache/babel-loader');
 
 function newWebpackConfig(codeCoverage, disableFeatures) {
   // Make a clone here because we plan on mutating this object, and don't want parallel tasks to trample each other.
@@ -14,6 +16,10 @@ function newWebpackConfig(codeCoverage, disableFeatures) {
   Object.assign(webpackConfig, {
     mode: 'development',
     devtool: 'inline-source-map',
+    cache: {
+      type: 'filesystem',
+      cacheDirectory: path.resolve(__dirname, '.cache/webpack-test')
+    },
   });
   ['entry', 'optimization'].forEach(prop => delete webpackConfig[prop]);
 
@@ -21,7 +27,10 @@ function newWebpackConfig(codeCoverage, disableFeatures) {
     .flatMap((r) => r.use)
     .filter((use) => use.loader === 'babel-loader')
     .forEach((use) => {
-      use.options = babelConfig({test: true, codeCoverage, disableFeatures});
+      use.options = Object.assign(
+        {cacheDirectory: cacheDir, cacheCompression: false},
+        babelConfig({test: true, codeCoverage, disableFeatures})
+      );
     });
 
   return webpackConfig;

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -1,6 +1,7 @@
 const TerserPlugin = require('terser-webpack-plugin');
 var prebid = require('./package.json');
 var path = require('path');
+const cacheDir = path.resolve(__dirname, '.cache/babel-loader');
 var webpack = require('webpack');
 var helpers = require('./gulpHelpers.js');
 var { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
@@ -40,6 +41,10 @@ if (argv.analyze) {
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '.cache/webpack')
+  },
   resolve: {
     modules: [
       path.resolve('.'),
@@ -78,7 +83,11 @@ module.exports = {
         use: [
           {
             loader: 'babel-loader',
-            options: Object.assign({}, babelConfig, helpers.getAnalyticsOptions()),
+            options: Object.assign(
+              {cacheDirectory: cacheDir, cacheCompression: false},
+              babelConfig,
+              helpers.getAnalyticsOptions()
+            ),
           }
         ]
       },
@@ -88,7 +97,7 @@ module.exports = {
         use: [
           {
             loader: 'babel-loader',
-            options: babelConfig
+            options: Object.assign({cacheDirectory: cacheDir, cacheCompression: false}, babelConfig)
           }
         ],
       }


### PR DESCRIPTION
## Summary
- turn on filesystem cache for webpack
- cache babel-loader during tests and builds
- revert incidental package-lock changes

## Testing
- `npx gulp lint` *(failed to run)*
- `npx gulp test --browsers=ChromeHeadless` *(failed during webpack bundling)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.