### PR TITLE
adapter: move common functions to library

### DIFF
--- a/libraries/appnexusUtils/bidderUtils.js
+++ b/libraries/appnexusUtils/bidderUtils.js
@@ -1,0 +1,42 @@
+import {isFn, isPlainObject} from '../../src/utils.js';
+
+export function hasUserInfo(bid) {
+  return !!(bid.params && bid.params.user);
+}
+
+export function hasAppDeviceInfo(bid) {
+  return !!(bid.params && bid.params.app);
+}
+
+export function hasAppId(bid) {
+  return !!(bid.params && bid.params.app && bid.params.app.id);
+}
+
+export function addUserId(eids, id, source, rti) {
+  if (id) {
+    if (rti) {
+      eids.push({source, id, rti_partner: rti});
+    } else {
+      eids.push({source, id});
+    }
+  }
+  return eids;
+}
+
+export function getBidFloor(bid, currency = 'USD') {
+  if (!isFn(bid.getFloor)) {
+    return bid.params && bid.params.reserve ? bid.params.reserve : null;
+  }
+
+  const floor = bid.getFloor({
+    currency,
+    mediaType: '*',
+    size: '*'
+  });
+
+  if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === currency) {
+    return floor.floor;
+  }
+
+  return null;
+}

--- a/modules/adrelevantisBidAdapter.js
+++ b/modules/adrelevantisBidAdapter.js
@@ -20,6 +20,8 @@ import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
 import {chunk} from '../libraries/chunk/chunk.js';
+import {transformSizes} from '../libraries/sizeUtils/tranformSize.js';
+import {hasUserInfo, hasAppDeviceInfo, hasAppId} from '../libraries/appnexusUtils/bidderUtils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -492,46 +494,6 @@ function bidToTag(bid) {
   }
 
   return tag;
-}
-
-/* Turn bid request sizes into ut-compatible format */
-function transformSizes(requestSizes) {
-  let sizes = [];
-  let sizeObj = {};
-
-  if (isArray(requestSizes) && requestSizes.length === 2 &&
-    !isArray(requestSizes[0])) {
-    sizeObj.width = parseInt(requestSizes[0], 10);
-    sizeObj.height = parseInt(requestSizes[1], 10);
-    sizes.push(sizeObj);
-  } else if (typeof requestSizes === 'object') {
-    for (let i = 0; i < requestSizes.length; i++) {
-      let size = requestSizes[i];
-      sizeObj = {};
-      sizeObj.width = parseInt(size[0], 10);
-      sizeObj.height = parseInt(size[1], 10);
-      sizes.push(sizeObj);
-    }
-  }
-
-  return sizes;
-}
-
-function hasUserInfo(bid) {
-  return !!bid.params.user;
-}
-
-function hasAppDeviceInfo(bid) {
-  if (bid.params) {
-    return !!bid.params.app
-  }
-}
-
-function hasAppId(bid) {
-  if (bid.params && bid.params.app) {
-    return !!bid.params.app.id
-  }
-  return !!bid.params.app
 }
 
 function getRtbBid(tag) {

--- a/modules/pixfutureBidAdapter.js
+++ b/modules/pixfutureBidAdapter.js
@@ -3,10 +3,12 @@ import {getStorageManager} from '../src/storageManager.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import {find, includes} from '../src/polyfill.js';
-import {deepAccess, isArray, isFn, isNumber, isPlainObject} from '../src/utils.js';
+import {deepAccess, isArray, isNumber, isPlainObject} from '../src/utils.js';
 import {auctionManager} from '../src/auctionManager.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
 import {convertCamelToUnderscore} from '../libraries/appnexusUtils/anUtils.js';
+import {transformSizes} from '../libraries/sizeUtils/tranformSize.js';
+import {addUserId, hasUserInfo, getBidFloor} from '../libraries/appnexusUtils/bidderUtils.js';
 
 const SOURCE = 'pbjs';
 const storageManager = getStorageManager({bidderCode: 'pixfuture'});
@@ -301,57 +303,6 @@ function bidToTag(bid) {
   return tag;
 }
 
-function addUserId(eids, id, source, rti) {
-  if (id) {
-    if (rti) {
-      eids.push({source, id, rti_partner: rti});
-    } else {
-      eids.push({source, id});
-    }
-  }
-  return eids;
-}
 
-function hasUserInfo(bid) {
-  return !!bid.params.user;
-}
-
-function transformSizes(requestSizes) {
-  let sizes = [];
-  let sizeObj = {};
-
-  if (isArray(requestSizes) && requestSizes.length === 2 &&
-            !isArray(requestSizes[0])) {
-    sizeObj.width = parseInt(requestSizes[0], 10);
-    sizeObj.height = parseInt(requestSizes[1], 10);
-    sizes.push(sizeObj);
-  } else if (typeof requestSizes === 'object') {
-    for (let i = 0; i < requestSizes.length; i++) {
-      let size = requestSizes[i];
-      sizeObj = {};
-      sizeObj.width = parseInt(size[0], 10);
-      sizeObj.height = parseInt(size[1], 10);
-      sizes.push(sizeObj);
-    }
-  }
-
-  return sizes;
-}
-
-function getBidFloor(bid) {
-  if (!isFn(bid.getFloor)) {
-    return (bid.params.reserve) ? bid.params.reserve : null;
-  }
-
-  let floor = bid.getFloor({
-    currency: 'USD',
-    mediaType: '*',
-    size: '*'
-  });
-  if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === 'USD') {
-    return floor.floor;
-  }
-  return null;
-}
 
 registerBidder(spec);

