### PR TITLE
build: improve missing modules error handling

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -5,7 +5,7 @@ const argv = require('yargs').argv;
 const MANIFEST = 'package.json';
 const through = require('through2');
 const _ = require('lodash');
-const gutil = require('plugin-error');
+const PluginError = require('plugin-error');
 const submodules = require('./modules/.submodules.json').parentModules;
 
 const MODULE_PATH = './modules';
@@ -52,10 +52,7 @@ module.exports = {
         );
       }
     } catch (e) {
-      throw new gutil.PluginError({
-        plugin: 'modules',
-        message: 'failed reading: ' + argv.modules
-      });
+      throw new PluginError('modules', 'failed reading: ' + argv.modules + '. Ensure the file exists and contains valid JSON.');
     }
 
     // we need to forcefuly include the parentModule if the subModule is present in modules list and parentModule is not present in modules list

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@
 var _ = require('lodash');
 var argv = require('yargs').argv;
 var gulp = require('gulp');
-var gutil = require('plugin-error');
+var PluginError = require('plugin-error');
 var fancyLog = require('fancy-log');
 var connect = require('gulp-connect');
 var webpack = require('webpack');
@@ -297,10 +297,7 @@ function bundle(dev, moduleArr) {
   } else {
     var diff = _.difference(modules, allModules);
     if (diff.length !== 0) {
-      throw new gutil.PluginError({
-        plugin: 'bundle',
-        message: 'invalid modules: ' + diff.join(', ')
-      });
+      throw new PluginError('bundle', 'invalid modules: ' + diff.join(', ') + '. Check your modules list.');
     }
   }
   const coreFile = helpers.getBuiltPrebidCoreFile(dev);


### PR DESCRIPTION
## Summary
- fix PluginError usage in build scripts
- clarify messages for missing module errors

## Testing
- `gulp lint` *(fails: Starting 'lint'...)*
- `gulp test --file test/spec/api_spec.js` *(fails: Starting 'test'...)*


------
https://chatgpt.com/codex/tasks/task_b_6841c166027c832b9295380c5aa15bf8