### PR TITLE
core: enable no trailing spaces in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -242,7 +242,7 @@ module.exports = [
       'default-case-last': 'off',
       '@stylistic/no-mixed-spaces-and-tabs': 'off',
       '@stylistic/no-tabs': 'off',
-      '@stylistic/no-trailing-spaces': 'off'
+      '@stylistic/no-trailing-spaces': 'error'
     }
   })
 ]

--- a/test/fake-server/README.md
+++ b/test/fake-server/README.md
@@ -9,9 +9,9 @@ All the `request-response` pairs are stored in the `fixtures/` directory. They a
 
 Follow the steps below to add another `request-response` pair.
 
-1. Inside the `/fixtures` directory, create a directory and give it a suitable name. 
-  - If you are creating a one-off type of test, you can name this directory with a name that describes the test; for example `basic-banner`.  
-  - If you plan to create a series of tests focusing on one feature/topic, then you can create a generic container directory to hold all your tests together; for example `longform`.  
+1. Inside the `/fixtures` directory, create a directory and give it a suitable name.
+  - If you are creating a one-off type of test, you can name this directory with a name that describes the test; for example `basic-banner`.
+  - If you plan to create a series of tests focusing on one feature/topic, then you can create a generic container directory to hold all your tests together; for example `longform`.
   - If you did the latter case, please proceed to create the necessary test directories describing them with a meaningful and **unique** test name.
 2. If you are planning to handle multiple bidder requests as part of your tests, you will need to create a specific directory for each request.  For example, you could create a pair named like so `longform_biddersettings_1` and `longform_biddersettings_2`.
 3. Once all your directories are created, inside the bottom test folder(s), create **three files**:

