### PR TITLE
core: ensure hooks initialized in pbjs api test

### DIFF
--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -29,6 +29,9 @@ import {BID_STATUS, EVENTS, GRANULARITY_OPTIONS, PB_LOCATOR, TARGETING_KEYS} fro
 import {getBidToRender} from '../../../src/adRendering.js';
 import {setBattrForAdUnit} from '../../../src/prebid.js';
 
+// ensure hooks are initialized before additional modules are loaded
+hook.ready();
+
 var assert = require('chai').assert;
 var expect = require('chai').expect;
 


### PR DESCRIPTION
## Summary
- initialize fun-hooks early in pbjs_api_spec to avoid warning when running this spec in isolation

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/unit/pbjs_api_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_6841c6bcc8e8832babad10b35a3b894e