### PR TITLE
Implement yield utility and disable GREEDY by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Or, if you are consuming Prebid through npm, with the `disableFeatures` option i
   }
 ```
 
-Features that can be disabled this way are:
+Features that can be enabled or disabled this way are:
 
  - `VIDEO` - support for video bids;
  - `NATIVE` - support for native bids;
@@ -236,8 +236,7 @@ Features that can be disabled this way are:
 
 #### Greedy promises
 
-By default, Prebid attempts to hold control of the main thread when possible, using a [custom implementation of `Promise`](https://github.com/prebid/Prebid.js/blob/master/libraries/greedy/greedyPromise.js) that does not submit callbacks to the scheduler once the promise is resolved (running them immediately instead).
-Disabling this behavior instructs Prebid to use the standard `window.Promise` instead; this has the effect of breaking up task execution, making them slower overall but giving the browser more chances to run other tasks in between, which can improve UX.         
+When the `GREEDY` feature is enabled, Prebid attempts to hold control of the main thread when possible, using a [custom implementation of `Promise`](https://github.com/prebid/Prebid.js/blob/master/libraries/greedy/greedyPromise.js) that does not submit callbacks to the scheduler once the promise is resolved (running them immediately instead). By default this behavior is disabled and Prebid uses the standard `window.Promise`; enabling it can reduce scheduling breaks but may degrade responsiveness.
 
 You may also override the `Promise` constructor used by Prebid through `pbjs.Promise`, for example:
 

--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -175,9 +175,13 @@ module.exports = {
     return options;
   },
   getDisabledFeatures() {
-    return (argv.disable || '')
+    const disabled = (argv.disable || '')
       .split(',')
       .map((s) => s.trim())
       .filter((s) => s);
+    if (!disabled.map((s) => s.toUpperCase()).includes('GREEDY')) {
+      disabled.push('GREEDY');
+    }
+    return disabled;
   },
 };

--- a/src/auction.js
+++ b/src/auction.js
@@ -93,6 +93,7 @@ import * as events from './events.js';
 import adapterManager from './adapterManager.js';
 import {EVENTS, GRANULARITY_OPTIONS, JSON_MAPPING, REJECTION_REASON, S2S, TARGETING_KEYS} from './constants.js';
 import {defer, PbPromise} from './utils/promise.js';
+import {pbYield} from './utils/yield.js';
 import {useMetrics} from './utils/perfMetrics.js';
 import {adjustCpm} from './utils/cpm.js';
 import {getGlobal} from './prebidGlobal.js';
@@ -465,9 +466,11 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
     if (allAdapterCalledDone && outstandingBidsAdded === 0) {
       auctionDone()
     }
+    pbYield();
   }
 
   function handleBidResponse(adUnitCode, bid, handler) {
+    pbYield();
     bidResponseMap[bid.requestId] = true;
     addCommonResponseProperties(bid, adUnitCode)
     outstandingBidsAdded++;

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -37,6 +37,7 @@ import { BID_STATUS, EVENTS, NATIVE_KEYS } from './constants.js';
 import * as events from './events.js';
 import {newMetrics, useMetrics} from './utils/perfMetrics.js';
 import {defer, PbPromise} from './utils/promise.js';
+import {pbYield} from './utils/yield.js';
 import {enrichFPD} from './fpd/enrichment.js';
 import {allConsent} from './consentHandler.js';
 import {
@@ -530,6 +531,7 @@ pbjsInstance.setTargetingForAst = function (adUnitCodes) {
 pbjsInstance.renderAd = hook('async', function (doc, id, options) {
   logInfo('Invoking $$PREBID_GLOBAL$$.renderAd', arguments);
   logMessage('Calling renderAd with adId :' + id);
+  pbYield();
   renderAdDirect(doc, id, options);
 });
 
@@ -1039,6 +1041,7 @@ function processQueue(queue) {
         logError('Error processing command :', 'prebid.js', e);
       }
     }
+    pbYield();
   });
 }
 

--- a/src/utils/yield.js
+++ b/src/utils/yield.js
@@ -1,0 +1,7 @@
+import {getGlobal} from '../prebidGlobal.js';
+import {PbPromise} from './promise.js';
+
+export function pbYield() {
+  const scheduler = getGlobal().scheduler;
+  return scheduler?.yield ? scheduler.yield() : PbPromise.resolve();
+}


### PR DESCRIPTION
## Summary
- implement pbYield utility for cooperative scheduling
- yield when handling bids, processing the queue, and before rendering ads
- disable the GREEDY promise by default while keeping the feature available

## Testing
- `npm test` *(fails: tests hang and were interrupted)*