### PR TITLE
adapter: fix utils mock in cointraffic tests

### DIFF
--- a/test/spec/modules/cointrafficBidAdapter_spec.js
+++ b/test/spec/modules/cointrafficBidAdapter_spec.js
@@ -97,7 +97,8 @@ describe('cointrafficBidAdapter', function () {
     });
 
     it('throws an error if currency provided in params is not allowed', function () {
-      const utilsMock = sinon.mock(utils).expects('logError').twice()
+      const utilsMock = sinon.mock(utils)
+      utilsMock.expects('logError').twice()
       const getConfigStub = sinon.stub(config, 'getConfig').callsFake(
         arg => arg === 'currency.bidderCurrencyDefault.cointraffic' ? 'BTC' : 'EUR'
       );


### PR DESCRIPTION
## Summary
- fix utils mock object in Cointraffic bid adapter tests

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/modules/cointrafficBidAdapter_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_684220e26a00832b8d96cbc812660f4b