### PR TITLE
adapter: share utilities between hybrid and vox

### DIFF
--- a/libraries/hybridVoxUtils/index.js
+++ b/libraries/hybridVoxUtils/index.js
@@ -1,0 +1,45 @@
+import {Renderer} from '../../src/Renderer.js';
+import {logWarn, deepAccess, isArray} from '../../src/utils.js';
+
+export const outstreamRender = bid => {
+  bid.renderer.push(() => {
+    window.ANOutstreamVideo.renderAd({
+      sizes: [bid.width, bid.height],
+      targetId: bid.adUnitCode,
+      rendererOptions: {
+        showBigPlayButton: false,
+        showProgressBar: 'bar',
+        showVolume: false,
+        allowFullscreen: true,
+        skippable: false,
+        content: bid.vastXml
+      }
+    });
+  });
+};
+
+export function createRenderer(bid, url) {
+  const renderer = Renderer.install({
+    targetId: bid.adUnitCode,
+    url,
+    loaded: false
+  });
+  try {
+    renderer.setRender(outstreamRender);
+  } catch (err) {
+    logWarn('Prebid Error calling setRender on renderer', err);
+  }
+  return renderer;
+}
+
+export function getMediaTypeFromBid(bid) {
+  return bid.mediaTypes && Object.keys(bid.mediaTypes)[0];
+}
+
+export function hasVideoMandatoryParams(mediaTypes) {
+  const isHasVideoContext = !!mediaTypes.video &&
+    (mediaTypes.video.context === 'instream' || mediaTypes.video.context === 'outstream');
+  const isPlayerSize = !!deepAccess(mediaTypes, 'video.playerSize') &&
+    isArray(deepAccess(mediaTypes, 'video.playerSize'));
+  return isHasVideoContext && isPlayerSize;
+}

--- a/modules/hybridBidAdapter.js
+++ b/modules/hybridBidAdapter.js
@@ -1,8 +1,8 @@
-import {_map, deepAccess, isArray, logWarn} from '../src/utils.js';
+import {_map, isArray} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {Renderer} from '../src/Renderer.js';
 import {find} from '../src/polyfill.js';
+import {createRenderer, getMediaTypeFromBid, hasVideoMandatoryParams} from '../libraries/hybridVoxUtils/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -42,38 +42,6 @@ function buildBidRequests(validBidRequests) {
   })
 }
 
-const outstreamRender = bid => {
-  bid.renderer.push(() => {
-    window.ANOutstreamVideo.renderAd({
-      sizes: [bid.width, bid.height],
-      targetId: bid.adUnitCode,
-      rendererOptions: {
-        showBigPlayButton: false,
-        showProgressBar: 'bar',
-        showVolume: false,
-        allowFullscreen: true,
-        skippable: false,
-        content: bid.vastXml
-      }
-    });
-  });
-}
-
-const createRenderer = (bid) => {
-  const renderer = Renderer.install({
-    targetId: bid.adUnitCode,
-    url: RENDERER_URL,
-    loaded: false
-  });
-
-  try {
-    renderer.setRender(outstreamRender);
-  } catch (err) {
-    logWarn('Prebid Error calling setRender on renderer', err);
-  }
-
-  return renderer;
-}
 
 function buildBid(bidData) {
   const bid = {
@@ -101,7 +69,7 @@ function buildBid(bidData) {
       bid.height = video.playerSize[0][1];
 
       if (video.context === 'outstream') {
-        bid.renderer = createRenderer(bid);
+        bid.renderer = createRenderer(bid, RENDERER_URL);
       }
     }
   } else if (bidData.placement === PLACEMENT_TYPE_IN_IMAGE) {
@@ -139,19 +107,6 @@ function buildBid(bidData) {
   return bid;
 }
 
-function getMediaTypeFromBid(bid) {
-  return bid.mediaTypes && Object.keys(bid.mediaTypes)[0]
-}
-
-function hasVideoMandatoryParams(mediaTypes) {
-  const isHasVideoContext = !!mediaTypes.video && (mediaTypes.video.context === 'instream' || mediaTypes.video.context === 'outstream');
-
-  const isPlayerSize =
-    !!deepAccess(mediaTypes, 'video.playerSize') &&
-    isArray(deepAccess(mediaTypes, 'video.playerSize'));
-
-  return isHasVideoContext && isPlayerSize;
-}
 
 function wrapAd(bid, bidData) {
   return `<!DOCTYPE html>


### PR DESCRIPTION
## Summary
- extract shared helper functions from Hybrid and Vox adapters into `hybridVoxUtils`
- use the new helpers in both adapters

## Testing
- `eslint modules/hybridBidAdapter.js modules/voxBidAdapter.js libraries/hybridVoxUtils/index.js`
- `gulp test --file test/spec/modules/hybridBidAdapter_spec.js` *(fails: no output)*
