### PR TITLE
tests: replace sinon.sandbox.create

### DIFF
--- a/test/helpers/fpd.js
+++ b/test/helpers/fpd.js
@@ -33,7 +33,7 @@ export function mockFpdEnrichments(sandbox, overrides = {}) {
 }
 
 export function addFPDEnrichments(ortb2 = {}, overrides) {
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   mockFpdEnrichments(sandbox, overrides)
   return enrichFPD(PbPromise.resolve(deepClone(ortb2))).finally(() => sandbox.restore());
 }

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1844,7 +1844,7 @@ describe('auctionmanager.js', function () {
   describe('addWinningBid', () => {
     let auction, bid, adUnits, sandbox;
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(adapterManager, 'callBidWonBidder');
       sandbox.stub(adapterManager, 'triggerBilling')
       adUnits = [{code: 'au1'}, {code: 'au2'}]

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -14,7 +14,7 @@ describe('FPD enrichment', () => {
     hook.ready();
   });
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/spec/fpd/gdpr_spec.js
+++ b/test/spec/fpd/gdpr_spec.js
@@ -7,7 +7,7 @@ describe('GDPR FPD enrichment', () => {
   let sandbox, consent;
   beforeEach(() => {
     consent = null;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(gdprDataHandler, 'getConsentData').callsFake(() => consent);
   });
   afterEach(() => {

--- a/test/spec/fpd/usp_spec.js
+++ b/test/spec/fpd/usp_spec.js
@@ -5,7 +5,7 @@ describe('FPD enrichment USP', () => {
   let sandbox, consent;
   beforeEach(() => {
     consent = null;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(uspDataHandler, 'getConsentData').callsFake(() => consent);
   });
 

--- a/test/spec/libraries/cmUtils_spec.js
+++ b/test/spec/libraries/cmUtils_spec.js
@@ -4,7 +4,7 @@ import {lookupConsentData, consentManagementHook} from '../../../libraries/conse
 describe('consent management utils', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ['logError', 'logInfo', 'logWarn'].forEach(n => sandbox.stub(utils, n));
   });
   afterEach(() => {

--- a/test/spec/libraries/currencyUtils_spec.js
+++ b/test/spec/libraries/currencyUtils_spec.js
@@ -17,7 +17,7 @@ describe('currency utils', () => {
   })
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/test/spec/libraries/vastTrackers_spec.js
+++ b/test/spec/libraries/vastTrackers_spec.js
@@ -34,7 +34,7 @@ describe('vast trackers', () => {
         return [{bids: [bidRequest]}]
       }
     };
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     index = new AuctionIndex(() => [auction]);
     tracker = sinon.stub().callsFake(function (bidResponse) {
       return [

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -498,7 +498,7 @@ describe('33acrossBidAdapter:', function () {
         .withBanner()
         .build()
     );
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(Date, 'now').returns(1);
     sandbox.stub(document, 'getElementById').returns(element);
     sandbox.stub(internal, 'getWindowTop').returns(win);

--- a/test/spec/modules/aaxBlockmeter_spec.js
+++ b/test/spec/modules/aaxBlockmeter_spec.js
@@ -16,7 +16,7 @@ const config = {
 
 describe('aaxBlockmeter realtime module', function () {
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     window.aax = window.aax || {};
     window.aax.getTargetingData = getTargetingDataSpy = sandbox.spy();
   });

--- a/test/spec/modules/adagioRtdProvider_spec.js
+++ b/test/spec/modules/adagioRtdProvider_spec.js
@@ -39,7 +39,7 @@ describe('Adagio Rtd Provider', function () {
   let clock;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sandbox.useFakeTimers();
   });
 

--- a/test/spec/modules/adkernelAdnAnalytics_spec.js
+++ b/test/spec/modules/adkernelAdnAnalytics_spec.js
@@ -36,7 +36,7 @@ describe('', function () {
   let sandbox;
 
   before(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   after(function () {

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -328,7 +328,7 @@ describe('Adkernel adapter', function () {
 
   var sandbox;
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/adlooxAdServerVideo_spec.js
+++ b/test/spec/modules/adlooxAdServerVideo_spec.js
@@ -98,7 +98,7 @@ describe('Adloox Ad Server Video', function () {
   });
 
   before(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(events, 'getEvents').returns([]);
 
     adapterManager.enableAnalytics({

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -144,7 +144,7 @@ describe('Adloox Analytics Adapter', function () {
 
   describe('process', function () {
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       sandbox.stub(events, 'getEvents').returns([]);
 

--- a/test/spec/modules/adlooxRtdProvider_spec.js
+++ b/test/spec/modules/adlooxRtdProvider_spec.js
@@ -50,7 +50,7 @@ describe('Adloox RTD Provider', function () {
   });
 
   before(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(events, 'getEvents').returns([]);
   });
 

--- a/test/spec/modules/adnuntiusAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adnuntiusAnalyticsAdapter_spec.js
@@ -292,7 +292,7 @@ describe('Adnuntius analytics adapter', function () {
   let clock;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     let element = {
       getAttribute: function() {

--- a/test/spec/modules/adtargetBidAdapter_spec.js
+++ b/test/spec/modules/adtargetBidAdapter_spec.js
@@ -264,7 +264,7 @@ describe('adtargetBidAdapter', () => {
     });
 
     describe('publisher environment', () => {
-      const sandbox = sinon.sandbox.create();
+      const sandbox = sinon.createSandbox();
       sandbox.stub(config, 'getConfig').callsFake((key) => {
         const config = {
           'coppa': true

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -350,7 +350,7 @@ describe('adtelligentBidAdapter', () => {
     });
 
     describe('publisher environment', () => {
-      const sandbox = sinon.sandbox.create();
+      const sandbox = sinon.createSandbox();
       sandbox.stub(config, 'getConfig').callsFake((key) => {
         const config = {
           'coppa': true

--- a/test/spec/modules/adtrueBidAdapter_spec.js
+++ b/test/spec/modules/adtrueBidAdapter_spec.js
@@ -348,7 +348,7 @@ describe('AdTrueBidAdapter', function () {
         }
       });
       it('should include coppa flag in bid request if coppa is set to true', () => {
-        let sandbox = sinon.sandbox.create();
+        let sandbox = sinon.createSandbox();
         sandbox.stub(config, 'getConfig').callsFake(key => {
           const config = {
             'coppa': true
@@ -361,7 +361,7 @@ describe('AdTrueBidAdapter', function () {
         sandbox.restore();
       });
       it('should NOT include coppa flag in bid request if coppa is set to false', () => {
-        let sandbox = sinon.sandbox.create();
+        let sandbox = sinon.createSandbox();
         sandbox.stub(config, 'getConfig').callsFake(key => {
           const config = {
             'coppa': false
@@ -407,7 +407,7 @@ describe('AdTrueBidAdapter', function () {
   describe('getUserSyncs', function () {
     let sandbox;
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
     afterEach(function () {
       sandbox.restore();

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -932,7 +932,7 @@ describe('Adyoulike Adapter', function () {
         let sandbox;
 
         this.beforeEach(function() {
-          sandbox = sinon.sandbox.create();
+          sandbox = sinon.createSandbox();
         });
 
         this.afterEach(function() {

--- a/test/spec/modules/agmaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/agmaAnalyticsAdapter_spec.js
@@ -55,7 +55,7 @@ describe('AGMA Analytics Adapter', () => {
   let agmaConfig, sandbox, clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sandbox.useFakeTimers();
     sandbox.stub(events, 'getEvents').returns([]);
     agmaConfig = {

--- a/test/spec/modules/asealBidAdapter_spec.js
+++ b/test/spec/modules/asealBidAdapter_spec.js
@@ -41,7 +41,7 @@ describe('asealBidAdapter', () => {
       },
     };
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(utils, 'getWindowTop').returns(w);
     sandbox.stub(utils, 'getWindowSelf').returns(w);
     done();

--- a/test/spec/modules/atsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/atsAnalyticsAdapter_spec.js
@@ -19,7 +19,7 @@ describe('ats analytics adapter', function () {
   beforeEach(function () {
     sinon.stub(events, 'getEvents').returns([]);
     storage.setCookie('_lr_env_src_ats', 'true', 'Thu, 01 Jan 1970 00:00:01 GMT');
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sandbox.useFakeTimers(now.getTime());
   });
 

--- a/test/spec/modules/bidViewabilityIO_spec.js
+++ b/test/spec/modules/bidViewabilityIO_spec.js
@@ -79,7 +79,7 @@ describe('#bidViewabilityIO', function() {
     };
 
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     })
 
     afterEach(function() {
@@ -105,7 +105,7 @@ describe('#bidViewabilityIO', function() {
     let sandbox;
 
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     })
 
     afterEach(function() {

--- a/test/spec/modules/bidViewability_spec.js
+++ b/test/spec/modules/bidViewability_spec.js
@@ -71,7 +71,7 @@ describe('#bidViewability', function() {
     let winningBidsArray;
     let sandbox
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       // mocking winningBidsArray
       winningBidsArray = [];
       sandbox.stub(prebidGlobal, 'getGlobal').returns({
@@ -132,7 +132,7 @@ describe('#bidViewability', function() {
     let triggerPixelSpy;
 
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       triggerPixelSpy = sandbox.spy(utils, ['triggerPixel']);
     });
 
@@ -258,7 +258,7 @@ describe('#bidViewability', function() {
     ];
 
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       triggerPixelSpy = sandbox.spy(utils, ['triggerPixel']);
       eventsEmitSpy = sandbox.spy(events, ['emit']);
       callBidViewableBidderSpy = sandbox.spy(adapterManager, ['callBidViewableBidder']);

--- a/test/spec/modules/brandmetricsRtdProvider_spec.js
+++ b/test/spec/modules/brandmetricsRtdProvider_spec.js
@@ -204,7 +204,7 @@ describe('getBidRequestData', () => {
     let eventsEmitSpy;
 
     before(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       eventsEmitSpy = sandbox.spy(events, ['emit']);
     });
 

--- a/test/spec/modules/bridgeuppBidAdapter_spec.js
+++ b/test/spec/modules/bridgeuppBidAdapter_spec.js
@@ -27,7 +27,7 @@ describe('bridgeuppBidAdapter_spec', function () {
   });
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     utilsMock = sinon.mock(utils);
     ajaxStub = sandbox.stub(ajax, 'ajax');
     fetchStub = sinon.stub(global, 'fetch').resolves(new Response('OK'));

--- a/test/spec/modules/browsiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/browsiAnalyticsAdapter_spec.js
@@ -177,7 +177,7 @@ describe('browsi analytics adapter', function () {
   let sandbox;
 
   before(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(utils, 'timestamp').returns(timestamp);
 
     adapterManager.registerAnalyticsAdapter({

--- a/test/spec/modules/browsiRtdProvider_spec.js
+++ b/test/spec/modules/browsiRtdProvider_spec.js
@@ -38,7 +38,7 @@ describe('browsi Real time data sub module', function () {
   let timestampStub;
 
   before(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     eventsEmitSpy = sandbox.spy(events, ['emit']);
     timestampStub = sandbox.stub(utils, 'timestamp');
     sandbox.stub(Global, 'getGlobal').callsFake(() => {

--- a/test/spec/modules/codefuelBidAdapter_spec.js
+++ b/test/spec/modules/codefuelBidAdapter_spec.js
@@ -12,7 +12,7 @@ const setUAMock = () => { window.navigator.__defineGetter__('userAgent', functio
 describe('Codefuel Adapter', function () {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -84,7 +84,7 @@ describe('ConcertAdapter', function () {
       }
     }
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(document, 'getElementById').withArgs('desktop_leaderboard_variable').returns(element)
   });
 

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -26,7 +26,7 @@ function createIFrameMarker() {
 describe('consentManagement', function () {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(adapterManager, 'callDataDeletionRequest');
   });
 

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -729,7 +729,7 @@ describe('Consumable BidAdapter', function () {
   describe('unifiedId from userId module', function() {
     let sandbox, bidderRequest;
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       bidderRequest = deepClone(BIDDER_REQUEST_1);
     });
 

--- a/test/spec/modules/contxtfulBidAdapter_spec.js
+++ b/test/spec/modules/contxtfulBidAdapter_spec.js
@@ -12,7 +12,7 @@ describe('contxtful bid adapter', function () {
   let sandbox;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/contxtfulRtdProvider_spec.js
+++ b/test/spec/modules/contxtfulRtdProvider_spec.js
@@ -62,7 +62,7 @@ function fakeGetElementById(width, height, x, y) {
 }
 
 describe('contxtfulRtdProvider', function () {
-  let sandbox = sinon.sandbox.create();
+  let sandbox = sinon.createSandbox();
   let loadExternalScriptTag;
   let eventsEmitSpy;
 

--- a/test/spec/modules/conversantAnalyticsAdapter_spec.js
+++ b/test/spec/modules/conversantAnalyticsAdapter_spec.js
@@ -37,7 +37,7 @@ describe('Conversant analytics adapter tests', function() {
 
   beforeEach(function () {
     requests = server.requests;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(events, 'getEvents').returns([]); // need to stub this otherwise unwanted events seem to get fired during testing
     const getGlobalStub = {
       version: PREBID_VERSION,

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -686,7 +686,7 @@ describe('Conversant adapter tests', function() {
     const cnvrResponse = {ext: {psyncs: [syncurl_image], fsyncs: [syncurl_iframe]}};
     let sandbox;
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
     afterEach(function() {
       sandbox.restore();

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -26,7 +26,7 @@ describe('The Criteo bidding adapter', function () {
     localStorage.removeItem('criteo_fast_bid');
     utilsMock = sinon.mock(utils);
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ajaxStub = sandbox.stub(ajax, 'ajax');
   });
 

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -44,7 +44,7 @@ describe('currency', function () {
 
   describe('setConfig', function () {
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
     });
 
@@ -544,7 +544,7 @@ describe('currency', function () {
     let logWarnSpy;
 
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
       logWarnSpy = sinon.spy(utils, 'logWarn');
     });

--- a/test/spec/modules/debugging_mod_spec.js
+++ b/test/spec/modules/debugging_mod_spec.js
@@ -593,7 +593,7 @@ describe('bid overrides', function () {
   const logger = prefixLog('TEST');
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -26,7 +26,7 @@ describe('The DFP video support module', function () {
   let sandbox, bid, adUnit;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     bid = {
       videoCacheKey: 'abc',
       adserverTargeting: {

--- a/test/spec/modules/discoveryBidAdapter_spec.js
+++ b/test/spec/modules/discoveryBidAdapter_spec.js
@@ -16,7 +16,7 @@ describe('discovery:BidAdapterTests', function () {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(storage, 'getCookie');
     sandbox.stub(storage, 'setCookie');
     sandbox.stub(storage, 'getDataFromLocalStorage');

--- a/test/spec/modules/dsaControl_spec.js
+++ b/test/spec/modules/dsaControl_spec.js
@@ -6,7 +6,7 @@ import {AuctionIndex} from '../../../src/auctionIndex.js';
 describe('DSA transparency', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/spec/modules/dynamicAdBoostRtdProvider_spec.js
+++ b/test/spec/modules/dynamicAdBoostRtdProvider_spec.js
@@ -16,7 +16,7 @@ describe('markViewed tests', function() {
   };
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   })
 
   afterEach(function() {

--- a/test/spec/modules/eightPodAnalyticsAdapter_spec.js
+++ b/test/spec/modules/eightPodAnalyticsAdapter_spec.js
@@ -12,7 +12,7 @@ describe('eightPodAnalyticAdapter', function() {
   let sandbox;
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     adapterManager.enableAnalytics({
       provider: 'eightPod'
     });

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -634,7 +634,7 @@ describe('E-Planning Adapter', function () {
           storageAllowed: true
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       getWindowTopStub = sandbox.stub(internal, 'getWindowTop');
       getWindowTopStub.returns(createWindow(800));
       resetWinDimensions();
@@ -1114,7 +1114,7 @@ describe('E-Planning Adapter', function () {
     let clock;
     let element;
     let getBoundingClientRectStub;
-    let sandbox = sinon.sandbox.create();
+    let sandbox = sinon.createSandbox();
     let intersectionObserverStub;
     let intersectionCallback;
 
@@ -1481,7 +1481,7 @@ describe('E-Planning Adapter', function () {
   describe('Send eids', function() {
     let sandbox;
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       // TODO: bid adapters should look at request data, not call getGlobal().getUserIds
       sandbox.stub(getGlobal(), 'getUserIds').callsFake(() => ({
         pubcid: 'c29cb2ae-769d-42f6-891a-f53cadee823d',

--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -51,7 +51,7 @@ describe('EUID module', function() {
   before(function() {
     uninstallTcfControl();
     hook.ready();
-    suiteSandbox = sinon.sandbox.create();
+    suiteSandbox = sinon.createSandbox();
     if (typeof window.crypto.subtle === 'undefined') {
       restoreSubtleToUndefined = true;
       window.crypto.subtle = { importKey: () => {}, digest: () => {}, decrypt: () => {}, deriveKey: () => {}, encrypt: () => {}, generateKey: () => {}, exportKey: () => {} };

--- a/test/spec/modules/fanAdapter_spec.js
+++ b/test/spec/modules/fanAdapter_spec.js
@@ -280,7 +280,7 @@ describe('Freedom Ad Network Bid Adapter', function () {
     let sandbox, ajaxStub;
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       ajaxStub = sandbox.stub(ajax, 'ajax');
     });
 

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -57,7 +57,7 @@ describe('fluctAdapter', function () {
     let sb;
 
     beforeEach(function () {
-      sb = sinon.sandbox.create();
+      sb = sinon.createSandbox();
     });
 
     afterEach(function () {

--- a/test/spec/modules/genericAnalyticsAdapter_spec.js
+++ b/test/spec/modules/genericAnalyticsAdapter_spec.js
@@ -8,7 +8,7 @@ describe('Generic analytics', () => {
   describe('adapter', () => {
     let adapter, sandbox, clock;
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(events, 'getEvents').returns([]);
       clock = sandbox.useFakeTimers();
       adapter = new GenericAnalytics();

--- a/test/spec/modules/geolocationRtdProvider_spec.js
+++ b/test/spec/modules/geolocationRtdProvider_spec.js
@@ -21,7 +21,7 @@ describe('Geolocation RTD Provider', function () {
   });
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/test/spec/modules/goldbachBidAdapter_spec.js
+++ b/test/spec/modules/goldbachBidAdapter_spec.js
@@ -275,7 +275,7 @@ describe('GoldbachBidAdapter', function () {
   let ajaxStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ajaxStub = sandbox.stub(ajaxLib, 'ajax');
     sandbox.stub(Math, 'random').returns(0);
   });

--- a/test/spec/modules/gptPreAuction_spec.js
+++ b/test/spec/modules/gptPreAuction_spec.js
@@ -16,7 +16,7 @@ import { taxonomies } from '../../../libraries/gptUtils/gptUtils.js';
 describe('GPT pre-auction module', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/spec/modules/greenbidsBidAdapter_specs.js
+++ b/test/spec/modules/greenbidsBidAdapter_specs.js
@@ -9,7 +9,7 @@ describe('greenbidsBidAdapter', () => {
   let sandbox;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/h12mediaBidAdapter_spec.js
+++ b/test/spec/modules/h12mediaBidAdapter_spec.js
@@ -153,7 +153,7 @@ describe('H12 Media Adapter', function () {
   let sandbox;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(frameElement, 'getBoundingClientRect').returns({
       left: 10,
       top: 10,

--- a/test/spec/modules/humansecurityRtdProvider_spec.js
+++ b/test/spec/modules/humansecurityRtdProvider_spec.js
@@ -24,7 +24,7 @@ describe('humansecurity RTD module', function () {
   const stubWindow = { [sonarStubId]: undefined };
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(utils, 'getWindowSelf').returns(stubWindow);
     sandbox.stub(utils, 'generateUUID').returns(stubUuid);
     sandbox.stub(refererDetection, 'getRefererInfo').returns({ domain: 'example.com' });
@@ -37,7 +37,7 @@ describe('humansecurity RTD module', function () {
     let sandbox2;
     let connectSpy;
     beforeEach(function() {
-      sandbox2 = sinon.sandbox.create();
+      sandbox2 = sinon.createSandbox();
       connectSpy = sandbox.spy();
       // Once the impl script is loaded, it registers the API using session ID
       sandbox2.stub(stubWindow, sonarStubId).value({ connect: connectSpy });
@@ -103,7 +103,7 @@ describe('humansecurity RTD module', function () {
     let callbackSpy;
     let reqBidsConfig;
     beforeEach(function() {
-      sandbox2 = sinon.sandbox.create();
+      sandbox2 = sinon.createSandbox();
       callbackSpy = sandbox2.spy();
       reqBidsConfig = { ortb2Fragments: { bidder: {}, global: {} } };
     });
@@ -164,7 +164,7 @@ describe('humansecurity RTD module', function () {
     let sandbox2;
     let submoduleStub;
     beforeEach(function() {
-      sandbox2 = sinon.sandbox.create();
+      sandbox2 = sinon.createSandbox();
       submoduleStub = sandbox2.stub(hook, 'submodule');
     });
     afterEach(function () {

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -852,7 +852,7 @@ describe('ID5 ID System', function () {
     describe('when legacy cookies are set', () => {
       let sandbox;
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(id5System.storage, 'getCookie');
       });
       afterEach(() => {
@@ -900,7 +900,7 @@ describe('ID5 ID System', function () {
   describe('Local storage', () => {
     let sandbox;
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(id5System.storage, 'localStorageIsEnabled');
     });
     afterEach(() => {
@@ -933,7 +933,7 @@ describe('ID5 ID System', function () {
     let sandbox;
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       mockGdprConsent(sandbox);
       sinon.stub(events, 'getEvents').returns([]);
       coreStorage.removeDataFromLocalStorage(id5System.ID5_STORAGE_NAME);

--- a/test/spec/modules/idImportLibrary_spec.js
+++ b/test/spec/modules/idImportLibrary_spec.js
@@ -42,7 +42,7 @@ describe('IdImportLibrary Tests', function () {
 
   describe('setConfig', function () {
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       clock = sinon.useFakeTimers(1046952000000); // 2003-03-06T12:00:00Z
     });
 

--- a/test/spec/modules/idxIdSystem_spec.js
+++ b/test/spec/modules/idxIdSystem_spec.js
@@ -89,7 +89,7 @@ describe('IDx ID System', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       mockGdprConsent(sandbox);
       adUnits = [getAdUnitMock()];
       init(config);

--- a/test/spec/modules/illuminBidAdapter_spec.js
+++ b/test/spec/modules/illuminBidAdapter_spec.js
@@ -276,7 +276,7 @@ describe('IlluminBidAdapter', function () {
           storageAllowed: true
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 

--- a/test/spec/modules/imdsBidAdapter_spec.js
+++ b/test/spec/modules/imdsBidAdapter_spec.js
@@ -1144,7 +1144,7 @@ describe('imdsBidAdapter ', function () {
     });
 
     it('should not include videoCacheKey property on the returned response when cache url is present in the config', function () {
-      let sandbox = sinon.sandbox.create();
+      let sandbox = sinon.createSandbox();
       let serverRespVideo = {
         body: {
           id: 'abcd1234',

--- a/test/spec/modules/impactifyBidAdapter_spec.js
+++ b/test/spec/modules/impactifyBidAdapter_spec.js
@@ -31,7 +31,7 @@ describe('ImpactifyAdapter', function () {
       }
     };
     sinon.stub(document.body, 'appendChild');
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     getLocalStorageStub = sandbox.stub(STORAGE, 'getDataFromLocalStorage');
     localStorageIsEnabledStub = sandbox.stub(STORAGE, 'localStorageIsEnabled');
   });

--- a/test/spec/modules/inmobiBidAdapter_spec.js
+++ b/test/spec/modules/inmobiBidAdapter_spec.js
@@ -26,7 +26,7 @@ describe('The inmobi bidding adapter', function () {
   beforeEach(function () {
     // mock objects
     utilsMock = sinon.mock(utils);
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     ajaxStub = sandbox.stub(ajax, 'ajax');
     fetchStub = sinon.stub(global, 'fetch').resolves(new Response('OK'));
   });

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -312,7 +312,7 @@ describe('InsticatorBidAdapter', function () {
       getCookieStub = sinon.stub(storage, 'getCookie');
       cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
 
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(utils, 'generateUUID').returns(USER_ID_STUBBED);
     });
 

--- a/test/spec/modules/instreamTracking_spec.js
+++ b/test/spec/modules/instreamTracking_spec.js
@@ -146,7 +146,7 @@ function getMockInput(mediaType) {
 
 describe('Instream Tracking', function () {
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/intersectionRtdProvider_spec.js
+++ b/test/spec/modules/intersectionRtdProvider_spec.js
@@ -28,7 +28,7 @@ describe('Intersection RTD Provider', function () {
   const rtdConfig = {realTimeData: {auctionDelay: 200, dataProviders: [providerConfig]}}
   describe('IntersectionObserver not supported', function() {
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
     afterEach(function() {
       sandbox.restore();
@@ -41,7 +41,7 @@ describe('Intersection RTD Provider', function () {
   });
   describe('IntersectionObserver supported', function() {
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       placeholder = createDiv();
       append();
       const __config = {};

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -198,7 +198,7 @@ describe('invibesBidAdapter:', function () {
     };
     document.cookie = '';
     this.cStub1 = sinon.stub(console, 'info');
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -4411,7 +4411,7 @@ describe('IndexexchangeAdapter', function () {
 
   describe('Features', () => {
     let localStorageValues = {};
-    let sandbox = sinon.sandbox.create();
+    let sandbox = sinon.createSandbox();
     let setDataInLocalStorageStub;
     let getDataFromLocalStorageStub;
     let removeDataFromLocalStorageStub;
@@ -4429,7 +4429,7 @@ describe('IndexexchangeAdapter', function () {
 
     beforeEach(() => {
       localStorageValues = {};
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       setDataInLocalStorageStub = sandbox.stub(storage, 'setDataInLocalStorage').callsFake((key, value) => localStorageValues[key] = value);
       getDataFromLocalStorageStub = sandbox.stub(storage, 'getDataFromLocalStorage').callsFake((key) => localStorageValues[key]);
       removeDataFromLocalStorageStub = sandbox.stub(storage, 'removeDataFromLocalStorage').callsFake((key) => delete localStorageValues[key]);

--- a/test/spec/modules/justpremiumBidAdapter_spec.js
+++ b/test/spec/modules/justpremiumBidAdapter_spec.js
@@ -5,7 +5,7 @@ describe('justpremium adapter', function () {
   let sandbox;
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function() {

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -203,7 +203,7 @@ describe('kargo adapter tests', function() {
 
     testBids = [{ ...minimumBidParams }];
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sinon.useFakeTimers(frozenNow.getTime());
   });
 

--- a/test/spec/modules/koblerBidAdapter_spec.js
+++ b/test/spec/modules/koblerBidAdapter_spec.js
@@ -66,7 +66,7 @@ describe('KoblerAdapter', function () {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/test/spec/modules/kueezRtbBidAdapter_spec.js
+++ b/test/spec/modules/kueezRtbBidAdapter_spec.js
@@ -273,7 +273,7 @@ describe('KueezRtbBidAdapter', function () {
           storageAllowed: true
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
       createFirstPartyDataStub = sandbox.stub(adapter, 'createFirstPartyData').returns({
         pcid: 'pcid',

--- a/test/spec/modules/lemmaDigitalBidAdapter_spec.js
+++ b/test/spec/modules/lemmaDigitalBidAdapter_spec.js
@@ -254,7 +254,7 @@ describe('lemmaDigitalBidAdapter', function () {
         expect(data.device).to.equal(undefined);
       });
       it('Set content from config, set site.content', function () {
-        let sandbox = sinon.sandbox.create();
+        let sandbox = sinon.createSandbox();
         const content = {
           'id': 'alpha-numeric-id'
         };
@@ -294,7 +294,7 @@ describe('lemmaDigitalBidAdapter', function () {
             },
           }
         }];
-        let sandbox = sinon.sandbox.create();
+        let sandbox = sinon.createSandbox();
         const content = {
           'id': 'alpha-numeric-id'
         };
@@ -571,7 +571,7 @@ describe('lemmaDigitalBidAdapter', function () {
       let sandbox, utilsMock, newVideoRequest;
       beforeEach(() => {
         utilsMock = sinon.mock(utils);
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.spy(utils, 'logWarn');
         newVideoRequest = utils.deepClone(videoBidRequests);
       });
@@ -603,7 +603,7 @@ describe('lemmaDigitalBidAdapter', function () {
       const syncurl_iframe = 'https://sync.lemmadigital.com/js/usersync.html?pid=1001';
       let sandbox;
       beforeEach(function () {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
       });
       afterEach(function () {
         sandbox.restore();

--- a/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
+++ b/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
@@ -56,7 +56,7 @@ const configWithNoAuctionInit = {
 
 describe('LiveIntent Analytics Adapter ', () => {
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(events, 'getEvents').returns([]);
     sandbox.stub(config, 'getConfig').withArgs('userSync.userIds').returns(USERID_CONFIG);
     sandbox.stub(utils, 'generateUUID').returns(instanceId);

--- a/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
+++ b/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
@@ -314,7 +314,7 @@ describe('Livewrapped analytics adapter', function () {
   let clock;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     let element = {
       getAttribute: function() {

--- a/test/spec/modules/livewrappedBidAdapter_spec.js
+++ b/test/spec/modules/livewrappedBidAdapter_spec.js
@@ -12,7 +12,7 @@ describe('Livewrapped adapter tests', function () {
     bidderRequest;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     window.livewrapped = undefined;
 

--- a/test/spec/modules/lmpIdSystem_spec.js
+++ b/test/spec/modules/lmpIdSystem_spec.js
@@ -87,7 +87,7 @@ describe('LMPID System', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       mockGdprConsent(sandbox);
       adUnits = [getAdUnitMock()];
       init(config);

--- a/test/spec/modules/luceadBidAdapter_spec.js
+++ b/test/spec/modules/luceadBidAdapter_spec.js
@@ -46,7 +46,7 @@ describe('Lucead Adapter', () => {
     ];
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     it('should trigger impression pixel', function () {

--- a/test/spec/modules/magniteAnalyticsAdapter_spec.js
+++ b/test/spec/modules/magniteAnalyticsAdapter_spec.js
@@ -358,7 +358,7 @@ describe('magnite analytics adapter', function () {
     setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage');
     localStorageIsEnabledStub = sinon.stub(storage, 'localStorageIsEnabled');
     removeDataFromLocalStorageStub = sinon.stub(storage, 'removeDataFromLocalStorage')
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     localStorageIsEnabledStub.returns(true);
 

--- a/test/spec/modules/mantisBidAdapter_spec.js
+++ b/test/spec/modules/mantisBidAdapter_spec.js
@@ -5,7 +5,7 @@ import {sfPostMessage, iframePostMessage} from 'modules/mantisBidAdapter';
 
 describe('MantisAdapter', function () {
   const adapter = newBidder(spec);
-  const sandbox = sinon.sandbox.create();
+  const sandbox = sinon.createSandbox();
   let clock;
 
   beforeEach(function () {

--- a/test/spec/modules/marsmediaBidAdapter_spec.js
+++ b/test/spec/modules/marsmediaBidAdapter_spec.js
@@ -69,7 +69,7 @@ describe('marsmedia adapter tests', function () {
       }
     ];
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(document, 'getElementById').withArgs('Unit-Code').returns(element);
     sandbox.stub(utils, 'getWindowTop').returns(win);
     sandbox.stub(utils, 'getWindowSelf').returns(win);

--- a/test/spec/modules/mediaforceBidAdapter_spec.js
+++ b/test/spec/modules/mediaforceBidAdapter_spec.js
@@ -7,7 +7,7 @@ describe('mediaforce bid adapter', function () {
   let sandbox;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/mediagoBidAdapter_spec.js
+++ b/test/spec/modules/mediagoBidAdapter_spec.js
@@ -146,7 +146,7 @@ describe('mediago:BidAdapterTests', function () {
       let sandbox;
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(storage, 'getCookie');
         sandbox.stub(storage, 'setCookie');
         sandbox.stub(utils, 'generateUUID').returns('new-uuid');

--- a/test/spec/modules/medianetAnalyticsAdapter_spec.js
+++ b/test/spec/modules/medianetAnalyticsAdapter_spec.js
@@ -412,7 +412,7 @@ describe('Media.net Analytics Adapter', function () {
   });
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sinon.useFakeTimers();
   });
 

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -1918,7 +1918,7 @@ let VALID_BID_REQUEST = [{
 describe('Media.net bid adapter', function () {
   let sandbox;
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(window.top, 'innerHeight').value(780)
     sandbox.stub(window.top, 'innerWidth').value(440)
     sandbox.stub(window.top, 'scrollY').value(100)

--- a/test/spec/modules/medianetRtdProvider_spec.js
+++ b/test/spec/modules/medianetRtdProvider_spec.js
@@ -18,7 +18,7 @@ const conf = {
 
 describe('medianet realtime module', function () {
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     window.mnjs = window.mnjs || {};
     window.mnjs.que = window.mnjs.que || [];
     window.mnjs.setData = setDataSpy = sandbox.spy();

--- a/test/spec/modules/merkleIdSystem_spec.js
+++ b/test/spec/modules/merkleIdSystem_spec.js
@@ -81,7 +81,7 @@ describe('Merkle System', function () {
     let ajaxStub;
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sinon.stub(utils, 'logInfo');
       sinon.stub(utils, 'logWarn');
       sinon.stub(utils, 'logError');
@@ -171,7 +171,7 @@ describe('Merkle System', function () {
     let ajaxStub;
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sinon.stub(utils, 'logInfo');
       sinon.stub(utils, 'logWarn');
       sinon.stub(utils, 'logError');

--- a/test/spec/modules/mgidBidAdapter_spec.js
+++ b/test/spec/modules/mgidBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('Mgid bid adapter', function () {
   let logErrorSpy;
   let logWarnSpy;
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     logErrorSpy = sinon.spy(utils, 'logError');
     logWarnSpy = sinon.spy(utils, 'logWarn');
   });

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -18,7 +18,7 @@ describe('Michao Bid Adapter', () => {
     nativeBidRequest = cloneDeep(_nativeBidRequest);
     videoServerResponse = cloneDeep(_videoServerResponse);
     bannerServerResponse = cloneDeep(_bannerServerResponse);
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     domainLoggerMock = sandbox.stub(domainLogger);
     triggerPixelSpy = sandbox.spy(utils, 'triggerPixel');
   });

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -17,7 +17,7 @@ describe('Missena Adapter', function () {
       storageAllowed: true,
     },
   };
-  let sandbox = sinon.sandbox.create();
+  let sandbox = sinon.createSandbox();
   sandbox.stub(config, 'getConfig').withArgs('coppa').returns(true);
   sandbox.stub(autoplay, 'isAutoplayEnabled').returns(false);
   const viewport = { width: getWinDimensions().innerWidth, height: getWinDimensions().innerHeight };

--- a/test/spec/modules/nodalsAiRtdProvider_spec.js
+++ b/test/spec/modules/nodalsAiRtdProvider_spec.js
@@ -150,7 +150,7 @@ describe('NodalsAI RTD Provider', () => {
   const outsideGdprUserConsent = generateGdprConsent({ gdprApplies: false });
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     validConfig = { params: { propertyId: '10312dd2' } };
 

--- a/test/spec/modules/omnidexBidAdapter_spec.js
+++ b/test/spec/modules/omnidexBidAdapter_spec.js
@@ -273,7 +273,7 @@ describe('OmnidexBidAdapter', function () {
           storageAllowed: true
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 

--- a/test/spec/modules/omsBidAdapter_spec.js
+++ b/test/spec/modules/omsBidAdapter_spec.js
@@ -73,7 +73,7 @@ describe('omsBidAdapter', function () {
       },
     }];
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(document, 'getElementById').withArgs('adunit-code').returns(element);
     sandbox.stub(utils, 'getWindowTop').returns(win);
     sandbox.stub(utils, 'getWindowSelf').returns(win);

--- a/test/spec/modules/onomagicBidAdapter_spec.js
+++ b/test/spec/modules/onomagicBidAdapter_spec.js
@@ -55,7 +55,7 @@ describe('onomagicBidAdapter', function() {
       'auctionId': 'ffe9a1f7-7b67-4bda-a8e0-9ee5dc9f442e'
     }];
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(document, 'getElementById').withArgs('adunit-code').returns(element);
     sandbox.stub(utils, 'getWindowTop').returns(win);
     sandbox.stub(utils, 'getWindowSelf').returns(win);

--- a/test/spec/modules/opaMarketplaceBidAdapter_spec.js
+++ b/test/spec/modules/opaMarketplaceBidAdapter_spec.js
@@ -273,7 +273,7 @@ describe('OpaMarketplaceBidAdapter', function () {
           storageAllowed: true
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 

--- a/test/spec/modules/openPairIdSystem_spec.js
+++ b/test/spec/modules/openPairIdSystem_spec.js
@@ -17,7 +17,7 @@ describe('openPairId', function () {
   let logInfoStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     logInfoStub = sandbox.stub(utils, 'logInfo');
   });
   afterEach(() => {

--- a/test/spec/modules/optidigitalBidAdapter_spec.js
+++ b/test/spec/modules/optidigitalBidAdapter_spec.js
@@ -543,7 +543,7 @@ describe('optidigitalAdapterTests', function () {
     const syncurlIframe = 'https://scripts.opti-digital.com/js/presync.html?endpoint=optidigital';
     let test;
     beforeEach(function () {
-      test = sinon.sandbox.create();
+      test = sinon.createSandbox();
       resetSync();
     });
     afterEach(function() {

--- a/test/spec/modules/paapiForGpt_spec.js
+++ b/test/spec/modules/paapiForGpt_spec.js
@@ -14,7 +14,7 @@ describe('paapiForGpt module', () => {
   let sandbox, fledgeAuctionConfig;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     fledgeAuctionConfig = {
       seller: 'bidder',
       mock: 'config'

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -39,7 +39,7 @@ describe('paapi module', () => {
   let sandbox;
   before(reset);
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/spec/modules/pairIdSystem_spec.js
+++ b/test/spec/modules/pairIdSystem_spec.js
@@ -6,7 +6,7 @@ describe('pairId', function () {
   let logInfoStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     logInfoStub = sandbox.stub(utils, 'logInfo');
   });
   afterEach(() => {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -682,7 +682,7 @@ describe('S2S Adapter', function () {
       let sandbox, ortb2Fragments, redactorMocks, s2sReq;
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         redactorMocks = {};
         sandbox.stub(redactor, 'redactor').callsFake((params) => {
           if (!redactorMocks.hasOwnProperty(params.component)) {

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -130,7 +130,7 @@ describe('the price floors module', function () {
   }
   beforeEach(function() {
     clock = sinon.useFakeTimers();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     logErrorSpy = sinon.spy(utils, 'logError');
     logWarnSpy = sinon.spy(utils, 'logWarn');
   });
@@ -2405,7 +2405,7 @@ describe('the price floors module', function () {
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(auctionManager, 'index').get(() => stubAuctionIndex({
         adUnits: [
           {

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -290,7 +290,7 @@ describe('pubmatic analytics adapter', function () {
 
   beforeEach(function () {
     setUADefault();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     requests = server.requests;
 

--- a/test/spec/modules/pubmaticRtdProvider_spec.js
+++ b/test/spec/modules/pubmaticRtdProvider_spec.js
@@ -242,7 +242,7 @@ describe('Pubmatic RTD Provider', () => {
         let logErrorStub;
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
             logErrorStub = sandbox.stub(utils, 'logError');
             floorsData = {
                 "currency": "USD",

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -34,7 +34,7 @@ describe('PubWise Prebid Analytics', function () {
   };
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sandbox.useFakeTimers();
     sandbox.stub(events, 'getEvents').returns([]);
 

--- a/test/spec/modules/pubwiseBidAdapter_spec.js
+++ b/test/spec/modules/pubwiseBidAdapter_spec.js
@@ -874,7 +874,7 @@ describe('PubWiseAdapter', function () {
       }
       beforeEach(() => {
         utilsMock = sinon.mock(utils);
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.spy(utils, 'logWarn');
       });
 

--- a/test/spec/modules/pubxBidAdapter_spec.js
+++ b/test/spec/modules/pubxBidAdapter_spec.js
@@ -70,7 +70,7 @@ describe('pubxAdapter', function () {
   });
 
   describe('getUserSyncs', function () {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
 
     const keywordsText = 'meta1,meta2,meta3,meta4,meta5';
     const descriptionText = 'description1description2description3description4description5description';

--- a/test/spec/modules/quantcastBidAdapter_spec.js
+++ b/test/spec/modules/quantcastBidAdapter_spec.js
@@ -607,7 +607,7 @@ describe('Quantcast adapter', function () {
   describe('propagates coppa', function() {
     let sandbox;
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {

--- a/test/spec/modules/r2b2AnalytiscAdapter_spec.js
+++ b/test/spec/modules/r2b2AnalytiscAdapter_spec.js
@@ -365,7 +365,7 @@ describe('r2b2 Analytics', function () {
   })
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     clock = sandbox.useFakeTimers();
     sandbox.stub(pbEvents, 'getEvents').returns([]);
     getGlobalStub = sandbox.stub(prebidGlobal, 'getGlobal').returns({

--- a/test/spec/modules/realTimeDataModule_spec.js
+++ b/test/spec/modules/realTimeDataModule_spec.js
@@ -73,7 +73,7 @@ describe('Real time module', function () {
 
   before(() => {
     eventHandlers = {};
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(events, 'on').callsFake((event, handler) => {
       if (!eventHandlers.hasOwnProperty(event)) {
         eventHandlers[event] = [];

--- a/test/spec/modules/relaidoBidAdapter_spec.js
+++ b/test/spec/modules/relaidoBidAdapter_spec.js
@@ -27,7 +27,7 @@ describe('RelaidoAdapter', function () {
     mockGpt.disable();
     generateUUIDStub = sinon.stub(utils, 'generateUUID').returns(relaido_uuid);
     triggerPixelStub = sinon.stub(utils, 'triggerPixel');
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     bidRequest = {
       bidder: 'relaido',
       params: {

--- a/test/spec/modules/responsiveAdsBidAdapter_spec.js
+++ b/test/spec/modules/responsiveAdsBidAdapter_spec.js
@@ -8,7 +8,7 @@ describe('responsiveAdsBidAdapter', function() {
   let sandbox;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(utils, 'isSafeFrameWindow').returns(false);
     sandbox.stub(utils, 'canAccessWindowTop').returns(true);
     bidRequests = [{

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -890,7 +890,7 @@ describe('Richaudience adapter tests', function () {
   describe('userSync', function () {
     let sandbox;
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
     afterEach(function () {
       sandbox.restore();

--- a/test/spec/modules/rivrAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rivrAnalyticsAdapter_spec.js
@@ -39,7 +39,7 @@ describe('RIVR Analytics adapter', () => {
   let timer;
 
   before(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     window.rivraddon = {
       analytics: {
         enableAnalytics: () => {},

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -397,7 +397,7 @@ describe('the rubicon adapter', function () {
   }
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     logErrorSpy = sinon.spy(utils, 'logError');
     getFloorResponse = {};
     bidderRequest = {

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -27,7 +27,7 @@ describe('SharedId System', function () {
     let sandbox;
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
     });
@@ -60,7 +60,7 @@ describe('SharedId System', function () {
     let sandbox;
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
     });

--- a/test/spec/modules/shinezRtbBidAdapter_spec.js
+++ b/test/spec/modules/shinezRtbBidAdapter_spec.js
@@ -278,7 +278,7 @@ describe('ShinezRtbBidAdapter', function () {
           storageAllowed: true
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 

--- a/test/spec/modules/sizeMapping_spec.js
+++ b/test/spec/modules/sizeMapping_spec.js
@@ -49,7 +49,7 @@ describe('sizeMapping', function () {
   beforeEach(function () {
     setSizeConfig(sizeConfig);
 
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     matchMediaOverride = {matches: false};
 

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -141,7 +141,7 @@ describe('smaatoBidAdapterTest', () => {
 
       let sandbox;
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
       });
 
       afterEach(() => {

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -12,7 +12,7 @@ describe('stroeerCore bid adapter', function () {
 
   beforeEach(() => {
     bidderRequest = buildBidderRequest();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     fakeServer = sandbox.useFakeServer();
     clock = sandbox.useFakeTimers();
   });

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -190,7 +190,7 @@ describe('Sublime Adapter', function () {
     ];
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     it('should trigger pixel', function () {
@@ -569,7 +569,7 @@ describe('Sublime Adapter', function () {
     const bid = { foo: 'bar' };
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     it('should trigger "bidwon" pixel', function () {
@@ -592,7 +592,7 @@ describe('Sublime Adapter', function () {
     }];
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     it('should trigger "bidtimeout" pixel', function () {

--- a/test/spec/modules/symitriDapRtdProvider_spec.js
+++ b/test/spec/modules/symitriDapRtdProvider_spec.js
@@ -656,7 +656,7 @@ describe('symitriDapRtdProvider', function() {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(() => {

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -12,7 +12,7 @@ describe('Taboola Adapter', function () {
   const TBLA_ID_COOKIE_KEY = 'tbla_id';
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     hasLocalStorage = sandbox.stub(userData.storageManager, 'hasLocalStorage');
     cookiesAreEnabled = sandbox.stub(userData.storageManager, 'cookiesAreEnabled');
     getCookie = sandbox.stub(userData.storageManager, 'getCookie');

--- a/test/spec/modules/tagorasBidAdapter_spec.js
+++ b/test/spec/modules/tagorasBidAdapter_spec.js
@@ -276,7 +276,7 @@ describe('TagorasBidAdapter', function () {
           storageAllowed: true
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 

--- a/test/spec/modules/targetVideoAdServerVideo_spec.js
+++ b/test/spec/modules/targetVideoAdServerVideo_spec.js
@@ -35,7 +35,7 @@ describe('TargetVideo Ad Server Video', function() {
   };
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     bid = {
       videoCacheKey: '123',
       adserverTargeting: {

--- a/test/spec/modules/tcfControl_spec.js
+++ b/test/spec/modules/tcfControl_spec.js
@@ -133,7 +133,7 @@ describe('gdpr enforcement', function () {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     gvlids = {};
     sandbox.stub(GDPR_GVLIDS, 'get').callsFake((name) => ({gvlid: gvlids[name], modules: {}}));
   });

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -11,7 +11,7 @@ describe('teadsBidAdapter', () => {
   let sandbox;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {

--- a/test/spec/modules/timeoutRtdProvider_spec.js
+++ b/test/spec/modules/timeoutRtdProvider_spec.js
@@ -76,7 +76,7 @@ describe('getConnectionSpeed', () => {
 describe('Timeout modifier calculations', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
@@ -207,7 +207,7 @@ describe('Timeout modifier calculations', () => {
 describe('Timeout RTD submodule', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/test/spec/modules/topicsFpdModule_spec.js
+++ b/test/spec/modules/topicsFpdModule_spec.js
@@ -321,7 +321,7 @@ describe('topics', () => {
     describe('caching', () => {
       let sandbox;
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
       })
 
       afterEach(() => {

--- a/test/spec/modules/tpmnBidAdapter_spec.js
+++ b/test/spec/modules/tpmnBidAdapter_spec.js
@@ -122,7 +122,7 @@ const VIDEO_BID_RESPONSE = {
 };
 
 describe('tpmnAdapterTests', function () {
-  let sandbox = sinon.sandbox.create();
+  let sandbox = sinon.createSandbox();
   let getCookieStub;
   beforeEach(function () {
     $$PREBID_GLOBAL$$.bidderSettings = {
@@ -130,7 +130,7 @@ describe('tpmnAdapterTests', function () {
         storageAllowed: true
       }
     };
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     getCookieStub = sinon.stub(storage, 'getCookie');
   });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -598,7 +598,7 @@ describe('triplelift adapter', function () {
           gdprApplies: true
         },
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       logErrorSpy = sinon.spy(utils, 'logError');
 
       $$PREBID_GLOBAL$$.bidderSettings = {

--- a/test/spec/modules/twistDigitalBidAdapter_spec.js
+++ b/test/spec/modules/twistDigitalBidAdapter_spec.js
@@ -298,7 +298,7 @@ describe('TwistDigitalBidAdapter', function () {
           storageAllowed: true,
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -96,7 +96,7 @@ describe(`UID2 module`, function () {
     uninstallTcfControl();
     attachIdSystem(uid2IdSubmodule);
 
-    suiteSandbox = sinon.sandbox.create();
+    suiteSandbox = sinon.createSandbox();
     // I'm unable to find an authoritative source, but apparently subtle isn't available in some test stacks for security reasons.
     // I've confirmed it's available in Firefox since v34 (it seems to be unavailable on BrowserStack in Firefox v106).
     if (typeof window.crypto.subtle === 'undefined') {
@@ -144,7 +144,7 @@ describe(`UID2 module`, function () {
     debugOutput(`----------------- START TEST ------------------`);
     fullTestTitle = getFullTestTitle(this.test.ctx.currentTest);
     debugOutput(fullTestTitle);
-    testSandbox = sinon.sandbox.create();
+    testSandbox = sinon.createSandbox();
     testSandbox.stub(utils, 'logWarn');
     init(config);
     setSubmoduleRegistry([uid2IdSubmodule]);

--- a/test/spec/modules/undertoneBidAdapter_spec.js
+++ b/test/spec/modules/undertoneBidAdapter_spec.js
@@ -314,7 +314,7 @@ describe('Undertone Adapter', () => {
         getBoundingClientRect() { return { left: 100, top: 100, width: 300, height: 250 }; }
       };
 
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(document, 'getElementById').withArgs('div-gpt-ad-1460505748561-0').returns(element);
     });
 

--- a/test/spec/modules/uniquestAnalyticsAdapter_spec.js
+++ b/test/spec/modules/uniquestAnalyticsAdapter_spec.js
@@ -383,7 +383,7 @@ describe('Uniquest Analytics Adapter', function () {
   let requests;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     requests = server.requests;
     sandbox.stub(events, 'getEvents').returns([]);
   });

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -128,7 +128,7 @@ describe('UnrulyAdapter', function () {
   let fakeRenderer;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(utils, 'logError');
     sandbox.stub(Renderer, 'install');
 

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -167,7 +167,7 @@ describe('User ID', function () {
 
   beforeEach(function () {
     resetConsentData();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     consentData = null;
     mockGdprConsent(sandbox, () => consentData);
     coreStorage.setCookie(CONSENT_LOCAL_STORAGE_NAME, '', EXPIRED_COOKIE_DATE);

--- a/test/spec/modules/vidazooBidAdapter_spec.js
+++ b/test/spec/modules/vidazooBidAdapter_spec.js
@@ -299,7 +299,7 @@ describe('VidazooBidAdapter', function () {
           storageAllowed: true,
         }
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 

--- a/test/spec/modules/visxBidAdapter_spec.js
+++ b/test/spec/modules/visxBidAdapter_spec.js
@@ -1056,7 +1056,7 @@ describe('VisxAdapter', function () {
     let documentStub;
 
     before(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       documentStub = sandbox.stub(document, 'getElementById');
       documentStub.withArgs('visx-adunit-code-1').returns({
         id: 'visx-adunit-code-1'

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -264,7 +264,7 @@ describe('weboramaRtdProvider', function() {
     let sandbox;
 
     beforeEach(function() {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
 
       storage.removeDataFromLocalStorage(DEFAULT_LOCAL_STORAGE_USER_PROFILE_KEY);
 

--- a/test/spec/modules/zeta_global_sspAnalyticsAdapter_spec.js
+++ b/test/spec/modules/zeta_global_sspAnalyticsAdapter_spec.js
@@ -526,7 +526,7 @@ describe('Zeta Global SSP Analytics Adapter', function () {
   let requests;
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     requests = server.requests;
     sandbox.stub(events, 'getEvents').returns([]);
     config.setConfig({ pageUrl: 'https://www.config.domain.com/index.html' })

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -27,7 +27,7 @@ import {
 describe('adRendering', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(utils, 'logWarn');
     sandbox.stub(utils, 'logError');
   })

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -107,7 +107,7 @@ describe('adapterManager tests', function () {
   });
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
   afterEach(() => {
     s2sTesting.clientTestBidders.clear();
@@ -2324,7 +2324,7 @@ describe('adapterManager tests', function () {
     describe('sizeMapping', function () {
       let sandbox;
       beforeEach(function () {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         // always have matchMedia return true for us
         sandbox.stub(utils.getWindowTop(), 'matchMedia').callsFake(() => ({matches: true}));
       });

--- a/test/spec/unit/core/ajax_spec.js
+++ b/test/spec/unit/core/ajax_spec.js
@@ -330,7 +330,7 @@ describe('attachCallbacks', () => {
     describe(`for ${t}`, () => {
       let sandbox, response, body;
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.spy(utils, 'logError');
         ({response, body} = makeResponse());
       });

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -78,7 +78,7 @@ describe('bidderFactory', () => {
       let aliasRegistryStub, aliasRegistry;
 
       beforeEach(function () {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(activityRules, 'isActivityAllowed').callsFake(() => true);
         ajaxStub = sandbox.stub(ajax, 'ajax');
         addBidResponseStub.resetHistory();

--- a/test/spec/unit/core/bidderSettings_spec.js
+++ b/test/spec/unit/core/bidderSettings_spec.js
@@ -110,7 +110,7 @@ describe('ScopedSettings', () => {
 describe('bidderSettings', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sandbox.stub(prebidGlobal, 'getGlobal').returns({
       bidderSettings: {
         scope: {

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -252,7 +252,7 @@ describe('targeting tests', function () {
   });
 
   beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
 
     useBidCache = true;
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -217,7 +217,7 @@ describe('Unit: Prebid Module', function () {
   });
 
   beforeEach(function () {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     mockFpdEnrichments(sandbox);
     bidExpiryStub = sinon.stub(filters, 'isBidNotExpired').callsFake(() => true);
     configObj.setConfig({ useBidCache: true });
@@ -1759,7 +1759,7 @@ describe('Unit: Prebid Module', function () {
   describe('requestBids', function () {
     let sandbox;
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
     afterEach(function () {
       sandbox.restore();

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -32,7 +32,7 @@ describe('secureCreatives', () => {
   });
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/test/spec/utils/prerendering_spec.js
+++ b/test/spec/utils/prerendering_spec.js
@@ -3,7 +3,7 @@ import {delayIfPrerendering} from '../../../src/utils/prerendering.js';
 describe('delayIfPrerendering', () => {
   let sandbox, enabled, ran;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     enabled = true;
     ran = false;
   });

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -25,7 +25,7 @@ describe('Utils', function () {
     let sandbox;
 
     beforeEach(function () {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
     });
 
     afterEach(function () {


### PR DESCRIPTION
## Summary
- modernize sinon usage

## Testing
- `npm run lint`
- `npx gulp test --file test/helpers/fpd.js --nolint` *(fails: Error: Karma tests failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_b_684205844f30832ba0c46e295b0c2a7d