### PR TITLE
core: stub ads loader in anonymisedRtdProvider spec

### DIFF
--- a/test/spec/modules/anonymisedRtdProvider_spec.js
+++ b/test/spec/modules/anonymisedRtdProvider_spec.js
@@ -1,6 +1,6 @@
 import {config} from 'src/config.js';
 import {getRealTimeData, anonymisedRtdSubmodule, storage} from 'modules/anonymisedRtdProvider.js';
-import { loadExternalScript } from '../../../src/adloader.js';
+import { loadExternalScriptStub as loadExternalScript } from 'test/mocks/adloaderStub.js';
 
 describe('anonymisedRtdProvider', function() {
   let getDataFromLocalStorageStub;
@@ -25,6 +25,7 @@ describe('anonymisedRtdProvider', function() {
   beforeEach(function() {
     config.resetConfig();
     getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage')
+    loadExternalScript.resetHistory();
   });
 
   afterEach(function () {


### PR DESCRIPTION
## Summary
- use the adloader stub in anonymisedRtdProvider_spec
- reset stub history between tests

## Testing
- `npx gulp lint` *(fails: no output)*
- `npx gulp test --file test/spec/modules/anonymisedRtdProvider_spec.js` *(fails: Webpack bundling stalled)*

------
https://chatgpt.com/codex/tasks/task_b_6841fe1d74ac832b8291c3b4541cd1b2