### PR TITLE
ci: add Coveralls workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,32 @@
+name: Upload coverage to Coveralls
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  coveralls:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests with coverage
+        run: npx gulp test-coverage
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./build/coverage/lcov.info
+          parallel: false
+          flag-name: run-${{ github.run_id }}
+
+# added by codex agent
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that sends coverage reports to Coveralls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6839fa57e660832bbb25dcb3079f2704