### PR TITLE
liveramp: handle url base64 decode

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -160,6 +160,7 @@ export function getEnvelopeFromStorage() {
       return window.atob(rawEnvelope.replace(/-/g, '+').replace(/_/g, '/'));
     } catch (e2) {
       return undefined;
+      utils.logError('identityLink: invalid envelope format');
     }
   }
 }

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -150,7 +150,18 @@ function setEnvelopeSource(src) {
 
 export function getEnvelopeFromStorage() {
   let rawEnvelope = storage.getCookie(liverampEnvelopeName) || storage.getDataFromLocalStorage(liverampEnvelopeName);
-  return rawEnvelope ? window.atob(rawEnvelope) : undefined;
+  if (!rawEnvelope) {
+    return undefined;
+  }
+  try {
+    return window.atob(rawEnvelope);
+  } catch (e) {
+    try {
+      return window.atob(rawEnvelope.replace(/-/g, '+').replace(/_/g, '/'));
+    } catch (e2) {
+      return undefined;
+    }
+  }
 }
 
 submodule('userId', identityLinkSubmodule);

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -159,8 +159,8 @@ export function getEnvelopeFromStorage() {
     try {
       return window.atob(rawEnvelope.replace(/-/g, '+').replace(/_/g, '/'));
     } catch (e2) {
-      return undefined;
       utils.logError('identityLink: invalid envelope format');
+      return undefined;
     }
   }
 }

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -208,6 +208,18 @@ describe('IdentityLinkId tests', function () {
     expect(callBackSpy.calledOnce).to.be.true;
   })
 
+  it('should replace invalid characters if initial atob fails', function () {
+    setTestEnvelopeCookie();
+    const realAtob = window.atob;
+    const stubAtob = sinon.stub(window, 'atob');
+    stubAtob.onFirstCall().throws(new Error('bad'));
+    stubAtob.onSecondCall().callsFake(realAtob);
+    let envelopeValueFromStorage = getEnvelopeFromStorage();
+    stubAtob.restore();
+    expect(stubAtob.calledTwice).to.be.true;
+    expect(envelopeValueFromStorage).to.equal(testEnvelopeValue);
+  })
+
   it('if there is no envelope in storage and ats is not present on a page try to call 3p url', function () {
     let envelopeValueFromStorage = getEnvelopeFromStorage();
     let callBackSpy = sinon.spy();


### PR DESCRIPTION
## Summary
- handle Safari failing atob call by replacing '-' and '_' before decode
- add unit test for fallback decode

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/modules/identityLinkIdSystem_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_6841e9442dd4832ba9274c3dc3feb40f