--- a/modules/ventesBidAdapter.js
+++ b/modules/ventesBidAdapter.js
@@ -4,6 +4,7 @@ import {find} from '../src/polyfill.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import {convertCamelToUnderscore} from '../libraries/appnexusUtils/anUtils.js';
+import {hasUserInfo} from '../libraries/appnexusUtils/bidderUtils.js';
 
 const BID_METHOD = 'POST';
 const BIDDER_URL = 'https://ad.ventesavenues.in/va/ad';
@@ -54,9 +55,6 @@ function validateMediaSizes(mediaSize) {
       mediaSize.every(size => (isNumber(size) && size >= 0));
 }
 
-function hasUserInfo(bid) {
-  return !!bid.params.user;
-}
 
 function validateParameters(parameters) {
   if (!(parameters.placementId)) {

--- a/modules/winrBidAdapter.js
+++ b/modules/winrBidAdapter.js
@@ -3,7 +3,6 @@ import {
   getBidRequest,
   getParameterByName,
   isArray,
-  isFn,
   isNumber,
   isPlainObject,
   logError
@@ -17,6 +16,7 @@ import {hasPurpose1Consent} from '../src/utils/gdpr.js';
 import {getANKeywordParam} from '../libraries/appnexusUtils/anKeywords.js';
 import {convertCamelToUnderscore} from '../libraries/appnexusUtils/anUtils.js';
 import { transformSizes } from '../libraries/sizeUtils/tranformSize.js';
+import {addUserId, hasUserInfo, hasAppDeviceInfo, hasAppId, getBidFloor} from '../libraries/appnexusUtils/bidderUtils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -471,27 +471,6 @@ function bidToTag(bid) {
   return tag;
 }
 
-function hasUserInfo(bid) {
-  return !!bid.params.user;
-}
-
-function hasMemberId(bid) {
-  return !!parseInt(bid.params.member, 10);
-}
-
-function hasAppDeviceInfo(bid) {
-  if (bid.params) {
-    return !!bid.params.app
-  }
-}
-
-function hasAppId(bid) {
-  if (bid.params && bid.params.app) {
-    return !!bid.params.app.id
-  }
-  return !!bid.params.app
-}
-
 function getRtbBid(tag) {
   return tag && tag.ads && tag.ads.length && find(tag.ads, (ad) => ad.rtb);
 }
@@ -504,31 +483,9 @@ function parseMediaType(rtbBid) {
   return BANNER;
 }
 
-function addUserId(eids, id, source, rti) {
-  if (id) {
-    if (rti) {
-      eids.push({ source, id, rti_partner: rti });
-    } else {
-      eids.push({ source, id });
-    }
-  }
-  return eids;
+function hasMemberId(bid) {
+  return !!parseInt(bid.params.member, 10);
 }
 
-function getBidFloor(bid) {
-  if (!isFn(bid.getFloor)) {
-    return (bid.params.reserve) ? bid.params.reserve : null;
-  }
-
-  let floor = bid.getFloor({
-    currency: 'USD',
-    mediaType: '*',
-    size: '*'
-  });
-  if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === 'USD') {
-    return floor.floor;
-  }
-  return null;
-}
 
 registerBidder(spec);


### PR DESCRIPTION
## Summary
- deduplicate helper methods in a new library
- reuse shared utils in adrelevantis, pixfuture, ventes and winr adapters

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/modules/adrelevantisBidAdapter_spec.js`
- `npx gulp test --file test/spec/modules/pixfutureBidAdapter_spec.js`
- `npx gulp test --file test/spec/modules/ventesBidAdapter_spec.js`
- `npx gulp test --file test/spec/modules/winrBidAdapter_spec.js`
