### PR TITLE
core: enforce no-absolute-path in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -235,7 +235,6 @@ module.exports = [
       'camelcase': 'off',
       'no-array-constructor': 'off',
       'import-x/no-duplicates': 'off',
-      'import-x/no-absolute-path': 'off',
       'no-loss-of-precision': 'off',
       'no-redeclare': 'off',
       'no-global-assign': 'off',

--- a/test/spec/modules/displayioBidAdapter_spec.js
+++ b/test/spec/modules/displayioBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import {spec} from 'modules/displayioBidAdapter.js'
-import {BANNER} from '/src/mediaTypes'
+import {BANNER} from '../../../src/mediaTypes.js'
 
 describe('Displayio adapter', function () {
   const BIDDER = 'displayio'

--- a/test/spec/modules/topLevelPaapi_spec.js
+++ b/test/spec/modules/topLevelPaapi_spec.js
@@ -14,7 +14,7 @@ import {
   parsePaapiAdId,
   parsePaapiSize, resizeCreativeHook,
   topLevelPAAPI
-} from '/modules/topLevelPaapi.js';
+} from '../../../modules/topLevelPaapi.js';
 import {auctionManager} from '../../../src/auctionManager.js';
 import {expect} from 'chai/index.js';
 import {getBidToRender} from '../../../src/adRendering.js';


### PR DESCRIPTION
## Summary
- enforce import-x/no-absolute-path in test lint configuration
- update tests to use relative imports

## Testing
- `npx gulp lint` *(fails: no output)*
- `npx gulp test --file test/spec/modules/displayioBidAdapter_spec.js` *(fails: no output)*
- `npx gulp test --file test/spec/modules/topLevelPaapi_spec.js` *(fails: no output)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6841a54deae0832b8321d925321ab101