--- a/test/helpers/testing-utils.js
+++ b/test/helpers/testing-utils.js
@@ -1,4 +1,4 @@
- 
+
 const {expect} = require('chai');
 const DEFAULT_TIMEOUT = 2000;
 const utils = {

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -172,7 +172,7 @@ describe('FPD enrichment', () => {
     testWindows(() => win, () => {
       it('sets w/h', () => {
         const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions');
-        
+
         getWinDimensionsStub.returns({screen: {width: 321, height: 123}});
         return fpd().then(ortb2 => {
           sinon.assert.match(ortb2.device, {

--- a/test/spec/libraries/greedy/greedyPromise_spec.js
+++ b/test/spec/libraries/greedy/greedyPromise_spec.js
@@ -24,7 +24,7 @@ describe('GreedyPromise', () => {
     let makePromise, pendingFailure, pendingSuccess;
 
     Object.entries({
-       
+
       'resolver that throws': (P) => new P(() => { throw 'error' }),
       'resolver that resolves multiple times': (P) => new P((resolve) => { resolve('first'); resolve('second'); }),
       'resolver that rejects multiple times': (P) => new P((resolve, reject) => { reject('first'); reject('second') }),
@@ -74,7 +74,7 @@ describe('GreedyPromise', () => {
           .finally(() => pendingSuccess.then(() => { fval = 'finally' }))
           .catch((err) => `${err} ${fval}`)
       },
-       
+
       '.finally that throws': (P) => makePromise(P, 'value').finally(() => { throw 'error' }),
       'chained .finally that rejects': (P) => makePromise(P, 'value').finally(() => P.reject('error')),
       'scalar Promise.resolve': (P) => P.resolve('scalar'),

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -1,5 +1,5 @@
 // jshint esversion: 6, es3: false, node: true
- 
+
 import { assert } from 'chai';
 import { spec } from 'modules/adfBidAdapter.js';
 import { config } from 'src/config.js';

--- a/test/spec/modules/contxtfulBidAdapter_spec.js
+++ b/test/spec/modules/contxtfulBidAdapter_spec.js
@@ -154,7 +154,7 @@ describe('contxtful bid adapter', function () {
         },
         enumerable: true
       });
-      
+
       const result = safeStringify(problematicObj);
       // Should not throw and should return a string
       expect(result).to.be.a('string');
@@ -165,7 +165,7 @@ describe('contxtful bid adapter', function () {
         name: 'test',
         windowRef: window
       };
-      
+
       const result = safeStringify(objWithWindow);
       expect(result).to.include('[Browser Object]');
       expect(result).to.include('"name":"test"');
@@ -177,20 +177,20 @@ describe('contxtful bid adapter', function () {
         safeData: 'value',
         normalProperty: 'normal'
       };
-      
+
       // Instead of testing property access errors (which can break entire stringify),
       // let's test that the function handles objects that contain browser objects
       // which should be converted to [Inaccessible Object] or [Browser Object]
       if (typeof window !== 'undefined') {
         problematicObj.browserRef = window;
       }
-      
+
       const result = safeStringify(problematicObj);
       expect(result).to.be.a('string');
       expect(result).to.include('"name":"test"');
       expect(result).to.include('"safeData":"value"');
       expect(result).to.include('"normalProperty":"normal"');
-      
+
       if (typeof window !== 'undefined') {
         expect(result).to.include('[Browser Object]');
       }
@@ -203,7 +203,7 @@ describe('contxtful bid adapter', function () {
         circular: null
       };
       mixedObj.circular = mixedObj; // Create circular reference
-      
+
       const result = safeStringify(mixedObj);
       expect(result).to.include('[Browser Object]');
       expect(result).to.include('[Circular]');
@@ -281,7 +281,7 @@ describe('contxtful bid adapter', function () {
       const result = safeStringify(objWithBrowserObjects);
       expect(result).to.be.a('string');
       expect(result).to.include('"name":"test"');
-      
+
       // Current implementation only detects Window, Document, HTMLElement, Node
       // It doesn't detect navigator, location, etc. as browser objects
       if (typeof window !== 'undefined' || typeof document !== 'undefined') {
@@ -359,7 +359,7 @@ describe('contxtful bid adapter', function () {
 
       // Add objects that should be caught by duck typing (constructor name patterns)
       const mockObjects = [];
-      
+
       // Mock HTMLCanvasElement (constructor name contains 'HTML' and 'Canvas')
       function HTMLCanvasElement() {}
       const mockCanvas = Object.create(HTMLCanvasElement.prototype);
@@ -377,7 +377,7 @@ describe('contxtful bid adapter', function () {
       expect(result).to.include('"normalData":"safe-value"');
       expect(result).to.include('"number":42');
       expect(result).to.include('[Browser Object]');
-      
+
       // Should not contain the actual browser object data
       expect(result).to.not.include('HTMLCanvasElement');
       expect(result).to.not.include('CSSStyleDeclaration');
@@ -401,7 +401,7 @@ describe('contxtful bid adapter', function () {
       const result = safeStringify(testObj);
       expect(result).to.be.a('string');
       expect(result).to.include('"safeData":"value"');
-      
+
       // Only expect [Browser Object] if we actually added detectable browser objects
       if (typeof document !== 'undefined' || typeof window !== 'undefined') {
         expect(result).to.include('[Browser Object]');

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -333,7 +333,7 @@ describe('C-WIRE bid adapter', () => {
       const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
 
       expect(userSyncs[0].type).to.equal('image');
-      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=0&gdpr_consent=testConsentString');    
+      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=0&gdpr_consent=testConsentString');
     })
 
     it('user-syncs with enabled iframe option', function () {
@@ -352,7 +352,7 @@ describe('C-WIRE bid adapter', () => {
       const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
 
       expect(userSyncs[0].type).to.equal('iframe');
-      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=abc123');    
+      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=abc123');
     })
   })
 });

--- a/test/spec/modules/enrichmentLiftMeasurement_spec.js
+++ b/test/spec/modules/enrichmentLiftMeasurement_spec.js
@@ -19,7 +19,7 @@ describe('enrichmentLiftMeasurement', () => {
     config.resetConfig();
     reset();
   })
-  
+
   it('should properly split traffic basing on percentage', () => {
     const TEST_SAMPLE_SIZE = 1000;
     const MARGIN_OF_ERROR = 0.05;
@@ -56,13 +56,13 @@ describe('enrichmentLiftMeasurement', () => {
 
     mathRandomStub.restore();
   });
-  
+
   describe('should register activity based on suppression param', () => {
     Object.entries({
       [suppressionMethod.EIDS]: false,
       [suppressionMethod.SUBMODULES]: true
     }).forEach(([method, value]) => {
-      it(method, () => {					
+      it(method, () => {
         config.setConfig({ enrichmentLiftMeasurement: {
           suppression: method,
           modules: [
@@ -123,7 +123,7 @@ describe('enrichmentLiftMeasurement', () => {
         sessionStorageIsEnabled: () => true,
         getDataFromSessionStorage: sinon.stub().returns(null),
         setDataInSessionStorage: sinon.stub()
-      };			
+      };
       init(fakeStorageManager);
       sinon.assert.calledOnce(fakeStorageManager.setDataInSessionStorage);
       sinon.assert.calledOnce(getCalculatedSubmodulesStub);
@@ -148,7 +148,7 @@ describe('enrichmentLiftMeasurement', () => {
         storeSplits: storeSplitsMethod.SESSION_STORAGE,
         modules: mockConfig.map(module => ({...module, percentage: 0.1}))
       }});
-      
+
       init(fakeStorageManager);
 
       sinon.assert.calledOnce(fakeStorageManager.setDataInSessionStorage);
@@ -168,7 +168,7 @@ describe('enrichmentLiftMeasurement', () => {
         testRun: TEST_RUN_ID,
         storeSplits: storeSplitsMethod.PAGE
       }});
-      
+
       init();
 
       const eventType = EVENTS.BID_WON;
@@ -189,7 +189,7 @@ describe('enrichmentLiftMeasurement', () => {
       };
       const stringifiedConfig = JSON.stringify(expectedResult);
 
-      Object.entries({ 
+      Object.entries({
         [LOCAL_STORAGE]: localStorage,
         [SESSION_STORAGE]: sessionStorage,
       }).forEach(([method, storage]) => {
@@ -206,7 +206,7 @@ describe('enrichmentLiftMeasurement', () => {
       const { LOCAL_STORAGE, SESSION_STORAGE } = storeSplitsMethod;
       const TEST_RUN_ID = 'ExperimentA';
 
-      Object.entries({ 
+      Object.entries({
         [LOCAL_STORAGE]: localStorage,
         [SESSION_STORAGE]: sessionStorage,
       }).forEach(([method, storage]) => {

--- a/test/spec/modules/iasRtdProvider_spec.js
+++ b/test/spec/modules/iasRtdProvider_spec.js
@@ -181,7 +181,7 @@ describe('iasRtdProvider is a RTD provider that', function () {
       });
       it('it merges response data', function () {
         const callback = sinon.spy();
-        
+
         iasSubModule.getBidRequestData({
           adUnits: [
             {code: 'adunit-1'},
@@ -201,7 +201,7 @@ describe('iasRtdProvider is a RTD provider that', function () {
         expect(targeting1['adunit-2']['adt']).to.be.eq('veryLow');
         expect(targeting1['adunit-2']['fr']).to.be.eq('false');
         expect(targeting1['adunit-2']['ias_id']).to.be.eq('id2');
-        
+
         iasSubModule.getBidRequestData({
           adUnits: [
             {code: 'adunit-2'},

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -26,7 +26,7 @@ describe('ID5 ID System', function () {
   });
   after(function () {
     logInfoStub.restore();
-  });  
+  });
   const ID5_MODULE_NAME = 'id5Id';
   const ID5_EIDS_NAME = ID5_MODULE_NAME.toLowerCase();
   const ID5_SOURCE = 'id5-sync.com';

--- a/test/spec/modules/intentIqAnalyticsAdapter_spec.js
+++ b/test/spec/modules/intentIqAnalyticsAdapter_spec.js
@@ -141,19 +141,19 @@ describe('IntentIQ tests all', function () {
   it('should send POST request with payload in request body if reportMethod is POST', function () {
     const [userConfig] = getUserConfig();
     userConfig.params.reportMethod = 'POST';
-  
+
     config.getConfig.restore();
     sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns([userConfig]);
-  
+
     localStorage.setItem(FIRST_PARTY_KEY, defaultData);
-  
+
     events.emit(EVENTS.BID_WON, wonRequest);
-  
+
     const request = server.requests[0];
-  
+
     const expectedData = preparePayload(wonRequest);
     const expectedPayload = `["${btoa(JSON.stringify(expectedData))}"]`;
-  
+
     expect(request.method).to.equal('POST');
     expect(request.requestBody).to.equal(expectedPayload);
   });
@@ -162,25 +162,25 @@ describe('IntentIQ tests all', function () {
     const [userConfig] = getUserConfig();
     config.getConfig.restore();
     sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns([userConfig]);
-  
+
     localStorage.setItem(FIRST_PARTY_KEY, defaultData);
     events.emit(EVENTS.BID_WON, wonRequest);
-  
+
     const request = server.requests[0];
-  
+
     expect(request.method).to.equal('GET');
-  
+
     const url = new URL(request.url);
     const payloadEncoded = url.searchParams.get('payload');
     const decoded = JSON.parse(atob(JSON.parse(payloadEncoded)[0]));
-  
+
     const expected = preparePayload(wonRequest);
-  
+
     expect(decoded.partnerId).to.equal(expected.partnerId);
     expect(decoded.adType).to.equal(expected.adType);
     expect(decoded.prebidAuctionId).to.equal(expected.prebidAuctionId);
   });
-  
+
   it('IIQ Analytical Adapter bid win report', function () {
     localStorage.setItem(FIRST_PARTY_KEY, defaultData);
     getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns({href: 'http://localhost:9876'});
@@ -430,8 +430,8 @@ describe('IntentIQ tests all', function () {
   });
 
   it('should include source parameter in report URL', function () {
-    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify(defaultData));  
-    
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify(defaultData));
+
     events.emit(EVENTS.BID_WON, wonRequest);
     const request = server.requests[0];
 
@@ -462,17 +462,17 @@ describe('IntentIQ tests all', function () {
       parameterValue: 'Lee',
       destination: [0, 0, 1]
     }];
-  
+
     config.getConfig.restore();
     sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns(userConfig);
-  
+
     localStorage.setItem(FIRST_PARTY_KEY, defaultData);
     events.emit(EVENTS.BID_WON, wonRequest);
-  
+
     const request = server.requests[0];
     expect(request.url).to.include('general=Lee');
   });
-  
+
   it('should not send additionalParams in report if value is too large', function () {
     const longVal = 'x'.repeat(5000000);
     const userConfig = getUserConfig();
@@ -481,21 +481,21 @@ describe('IntentIQ tests all', function () {
       parameterValue: longVal,
       destination: [0, 0, 1]
     }];
-  
+
     config.getConfig.restore();
     sinon.stub(config, 'getConfig').withArgs('userSync.userIds').returns(userConfig);
-  
+
     localStorage.setItem(FIRST_PARTY_KEY, defaultData);
     events.emit(EVENTS.BID_WON, wonRequest);
-  
+
     const request = server.requests[0];
     expect(request.url).not.to.include('general');
-  });  
+  });
   it('should include spd parameter from LS in report URL', function () {
     const spdObject = { foo: 'bar', value: 42 };
     const expectedSpdEncoded = encodeURIComponent(JSON.stringify(spdObject));
 
-    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({...defaultData, spd: spdObject}));  
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({...defaultData, spd: spdObject}));
     getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns({ href: 'http://localhost:9876/' });
 
     events.emit(EVENTS.BID_WON, wonRequest);
@@ -510,7 +510,7 @@ describe('IntentIQ tests all', function () {
     const spdObject = 'server provided data';
     const expectedSpdEncoded = encodeURIComponent(spdObject);
 
-    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({...defaultData, spd: spdObject}));  
+    localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify({...defaultData, spd: spdObject}));
     getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns({ href: 'http://localhost:9876/' });
 
     events.emit(EVENTS.BID_WON, wonRequest);

--- a/test/spec/modules/intentIqIdSystem_spec.js
+++ b/test/spec/modules/intentIqIdSystem_spec.js
@@ -193,9 +193,9 @@ describe('IntentIQ tests', function () {
       }
     });
     const currentBrowserLowerCase = detectBrowser();
-    
+
     if (currentBrowserLowerCase === usedBrowser) {
-      const at20request = server.requests[0];   
+      const at20request = server.requests[0];
       expect(at20request.url).to.contain(`&source=${PREBID}`);
       expect(at20request.url).to.contain(`at=20`);
     }
@@ -205,10 +205,10 @@ describe('IntentIQ tests', function () {
   it('should send at=39 request and send source in it', function () {
     const callBackSpy = sinon.spy();
     const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
-  
+
     submoduleCallback(callBackSpy);
     const request = server.requests[0];
-  
+
     expect(request.url).to.contain(`&source=${PREBID}`);
   });
 
@@ -436,7 +436,7 @@ describe('IntentIQ tests', function () {
       browserBlackList: 'chrome'
       }
     });
-    
+
     const at20request = server.requests[0];
     expect(at20request.url).to.contain(`&spd=${encodedSpd}`);
     expect(at20request.url).to.contain(`at=20`);
@@ -452,12 +452,12 @@ describe('IntentIQ tests', function () {
       browserBlackList: 'chrome'
       }
     });
-    
-    const at20request = server.requests[0];   
+
+    const at20request = server.requests[0];
     expect(at20request.url).to.contain(`&spd=${encodedSpd}`);
     expect(at20request.url).to.contain(`at=20`);
   });
-  
+
   it('should send spd from firstPartyData in localStorage in at=39 request', function () {
     const spdValue = { foo: 'bar', value: 42 };
     const encodedSpd = encodeURIComponent(JSON.stringify(spdValue));
@@ -466,10 +466,10 @@ describe('IntentIQ tests', function () {
 
     const callBackSpy = sinon.spy();
     const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
-  
+
     submoduleCallback(callBackSpy);
     const request = server.requests[0];
-    
+
     expect(request.url).to.contain(`&spd=${encodedSpd}`);
     expect(request.url).to.contain(`at=39`);
   });
@@ -481,7 +481,7 @@ describe('IntentIQ tests', function () {
 
     const callBackSpy = sinon.spy();
     const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
-  
+
     submoduleCallback(callBackSpy);
     const request = server.requests[0];
 
@@ -493,19 +493,19 @@ describe('IntentIQ tests', function () {
     const spdValue = { foo: 'bar', value: 42 };
     let callBackSpy = sinon.spy();
     const submoduleCallback = intentIqIdSubmodule.getId(defaultConfigParams).callback;
-  
+
     submoduleCallback(callBackSpy);
     const request = server.requests[0];
-  
+
     request.respond(
       200,
       responseHeader,
       JSON.stringify({ pid: 'test_pid', data: 'test_personid', ls: true, spd: spdValue })
     );
-  
+
     const storedLs = readData(FIRST_PARTY_KEY, ['html5', 'cookie'], storage);
     const parsedLs = JSON.parse(storedLs);
-    
+
     expect(storedLs).to.not.be.null;
     expect(callBackSpy.calledOnce).to.be.true;
     expect(parsedLs).to.have.property('spd');
@@ -576,7 +576,7 @@ describe('IntentIQ tests', function () {
         gdprString: null,
         gppString: null,
         uspString: null
-      };     
+      };
 
       storeData(FIRST_PARTY_KEY, JSON.stringify(FPD), allowedStorage, storage)
       const callBackSpy = sinon.spy()
@@ -597,7 +597,7 @@ describe('IntentIQ tests', function () {
         gdprString: null,
         gppString: null,
         uspString: null
-      };     
+      };
 
       storeData(FIRST_PARTY_KEY, JSON.stringify(FPD), allowedStorage, storage)
       const returnedObject = intentIqIdSubmodule.getId({...allConfigParams, params: {...allConfigParams.params, partner: newPartnerId}});
@@ -1032,7 +1032,7 @@ describe('IntentIQ tests', function () {
 
   it('should store first party data under the silo key when siloEnabled is true', function () {
     const configParams = { params: {...allConfigParams.params, siloEnabled: true} };
-    
+
     intentIqIdSubmodule.getId(configParams);
     const expectedKey = FIRST_PARTY_KEY + '_p_' + configParams.params.partner;
     const storedData = localStorage.getItem(expectedKey);
@@ -1121,10 +1121,10 @@ describe('IntentIQ tests', function () {
         }]
       }
     };
-  
+
     intentIqIdSubmodule.getId(configParams);
     const syncRequest = server.requests[0];
-  
+
     expect(syncRequest.url).to.include('general=Lee');
   });
   it('should send additionalParams in VR request', function () {
@@ -1143,10 +1143,10 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     const vrRequest = server.requests[0];
-  
+
     expect(vrRequest.url).to.include('general=Lee');
   });
-  
+
   it('should not send additionalParams in case it is not an array', function () {
     const configParams = {
       params: {
@@ -1163,10 +1163,10 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     const vrRequest = server.requests[0];
-  
+
     expect(vrRequest.url).not.to.include('general=');
   });
-  
+
   it('should not send additionalParams in case request url is too long', function () {
     const longValue = 'x'.repeat(5000000); // simulate long parameter
     const configParams = {
@@ -1184,7 +1184,7 @@ describe('IntentIQ tests', function () {
     let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     const vrRequest = server.requests[0];
-  
+
     expect(vrRequest.url).not.to.include('general=');
   });
 
@@ -1197,10 +1197,10 @@ describe('IntentIQ tests', function () {
         groupChanged: groupChangedSpy
       }
     };
-  
+
     const submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
-  
+
     const request = server.requests[0];
     request.respond(
       200,
@@ -1211,7 +1211,7 @@ describe('IntentIQ tests', function () {
         data: { eids: [] }
       })
     );
-  
+
     expect(callBackSpy.calledOnce).to.be.true;
     expect(groupChangedSpy.calledWith(WITHOUT_IIQ)).to.be.true;
   });
@@ -1225,10 +1225,10 @@ describe('IntentIQ tests', function () {
         groupChanged: groupChangedSpy
       }
     };
-  
+
     const submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
-  
+
     const request = server.requests[0];
     request.respond(
       200,
@@ -1239,8 +1239,8 @@ describe('IntentIQ tests', function () {
         data: { eids: [] }
       })
     );
-  
+
     expect(callBackSpy.calledOnce).to.be.true;
     expect(groupChangedSpy.calledWith(WITH_IIQ)).to.be.true;
-  });  
+  });
 });

--- a/test/spec/modules/lockrAIMIdSystem_spec.js
+++ b/test/spec/modules/lockrAIMIdSystem_spec.js
@@ -1,5 +1,5 @@
- 
- 
+
+
 import * as lockrAIMSystem from "../../../modules/lockrAIMIdSystem.js";
 import { hook } from "../../../src/hook.js";
 import { expect } from "chai";

--- a/test/spec/modules/luceadBidAdapter_spec.js
+++ b/test/spec/modules/luceadBidAdapter_spec.js
@@ -1,4 +1,4 @@
- 
+
 import { expect } from 'chai';
 import { spec } from 'modules/luceadBidAdapter.js';
 import sinon from 'sinon';

--- a/test/spec/modules/mediaeyesBidAdapter_spec.js
+++ b/test/spec/modules/mediaeyesBidAdapter_spec.js
@@ -152,7 +152,7 @@ describe('mediaeyes adapter', function () {
             let request = spec.buildRequests(newRequest);
             let data = JSON.parse(request[0].data);
             data = data.imp[0];
-            expect(data.bidfloor).to.equal(0); 
+            expect(data.bidfloor).to.equal(0);
         });
 
         it('floormodule if currency is not matched', function () {

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -80,7 +80,7 @@ describe('Missena Adapter', function () {
       user: {
         ext: { consent: CONSENT_STRING },
       },
-      device: {        
+      device: {
         w: screen.width,
         h: screen.height,
         ext: { cdep: COOKIE_DEPRECATION_LABEL },

--- a/test/spec/modules/nexx360BidAdapter_spec.js
+++ b/test/spec/modules/nexx360BidAdapter_spec.js
@@ -31,7 +31,7 @@ describe('Nexx360 bid adapter tests', () => {
       }],
     },
   };
-    
+
 
   describe('isBidRequestValid()', () => {
     let bannerBid;
@@ -226,7 +226,7 @@ describe('Nexx360 bid adapter tests', () => {
               sizes: [[728, 90], [970, 250]]
             }
           },
-          
+
           adUnitCode: 'div-2-abcd',
           transactionId: '6196885d-4e76-40dc-a09c-906ed232626b',
           sizes: [[728, 90], [970, 250]],
@@ -523,7 +523,7 @@ describe('Nexx360 bid adapter tests', () => {
           },
         },
       };
-      
+
       const output = spec.interpretResponse(response);
       const expectedOutput = [{
         requestId: '263cba3b8bfb72',
@@ -575,7 +575,7 @@ describe('Nexx360 bid adapter tests', () => {
           },
         },
       };
-      
+
       const output = spec.interpretResponse(response);
       const expectedOutut = [{
         requestId: '4ce809b61a3928',
@@ -631,7 +631,7 @@ describe('Nexx360 bid adapter tests', () => {
           },
         },
       };
-      
+
       const output = spec.interpretResponse(response);
       const expectOutput = [{
         requestId: '23e11d845514bb',
@@ -692,7 +692,7 @@ describe('Nexx360 bid adapter tests', () => {
           },
         },
       }];
-      expect(output).to.eql(expectOutput);      
+      expect(output).to.eql(expectOutput);
     });
   });
 

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -941,10 +941,10 @@ describe('OguryBidAdapter', () => {
 
       const bid = { nurl: 'http://url.co/win' };
 
-      expect(ortbConverterProps.bidResponse(buildBidResponseSpy, utils.deepClone(bid), {})).to.deep.equal({ 
+      expect(ortbConverterProps.bidResponse(buildBidResponseSpy, utils.deepClone(bid), {})).to.deep.equal({
         ...bidResponse,
         currency: 'USD',
-        nurl: bid.nurl 
+        nurl: bid.nurl
       });
 
       sinon.assert.calledWith(buildBidResponseSpy, {}, {});

--- a/test/spec/modules/omsBidAdapter_spec.js
+++ b/test/spec/modules/omsBidAdapter_spec.js
@@ -331,7 +331,7 @@ describe('omsBidAdapter', function () {
 
     context('when element is partially in view', function () {
       it('returns percentage', function () {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')     
+        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')
         getWinDimensionsStub.returns({ innerHeight: win.innerHeight, innerWidth: win.innerWidth });
         Object.assign(element, {width: 800, height: 800});
         const request = spec.buildRequests(bidRequests);

--- a/test/spec/modules/onomagicBidAdapter_spec.js
+++ b/test/spec/modules/onomagicBidAdapter_spec.js
@@ -161,7 +161,7 @@ describe('onomagicBidAdapter', function() {
 
     context('when element is partially in view', function() {
       it('returns percentage', function() {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')     
+        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')
         getWinDimensionsStub.returns({ innerHeight: win.innerHeight, innerWidth: win.innerWidth });
         Object.assign(element, { width: 800, height: 800 });
         const request = spec.buildRequests(bidRequests);
@@ -172,7 +172,7 @@ describe('onomagicBidAdapter', function() {
 
     context('when width or height of the element is zero', function() {
       it('try to use alternative values', function() {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')     
+        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')
         getWinDimensionsStub.returns({ innerHeight: win.innerHeight, innerWidth: win.innerWidth });
         Object.assign(element, { width: 0, height: 0 });
         bidRequests[0].mediaTypes.banner.sizes = [[800, 2400]];

--- a/test/spec/modules/overtoneRtdProvider_spec.mjs
+++ b/test/spec/modules/overtoneRtdProvider_spec.mjs
@@ -26,7 +26,7 @@ describe('Overtone RTD Submodule with Test URLs', function () {
       }
       throw new Error('Unexpected URL in test');
     });
-    
+
     getBidRequestDataStub = sinon.stub(overtoneRtdProvider, 'getBidRequestData').callsFake((config, callback) => {
       if (config.shouldFail) {
         return;

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1,4 +1,4 @@
- 
+
 import {expect} from 'chai';
 import {
   PrebidServer as Adapter,

--- a/test/spec/modules/previousAuctionInfo_spec.js
+++ b/test/spec/modules/previousAuctionInfo_spec.js
@@ -155,10 +155,10 @@ describe('previous auction info', () => {
         ],
         timestamp: Date.now(),
       };
-    
+
       config.setConfig({ [CONFIG_NS]: { enabled: true, bidders: ['testBidder1'] } });
       previousAuctionInfo.onAuctionEndHandler(auctionDetailsWithRejectedBid);
-    
+
       const stored = previousAuctionInfo.auctionState['testBidder1'][0];
       expect(stored).to.include({
         bidId: 'bid456',

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -558,7 +558,7 @@ describe('pubmatic analytics adapter', function () {
           userId: mockUserIds
         }]
       }]);
-      
+
       sandbox.stub($$PREBID_GLOBAL$$, 'getConfig').callsFake((key) => {
         if (key === 'userSync') return mockUserSync;
         return null;

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -225,21 +225,21 @@ describe('PubMatic adapter', () => {
       it('should include previousAuctionInfo in request when available', () => {
         const bidRequestWithPrevAuction = utils.deepClone(validBidRequests[0]);
         const bidderRequestWithPrevAuction = utils.deepClone(bidderRequest);
-        
+
         bidderRequestWithPrevAuction.ortb2 = bidderRequestWithPrevAuction.ortb2 || {};
         bidderRequestWithPrevAuction.ortb2.ext = bidderRequestWithPrevAuction.ortb2.ext || {};
         bidderRequestWithPrevAuction.ortb2.ext.prebid = bidderRequestWithPrevAuction.ortb2.ext.prebid || {};
         bidderRequestWithPrevAuction.ortb2.ext.prebid.previousauctioninfo = {
           bidderRequestId: 'bidder-request-id'
         };
-        
+
         const request = spec.buildRequests([bidRequestWithPrevAuction], bidderRequestWithPrevAuction);
         expect(request.data.ext).to.have.property('previousAuctionInfo');
         expect(request.data.ext.previousAuctionInfo).to.deep.equal({
           bidderRequestId: 'bidder-request-id'
         });
       });
-      
+
       it('should generate request with banner', () => {
         const request = spec.buildRequests(validBidRequests, bidderRequest);
         const { imp } = request?.data;
@@ -1108,7 +1108,7 @@ describe('PubMatic adapter', () => {
         expect(bidResponse[0].meta).to.not.have.property('primaryCatId');
         expect(bidResponse[0].meta).to.not.have.property('secondaryCatIds');
       });
-      
+
       it('should not set primaryCatId and secondaryCatIds in meta when bid.cat is undefined', () => {
         const copiedResponse = utils.deepClone(response);
         delete copiedResponse.body.seatbid[0].bid[0].cat;

--- a/test/spec/modules/pubmaticRtdProvider_spec.js
+++ b/test/spec/modules/pubmaticRtdProvider_spec.js
@@ -30,7 +30,7 @@ describe('Pubmatic RTD Provider', () => {
             };
         });
     });
-    
+
     afterEach(() => {
         sandbox.restore();
     });
@@ -517,7 +517,7 @@ describe('Pubmatic RTD Provider', () => {
               }
             }
         }
-      
+
         const hookConfig = {
             reqBidsConfigObj,
             context: this,
@@ -530,18 +530,18 @@ describe('Pubmatic RTD Provider', () => {
             callback = sinon.spy();
             continueAuctionStub = sandbox.stub(priceFloors, 'continueAuction');
             logErrorStub = sandbox.stub(utils, 'logError');
-    
+
             global.configMergedPromise = Promise.resolve();
         });
-    
+
         afterEach(() => {
             sandbox.restore(); // Restore all stubs/spies
         });
-    
+
         it('should call continueAuction with correct hookConfig', async function () {
             configMerged();
             await pubmaticSubmodule.getBidRequestData(reqBidsConfigObj, callback);
-    
+
             expect(continueAuctionStub.called).to.be.true;
             expect(continueAuctionStub.firstCall.args[0]).to.have.property('reqBidsConfigObj', reqBidsConfigObj);
             expect(continueAuctionStub.firstCall.args[0]).to.have.property('haveExited', false);
@@ -551,18 +551,18 @@ describe('Pubmatic RTD Provider', () => {
         //     configMerged();
         //     global._country = 'US';
         //     pubmaticSubmodule.getBidRequestData(reqBidsConfigObj, callback);
-    
+
         //     expect(reqBidsConfigObj.ortb2Fragments.bidder).to.have.property('pubmatic');
         //     // expect(reqBidsConfigObj.ortb2Fragments.bidder.pubmatic.user.ext.ctr).to.equal('US');
         // });
-    
+
         it('should call callback once after execution', async function () {
             configMerged();
             await pubmaticSubmodule.getBidRequestData(reqBidsConfigObj, callback);
-    
+
             expect(callback.called).to.be.true;
         });
-    });        
+    });
 
     describe('withTimeout', function () {
         it('should resolve with the original promise value if it resolves before the timeout', async function () {
@@ -598,12 +598,12 @@ describe('Pubmatic RTD Provider', () => {
 
             const promise = new Promise((resolve) => setTimeout(() => resolve('success'), 50));
             const resultPromise = withTimeout(promise, 100);
-            
+
             clock.tick(50);
             await resultPromise;
-            
+
             expect(clearTimeoutSpy.called).to.be.true;
-            
+
             clearTimeoutSpy.restore();
             clock.restore();
         });

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -79,7 +79,7 @@ describe('PubWise Prebid Analytics', function () {
       /* check for critical values */
       let request = requests[0];
       let data = JSON.parse(request.requestBody);
-       
+
       // console.log(data.metaData);
       expect(data.metaData, 'metaData property').to.exist;
       expect(data.metaData.pbjs_version, 'pbjs version').to.equal('$prebid.version$')
@@ -133,7 +133,7 @@ describe('PubWise Prebid Analytics', function () {
       expect(data.eventList[0], 'eventList property').to.exist;
       expect(data.eventList[0].args, 'eventList property').to.exist;
 
-       
+
       // console.log(data.eventList[0].args);
 
       let eventArgs = data.eventList[0].args;

--- a/test/spec/modules/sizeMappingV2_spec.js
+++ b/test/spec/modules/sizeMappingV2_spec.js
@@ -1174,7 +1174,7 @@ describe('sizeMappingV2', function () {
     });
   });
 
-  describe('getFilteredMediaTypes(mediaTypes)', function () {    
+  describe('getFilteredMediaTypes(mediaTypes)', function () {
     beforeEach(function () {
       utils.resetWinDimensions();
       sinon

--- a/test/spec/modules/tpmnBidAdapter_spec.js
+++ b/test/spec/modules/tpmnBidAdapter_spec.js
@@ -1,4 +1,4 @@
- 
+
 import {spec, storage, VIDEO_RENDERER_URL} from 'modules/tpmnBidAdapter.js';
 import {generateUUID} from '../../../src/utils.js';
 import {expect} from 'chai';

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -269,7 +269,7 @@ describe('ttdBidAdapter', function () {
       };
       var requestBody = testBuildRequests(baseBannerBidRequests, requestWithoutTimeout).data;
       expect(requestBody.tmax).to.be.equal(400);
-      
+
       const requestWithTimeout = {
         ...baseBidderRequest,
         timeout: 600

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -3204,7 +3204,7 @@ describe('User ID', function () {
           }
         };
         addIdData({ adUnits, ortb2Fragments });
-        
+
         adUnits[0].bids.forEach(({userId}) => {
           const userIdModules = Object.keys(userId);
           expect(userIdModules).to.include(ALLOWED_MODULE);

--- a/test/spec/modules/vibrantmediaBidAdapter_spec.js
+++ b/test/spec/modules/vibrantmediaBidAdapter_spec.js
@@ -546,7 +546,7 @@ describe('VibrantMediaBidAdapter', function () {
       const request = spec.buildRequests(bidRequests, {});
       const payload = JSON.parse(request.data);
 
-      expect(payload.window).to.exist; 
+      expect(payload.window).to.exist;
       expect(payload.window.width).to.equal(getWinDimensions().innerWidth);
       expect(payload.window.height).to.equal(getWinDimensions().innerHeight);
     });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1005,7 +1005,7 @@ describe('Unit: Prebid Module', function () {
 
   describe('setTargetingForGPTAsync', function () {
     let logErrorSpy;
-    let targeting; 
+    let targeting;
 
     beforeEach(function () {
       logErrorSpy = sinon.spy(utils, 'logError');
@@ -1022,7 +1022,7 @@ describe('Unit: Prebid Module', function () {
       window.googletag.pubads().setSlots(slots);
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync([config.adUnitCodes[0]]);
 
-      
+
       slots.forEach(function(slot) {
         targeting = {};
         slot.getTargetingKeys().map(function (key) {

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1333,16 +1333,16 @@ describe('Utils', function () {
     it('should compress data correctly when CompressionStream is available', async () => {
       const data = JSON.stringify({ test: 'data' });
       const compressedData = await utils.compressDataWithGZip(data);
-  
+
       expect(compressedData).to.be.instanceOf(Uint8Array);
       expect(compressedData.length).to.be.greaterThan(0);
       expect(compressedData).to.deep.equal(new Uint8Array([1, 2, 3, 4]));
     });
-  
+
     it('should handle non-string input by stringifying it', async () => {
       const nonStringData = { test: 'data' };
       const compressedData = await utils.compressDataWithGZip(nonStringData);
-  
+
       expect(compressedData).to.be.instanceOf(Uint8Array);
       expect(compressedData.length).to.be.greaterThan(0);
       expect(compressedData).to.deep.equal(new Uint8Array([1, 2, 3, 4]));

--- a/test/test_deps.js
+++ b/test/test_deps.js
@@ -21,7 +21,7 @@ window.addEventListener('error', function (ev) {
 })
 
 window.addEventListener('unhandledrejection', function (ev) {
-  // this message is used for counting intentional failures created in the tests 
+  // this message is used for counting intentional failures created in the tests
   if (ev.reason === 'pending failure') return;
   // eslint-disable-next-line no-console
   console.error('Unhandled rejection:', ev.reason);


### PR DESCRIPTION
## Summary
- enforce `@stylistic/no-trailing-spaces` for test files
- strip trailing whitespace from multiple test specs

## Testing
- `npx gulp lint` *(fails: no output)*
- `npx gulp test --file test/spec/modules/pubmaticAnalyticsAdapter_spec.js` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_b_68419e2ad8a0832b959796f460cf2670