### PR TITLE
Deprecate getAllPrebidWinningBids

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -922,10 +922,15 @@ pbjsInstance.getAllWinningBids = function () {
 };
 
 /**
- * Get all of the bids that have won their respective auctions.
- * @return {Array<AdapterBidResponse>} A list of bids that have won their respective auctions.
+ * Deprecated. Returns bids that have had targeting set but haven't been rendered yet.
+ * This method does not return all winning bids after auctions complete.
+ * Use `pbjs.getAllWinningBids()` for the complete list of winners.
+ * @deprecated
+ * @return {Array<AdapterBidResponse>} Bids that have had targeting set and not yet rendered.
  */
 pbjsInstance.getAllPrebidWinningBids = function () {
+  logWarn('pbjs.getAllPrebidWinningBids is deprecated and will be removed in a future release. ' +
+    'It returns bids that have had targeting set but not yet rendered. Use pbjs.getAllWinningBids instead.');
   return auctionManager.getBidsReceived()
     .filter(bid => bid.status === BID_STATUS.BID_TARGETING_SET);
 };

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -3889,15 +3889,18 @@ describe('Unit: Prebid Module', function () {
 
   describe('getAllPrebidWinningBids', function () {
     let auctionManagerStub;
+    let logWarnSpy;
     beforeEach(function () {
       auctionManagerStub = sinon.stub(auctionManager, 'getBidsReceived');
+      logWarnSpy = sandbox.spy(utils, 'logWarn');
     });
 
     afterEach(function () {
       auctionManagerStub.restore();
+      logWarnSpy.restore();
     });
 
-    it('should return prebid auction winning bids', function () {
+    it('should warn about deprecation and return bids with targeting set', function () {
       let bidsReceived = [
         createBidReceived({bidder: 'appnexus', cpm: 7, auctionId: 1, responseTimestamp: 100, adUnitCode: 'code-0', adId: 'adid-1', status: 'targetingSet', requestId: 'reqid-1'}),
         createBidReceived({bidder: 'rubicon', cpm: 6, auctionId: 1, responseTimestamp: 101, adUnitCode: 'code-1', adId: 'adid-2', requestId: 'reqid-2'}),
@@ -3907,8 +3910,9 @@ describe('Unit: Prebid Module', function () {
       auctionManagerStub.returns(bidsReceived)
       let bids = $$PREBID_GLOBAL$$.getAllPrebidWinningBids();
 
-      expect(bids.length).to.equal(1); sandbox
+      expect(bids.length).to.equal(1);
       expect(bids[0].adId).to.equal('adid-1');
+      sinon.assert.calledOnce(logWarnSpy);
     });
   });
 


### PR DESCRIPTION
## Summary
- deprecate `pbjs.getAllPrebidWinningBids` with a warning
- add unit test for the deprecation
- remove README changes per feedback

## Testing
- `npm test` *(fails: Webpack bundling step could not finish in this environment)*