### PR TITLE
adapter: fix amxId error return

### DIFF
--- a/modules/amxIdSystem.js
+++ b/modules/amxIdSystem.js
@@ -48,14 +48,14 @@ function handleSyncResponse(client, response, params, callback) {
   }
 
   if (response.u == null || response.u.length === 0) {
-    callback(null);
+    callback(undefined);
     return;
   }
 
   client(response.u, {
     error(e) {
       logError(`${NAME} failed on ${response.u}`, e);
-      callback(null);
+      callback(undefined);
     },
     success(complete) {
       if (complete != null && complete.length > 0) {
@@ -67,7 +67,7 @@ function handleSyncResponse(client, response, params, callback) {
       }
 
       logError(`${NAME} invalid value`, complete);
-      callback(null);
+      callback(undefined);
     },
   }, params, AJAX_OPTIONS);
 }
@@ -130,7 +130,7 @@ export const amxIdSubmodule = {
         {
           error(e) {
             logError(`${NAME} failed to load`, e);
-            done(null);
+            done(undefined);
           },
           success(responseText) {
             if (responseText != null && responseText.length > 0) {
@@ -143,7 +143,7 @@ export const amxIdSubmodule = {
               }
             }
 
-            done(null);
+            done(undefined);
           },
         },
         params,


### PR DESCRIPTION
## Summary
- update `amxIdSystem` so callbacks return `undefined` when responses are invalid or error

## Testing
- `node node_modules/eslint/bin/eslint.js modules/amxIdSystem.js test/spec/modules/amxIdSystem_spec.js`
- `npx gulp test --file test/spec/modules/amxIdSystem_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_684215658324832b888a05771c155304