### PR TITLE
test: replace sinon fake xhr usage

### DIFF
--- a/test/mocks/xhr.js
+++ b/test/mocks/xhr.js
@@ -3,7 +3,7 @@ import {GreedyPromise} from 'libraries/greedy/greedyPromise.js';
 import {fakeXhr} from 'nise';
 import {dep} from 'src/ajax.js';
 
-export const xhr = sinon.useFakeXMLHttpRequest();
+export const xhr = fakeXhr.useFakeXMLHttpRequest();
 export const server = mockFetchServer();
 
 /**

--- a/test/spec/modules/concertAnalyticsAdapter_spec.js
+++ b/test/spec/modules/concertAnalyticsAdapter_spec.js
@@ -9,8 +9,6 @@ let events = require('src/events');
 
 describe('ConcertAnalyticsAdapter', function() {
   let sandbox;
-  let xhr;
-  let requests;
   let clock;
   let timestamp = 1896134400;
   let auctionId = '9f894496-10fe-4652-863d-623462bf82b8';
@@ -18,16 +16,11 @@ describe('ConcertAnalyticsAdapter', function() {
 
   before(function () {
     sandbox = sinon.createSandbox();
-    xhr = sandbox.useFakeXMLHttpRequest();
-    requests = [];
-
-    xhr.onCreate = function (request) {
-      requests.push(request);
-    };
-    clock = sandbox.useFakeTimers(1896134400);
+    clock = sinon.useFakeTimers(1896134400);
   });
 
   after(function () {
+    clock.restore();
     sandbox.restore();
   });
 

--- a/test/spec/modules/idImportLibrary_spec.js
+++ b/test/spec/modules/idImportLibrary_spec.js
@@ -7,6 +7,7 @@ import {hook} from '../../../src/hook.js';
 import * as activities from '../../../src/activities/rules.js';
 import { ACTIVITY_ENRICH_UFPD } from '../../../src/activities/activities.js';
 import { CONF_DEFAULT_FULL_BODY_SCAN, CONF_DEFAULT_INPUT_SCAN } from '../../../modules/idImportLibrary.js';
+import {server} from 'test/mocks/xhr.js';
 
 var expect = require('chai').expect;
 
@@ -17,7 +18,6 @@ const mockMutationObserver = {
 }
 
 describe('IdImportLibrary Tests', function () {
-  let fakeServer;
   let sandbox;
   let clock;
   let fn = sinon.spy();
@@ -28,7 +28,6 @@ describe('IdImportLibrary Tests', function () {
   });
 
   beforeEach(function () {
-    fakeServer = sinon.fakeServer.create();
     sinon.stub(utils, 'logInfo');
     sinon.stub(utils, 'logError');
   });
@@ -36,13 +35,12 @@ describe('IdImportLibrary Tests', function () {
   afterEach(function () {
     utils.logInfo.restore();
     utils.logError.restore();
-    fakeServer.restore();
     idImportlibrary.setConfig({});
   });
 
   describe('setConfig', function () {
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
     });
 
@@ -111,7 +109,7 @@ describe('IdImportLibrary Tests', function () {
       clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
       mutationObserverStub = sinon.stub(window, 'MutationObserver').returns(mockMutationObserver);
       userId = sandbox.stub(getGlobal(), 'getUserIds').returns({id: {'MOCKID': '1111'}});
-      fakeServer.respondWith('POST', 'URL', [200,
+      server.respondWith('POST', 'URL', [200,
         {
           'Content-Type': 'application/json',
           'Access-Control-Allow-Origin': '*'
@@ -238,7 +236,7 @@ describe('IdImportLibrary Tests', function () {
       clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
       mutationObserverStub = sinon.stub(window, 'MutationObserver');
       jsonSpy = sinon.spy(JSON, 'stringify');
-      fakeServer.respondWith('POST', 'URL', [200,
+      server.respondWith('POST', 'URL', [200,
         {
           'Content-Type': 'application/json',
           'Access-Control-Allow-Origin': '*'

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -6,18 +6,17 @@ import sinon from 'sinon';
 
 describe('stroeerCore bid adapter', function () {
   let sandbox;
-  let fakeServer;
   let bidderRequest;
   let clock;
 
   beforeEach(() => {
     bidderRequest = buildBidderRequest();
-    sandbox = sinon.sandbox.create();
-    fakeServer = sandbox.useFakeServer();
-    clock = sandbox.useFakeTimers();
+    sandbox = sinon.createSandbox();
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
+    clock.restore();
     sandbox.restore();
   });
 

--- a/test/test_deps.js
+++ b/test/test_deps.js
@@ -21,11 +21,22 @@ window.addEventListener('error', function (ev) {
 })
 
 window.addEventListener('unhandledrejection', function (ev) {
-  // this message is used for counting intentional failures created in the tests 
+  // this message is used for counting intentional failures created in the tests
   if (ev.reason === 'pending failure') return;
   // eslint-disable-next-line no-console
   console.error('Unhandled rejection:', ev.reason);
 })
+
+const sinon = require('sinon');
+if (!sinon.sandbox) {
+  sinon.sandbox = {create: sinon.createSandbox.bind(sinon)};
+}
+const {fakeServer, fakeServerWithClock, fakeXhr} = require('nise');
+sinon.fakeServer = fakeServer;
+sinon.fakeServerWithClock = fakeServerWithClock;
+sinon.useFakeXMLHttpRequest = fakeXhr.useFakeXMLHttpRequest.bind(fakeXhr);
+sinon.createFakeServer = fakeServer.create.bind(fakeServer);
+sinon.createFakeServerWithClock = fakeServerWithClock.create.bind(fakeServerWithClock);
 
 require('test/helpers/global_hooks.js');
 require('test/helpers/consentData.js');


### PR DESCRIPTION
## Summary
- use global server mock in tests instead of local nise fakes
- restore deprecated Sinon APIs via nise compatibility

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/modules/concertAnalyticsAdapter_spec.js`
- `npx gulp test --file test/spec/modules/idImportLibrary_spec.js`
- `npx gulp test --file test/spec/modules/stroeerCoreBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_6841fcd2bc08832bace756d99c332ef7