### PR TITLE
Add GAM alias modules

### DIFF
--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -117,7 +117,7 @@
                 if (videoBids) {
 // DEMO NOTES: your environment likely will use the commented section ////
                     var videoUrl = videoBids.bids[0].vastUrl;
-//                    var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+//                    var videoUrl = pbjs.adServers.gam.buildVideoUrl({
 //                        adUnit: videoAdUnit,
 //                        params: {
 //                            iu: '/19968336/prebid_cache_video_adunit',

--- a/integrationExamples/gpt/localCacheGam.html
+++ b/integrationExamples/gpt/localCacheGam.html
@@ -95,7 +95,7 @@
 
             const bid = bidResponse.bids[0];
 
-            const vastXml = await pbjs.adServers.dfp.getVastXml({
+            const vastXml = await pbjs.adServers.gam.getVastXml({
               bid,
               adUnit: 'div-gpt-ad-51545-0',
               params: {

--- a/integrationExamples/videoModule/jwplayer/bidsBackHandlerOverride.html
+++ b/integrationExamples/videoModule/jwplayer/bidsBackHandlerOverride.html
@@ -112,7 +112,7 @@
             }
 
             bidResponse.bids.forEach(bid => {
-              const videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+              const videoUrl = pbjs.adServers.gam.buildVideoUrl({
                 adUnit: videoAdUnit,
                 url: bid.vastUrl,
                 params: {

--- a/integrationExamples/videoModule/videojs/bidsBackHandlerOverride.html
+++ b/integrationExamples/videoModule/videojs/bidsBackHandlerOverride.html
@@ -135,7 +135,7 @@
             }
 
             bidResponse.bids.forEach(bid => {
-              const videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+              const videoUrl = pbjs.adServers.gam.buildVideoUrl({
                 adUnit: videoAdUnit,
                 url: bid.vastUrl,
                 params: {

--- a/libraries/gamUtils/gamUtils.js
+++ b/libraries/gamUtils/gamUtils.js
@@ -1,0 +1,1 @@
+export {DEFAULT_DFP_PARAMS as DEFAULT_GAM_PARAMS, DFP_ENDPOINT as GAM_ENDPOINT, gdprParams} from '../dfpUtils/dfpUtils.js';

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -59,7 +59,7 @@
     ],
     "adpod": [
       "freeWheelAdserverVideo",
-      "dfpAdpod"
+      "gamAdpod"
     ],
     "rtdModule": [
       "1plusXRtdProvider",

--- a/modules/adlooxAdServerVideo.js
+++ b/modules/adlooxAdServerVideo.js
@@ -49,7 +49,7 @@ export function buildVideoUrl(options, callback) {
     return false;
   }
 
-  // same logic used in modules/dfpAdServerVideo.js
+  // same logic used in modules/gamAdServerVideo.js
   options.bid = options.bid || targeting.getWinningBids(options.adUnit.code)[0];
 
   deepSetValue(options.bid, 'ext.adloox.video.adserver', true);

--- a/modules/adlooxAdServerVideo.md
+++ b/modules/adlooxAdServerVideo.md
@@ -50,7 +50,7 @@ To use this, you *must* also integrate the [Adloox Analytics Adapter](./adlooxAn
       // handle the bids on the video adUnit
       var videoBids = bids[videoAdUnit.code];
       if (videoBids) {
-        var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+        var videoUrl = pbjs.adServers.gam.buildVideoUrl({
           adUnit: videoAdUnit,
           params: {
             iu: '/19968336/prebid_cache_video_adunit',
@@ -76,8 +76,8 @@ Where:
 
  * **`options`:** configuration object:
      * **`adUnit`:** ad unit that is being filled
-     * **`bid` [optional]:** if you override the hardcoded `pbjs.adServers.dfp.buildVideoUrl(...)` logic that picks the first bid you *must* pass in the `bid` object you select
-     * **`url`:** VAST tag URL, typically the value returned by `pbjs.adServers.dfp.buildVideoUrl(...)`
+    * **`bid` [optional]:** if you override the hardcoded `pbjs.adServers.gam.buildVideoUrl(...)` logic that picks the first bid you *must* pass in the `bid` object you select
+    * **`url`:** VAST tag URL, typically the value returned by `pbjs.adServers.gam.buildVideoUrl(...)`
      * **`wrap`:**
          * **`true` [default]:** VAST tag is be converted to an Adloox VAST wrapped tag
          * **`false`:** VAST tag URL is returned as is

--- a/modules/adlooxAnalyticsAdapter.md
+++ b/modules/adlooxAnalyticsAdapter.md
@@ -34,9 +34,9 @@ When tracking video you have two options:
 
 To view an [example of an Adloox integration](../integrationExamples/gpt/adloox.html):
 
-    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,dfpAdServerVideo,intersectionRtdProvider,rtdModule,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo,adlooxRtdProvider
+    gulp serve --nolint --notest --modules=gptPreAuction,categoryTranslation,gamAdServerVideo,intersectionRtdProvider,rtdModule,instreamTracking,rubiconBidAdapter,spotxBidAdapter,adlooxAnalyticsAdapter,adlooxAdServerVideo,adlooxRtdProvider
 
-**N.B.** `categoryTranslation` is required by `dfpAdServerVideo` that otherwise causes a JavaScript console warning
+**N.B.** `categoryTranslation` is required by `gamAdServerVideo` that otherwise causes a JavaScript console warning
 
 **N.B.** `intersectionRtdProvider` is used by `adlooxRtdProvider` to provide (above-the-fold) ATF measurement, if not enabled the `atf` segment will not be available
 

--- a/modules/aidemBidAdapter.md
+++ b/modules/aidemBidAdapter.md
@@ -183,7 +183,7 @@ gulp test --file "test/spec/modules/aidemBidAdapter_spec.js"
 ```
 
 
-For video: gulp serve --modules=aidemBidAdapter,dfpAdServerVideo
+For video: gulp serve --modules=aidemBidAdapter,gamAdServerVideo
 
 # FAQs
 ### How do I view AIDEM bid request?

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -74,7 +74,7 @@ export const VAST_TAG_URI_TAGNAME = 'VASTAdTagURI';
  */
 export function buildDfpVideoUrl(options) {
   if (!options.params && !options.url) {
-    logError(`A params object or a url is required to use $$PREBID_GLOBAL$$.adServers.dfp.buildVideoUrl`);
+    logError(`A params object or a url is required to use $$PREBID_GLOBAL$$.adServers.gam.buildVideoUrl`);
     return;
   }
 

--- a/modules/dfpAdpod.js
+++ b/modules/dfpAdpod.js
@@ -22,9 +22,9 @@ export const adpodUtils = {};
  */
 export function buildAdpodVideoUrl({code, params, callback} = {}) {
   // TODO: the public API for this does not take in enough info to fill all DFP params (adUnit/bid),
-  // and is marked "alpha": https://docs.prebid.org/dev-docs/publisher-api-reference/adServers.dfp.buildAdpodVideoUrl.html
+  // and is marked "alpha": https://docs.prebid.org/dev-docs/publisher-api-reference/adServers.gam.buildAdpodVideoUrl.html
   if (!params || !callback) {
-    logError(`A params object and a callback is required to use pbjs.adServers.dfp.buildAdpodVideoUrl`);
+    logError(`A params object and a callback is required to use pbjs.adServers.gam.buildAdpodVideoUrl`);
     return;
   }
 

--- a/modules/gamAdServerVideo.js
+++ b/modules/gamAdServerVideo.js
@@ -1,0 +1,11 @@
+/* eslint prebid/validate-imports: "off" */
+import {registerVideoSupport} from '../src/adServerManager.js';
+import {buildDfpVideoUrl, getVastXml, notifyTranslationModule, dep, VAST_TAG_URI_TAGNAME, getBase64BlobContent} from 'modules/dfpAdServerVideo.js';
+
+export const buildGamVideoUrl = buildDfpVideoUrl;
+export { getVastXml, notifyTranslationModule, dep, VAST_TAG_URI_TAGNAME, getBase64BlobContent };
+
+registerVideoSupport('gam', {
+  buildVideoUrl: buildGamVideoUrl,
+  getVastXml
+});

--- a/modules/gamAdpod.js
+++ b/modules/gamAdpod.js
@@ -1,0 +1,10 @@
+/* eslint prebid/validate-imports: "off" */
+import {registerVideoSupport} from '../src/adServerManager.js';
+import {buildAdpodVideoUrl, adpodUtils} from 'modules/dfpAdpod.js';
+
+registerVideoSupport('gam', {
+  buildAdpodVideoUrl,
+  getAdpodTargeting: (args) => adpodUtils.getTargeting(args)
+});
+
+export { buildAdpodVideoUrl, adpodUtils };

--- a/modules/ixBidAdapter.md
+++ b/modules/ixBidAdapter.md
@@ -393,10 +393,10 @@ var adUnits = [{
 
 ### 2. Include `ixBidAdapter` in your build process
 
-When running the build command, include `ixBidAdapter` as a module, as well as `dfpAdServerVideo` if you require video support.
+When running the build command, include `ixBidAdapter` as a module, as well as `gamAdServerVideo` if you require video support.
 
 ```
-gulp build --modules=ixBidAdapter,dfpAdServerVideo,fooBidAdapter,bazBidAdapter
+gulp build --modules=ixBidAdapter,gamAdServerVideo,fooBidAdapter,bazBidAdapter
 ```
 
 If a JSON file is being used to specify the bidder modules, add `"ixBidAdapter"`
@@ -405,7 +405,7 @@ to the top-level array in that file.
 ```json
 [
     "ixBidAdapter",
-    "dfpAdServerVideo",
+    "gamAdServerVideo",
     "fooBidAdapter",
     "bazBidAdapter"
 ]

--- a/modules/sonobiBidAdapter.md
+++ b/modules/sonobiBidAdapter.md
@@ -55,7 +55,7 @@ Example bidsBackHandler for video bids
 pbjs.requestBids({
           timeout : 700,
           bidsBackHandler : function(bids) {
-            var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+            var videoUrl = pbjs.adServers.gam.buildVideoUrl({
                 adUnit: videoAdUnit,
                 params: {
                     cust_params: {

--- a/modules/targetVideoAdServerVideo.md
+++ b/modules/targetVideoAdServerVideo.md
@@ -22,5 +22,5 @@ Where:
     * **`params`:**
         * **`iu`:** required property used to construct valid VAST tag URL
     * **`adUnit`:** ad unit that is being filled
-    * **`bid` [optional]:** if you override the hardcoded `pbjs.adServers.dfp.buildVideoUrl(...)` logic that picks the first bid you *must* pass in the `bid` object you select
-    * **`url`:** VAST tag URL, similar to the value returned by `pbjs.adServers.dfp.buildVideoUrl(...)`
+    * **`bid` [optional]:** if you override the hardcoded `pbjs.adServers.gam.buildVideoUrl(...)` logic that picks the first bid you *must* pass in the `bid` object you select
+    * **`url`:** VAST tag URL, similar to the value returned by `pbjs.adServers.gam.buildVideoUrl(...)`

--- a/modules/videoModule/gamAdServerSubmodule.js
+++ b/modules/videoModule/gamAdServerSubmodule.js
@@ -3,10 +3,10 @@ import { getGlobal } from '../../src/prebidGlobal.js';
 
 /**
  * @class
- * @param {Object} dfpModule_ - the DFP ad server module
+ * @param {Object} gamModule_ - the GAM ad server module
  */
-function GamAdServerProvider(dfpModule_) {
-  const dfp = dfpModule_;
+function GamAdServerProvider(gamModule_) {
+  const dfp = gamModule_;
 
   function getAdTagUrl(adUnit, baseAdTag, params, bid) {
     return dfp.buildVideoUrl({ adUnit: adUnit, url: baseAdTag, params, bid });
@@ -23,7 +23,7 @@ function GamAdServerProvider(dfpModule_) {
 }
 
 export function gamSubmoduleFactory() {
-  const dfp = getGlobal().adServers.dfp;
+  const dfp = getGlobal().adServers.gam;
   const gamProvider = GamAdServerProvider(dfp);
   return gamProvider;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -555,6 +555,6 @@ export function newConfig() {
 
 /**
  * Set a `cache.url` if we should use prebid-cache to store video bids before adding bids to the auction.
- * This must be set if you want to use the dfpAdServerVideo module.
+ * This must be set if you want to use the gamAdServerVideo module.
  */
 export const config = newConfig();

--- a/test/pages/instream.html
+++ b/test/pages/instream.html
@@ -16,7 +16,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-vast-vpaid/2.0.2/videojs_5.vast.vpaid.min.js"></script>
 
     <!-- prebid.js -->
-    <script src="http://localhost:4444/bundle?modules=appnexusBidAdapter&modules=dfpAdServerVideo" async=true></script>
+    <script src="http://localhost:4444/bundle?modules=appnexusBidAdapter&modules=gamAdServerVideo" async=true></script>
 
 
     <script>
@@ -69,7 +69,7 @@
         pbjs.requestBids({
           timeout: 10000,
           bidsBackHandler : function(bids) {
-            var videoUrl = pbjs.adServers.dfp.buildVideoUrl({
+            var videoUrl = pbjs.adServers.gam.buildVideoUrl({
               adUnit: videoAdUnit,
               params: {
                 iu: '/19968336/prebid_cache_video_adunit'

--- a/test/spec/modules/gamAdServerVideo_spec.js
+++ b/test/spec/modules/gamAdServerVideo_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 
 import parse from 'url-parse';
-import {buildDfpVideoUrl, dep} from 'modules/dfpAdServerVideo.js';
+import {buildGamVideoUrl as buildDfpVideoUrl, dep} from 'modules/gamAdServerVideo.js';
 import AD_UNIT from 'test/fixtures/video/adUnit.json';
 import * as utils from 'src/utils.js';
 import {deepClone} from 'src/utils.js';
@@ -14,7 +14,7 @@ import * as adServer from 'src/adserver.js';
 import {hook} from '../../../src/hook.js';
 import {stubAuctionIndex} from '../../helpers/indexStub.js';
 import {AuctionIndex} from '../../../src/auctionIndex.js';
-import { getVastXml } from '../../../modules/dfpAdServerVideo.js';
+import { getVastXml } from '../../../modules/gamAdServerVideo.js';
 import { server } from '../../mocks/xhr.js';
 import { generateUUID } from '../../../src/utils.js';
 

--- a/test/spec/modules/gamAdpod_spec.js
+++ b/test/spec/modules/gamAdpod_spec.js
@@ -2,13 +2,13 @@ import {auctionManager} from '../../../src/auctionManager.js';
 import {config} from '../../../src/config.js';
 import {gdprDataHandler, uspDataHandler} from '../../../src/consentHandler.js';
 import parse from 'url-parse';
-import {buildAdpodVideoUrl} from '../../../modules/dfpAdpod.js';
+import {buildAdpodVideoUrl} from '../../../modules/gamAdpod.js';
 import {expect} from 'chai/index.js';
 import * as utils from '../../../src/utils.js';
 import {server} from '../../mocks/xhr.js';
 import * as adpod from 'modules/adpod.js';
 
-describe('dfpAdpod', function () {
+describe('gamAdpod', function () {
   let amStub;
   let amGetAdUnitsStub;
 

--- a/test/spec/unit/adServerManager_spec.js
+++ b/test/spec/unit/adServerManager_spec.js
@@ -15,21 +15,21 @@ describe('The ad server manager', function () {
 
   it('should register video support to the proper place on the API', function () {
     function videoSupport() { }
-    registerVideoSupport('dfp', { buildVideoUrl: videoSupport });
+    registerVideoSupport('gam', { buildVideoUrl: videoSupport });
 
     expect(prebid).to.have.property('adServers');
-    expect(prebid.adServers).to.have.property('dfp');
-    expect(prebid.adServers.dfp).to.have.property('buildVideoUrl', videoSupport);
+    expect(prebid.adServers).to.have.property('gam');
+    expect(prebid.adServers.gam).to.have.property('buildVideoUrl', videoSupport);
   });
 
   it('should keep the first function when we try to add a second', function () {
     function videoSupport() { }
-    registerVideoSupport('dfp', { buildVideoUrl: videoSupport });
-    registerVideoSupport('dfp', { buildVideoUrl: function noop() { } });
+    registerVideoSupport('gam', { buildVideoUrl: videoSupport });
+    registerVideoSupport('gam', { buildVideoUrl: function noop() { } });
 
     expect(prebid).to.have.property('adServers');
-    expect(prebid.adServers).to.have.property('dfp');
-    expect(prebid.adServers.dfp).to.have.property('buildVideoUrl', videoSupport);
+    expect(prebid.adServers).to.have.property('gam');
+    expect(prebid.adServers.gam).to.have.property('buildVideoUrl', videoSupport);
   });
 
   it('should support any custom named property in the public API', function () {


### PR DESCRIPTION
## Summary
- add `gamAdServerVideo` and `gamAdpod` modules
- alias GAM utilities
- update docs and integration examples
- adjust tests for new names
- add GAM entry in submodules

## Testing
- `npm test` *(fails: Karma tests failed)*