### PR TITLE
core: enforce no-array-constructor in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -233,7 +233,6 @@ module.exports = [
       'no-unused-vars': 'off',
       'import/extensions': 'off',
       'camelcase': 'off',
-      'no-array-constructor': 'off',
       'import-x/no-duplicates': 'off',
       'import-x/no-absolute-path': 'off',
       'no-loss-of-precision': 'off',

--- a/test/helpers/index_adapter_utils.js
+++ b/test/helpers/index_adapter_utils.js
@@ -79,11 +79,11 @@ exports.createBidSlots = function(numSlot, numSize) {
   if (typeof numSlot === 'undefined') numSlot = 1;
   if (typeof numSize === 'undefined') numSize = 1;
 
-  var bids = new Array(numSlot);
+  var bids = Array(numSlot);
 
   var mkPlacementCode = function(i, j) { return DefaultPlacementCodePrefix + i + '_' + j; };
   for (var i = 0; i < bids.length; i++) {
-    var requestSizes = new Array(numSize);
+    var requestSizes = Array(numSize);
     for (var j = 0; j < requestSizes.length; j++) requestSizes[j] = AllowedAdUnits[(i + j) % AllowedAdUnits.length];
 
     bids[i] = _createBidSlot(mkPlacementCode(i, j), 'slot-' + i, requestSizes, {

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -332,7 +332,7 @@ describe('YieldmoAdapter', function () {
       });
 
       it('should not exceed max url length', () => {
-        const longString = new Array(8000).join('a');
+        const longString = Array(8000).join('a');
         const localWindow = utils.getWindowTop();
 
         const originalTitle = localWindow.document.title;
@@ -356,7 +356,7 @@ describe('YieldmoAdapter', function () {
       });
 
       it('should only shortcut properties rather then completely remove it', () => {
-        const longString = new Array(8000).join('a');
+        const longString = Array(8000).join('a');
         const localWindow = utils.getWindowTop();
 
         const originalTitle = localWindow.document.title;

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -661,7 +661,7 @@ describe('targeting tests', function () {
           .filter((bid) => bid.adserverTargeting[key] != null)
           .map((bid) => bid.bidderCode)
           .forEach((code) => keys.add(`${key}_${code}`.substr(0, 20)));
-        return new Array(...keys);
+        return [...keys];
       }
 
       const targetingResult = function () {


### PR DESCRIPTION
## Summary
- re-enable `no-array-constructor` for test files
- fix `new Array()` usage in tests

## Testing
- `npx gulp lint` *(fails: Missing output)*
- `npx gulp test --file test/spec/unit/core/targeting_spec.js` *(fails: Missing output)*
- `npx gulp test --file test/spec/modules/yieldmoBidAdapter_spec.js` *(fails: Missing output)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68419e23dd14832b9e1943ae4cc0821a