### PR TITLE
core: guard liveIntent test stubs

### DIFF
--- a/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
+++ b/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
@@ -69,8 +69,8 @@ describe('LiveIntent Analytics Adapter ', () => {
   });
   afterEach(function () {
     liAnalytics.disableAnalytics();
-    sandbox.restore();
-    clock.restore();
+    sandbox?.restore();
+    clock?.restore();
     window.liTreatmentRate = undefined
     window.liModuleEnabled = undefined
   });

--- a/test/spec/modules/liveIntentExternalIdSystem_spec.js
+++ b/test/spec/modules/liveIntentExternalIdSystem_spec.js
@@ -24,12 +24,12 @@ describe('LiveIntentExternalId', function() {
   });
 
   afterEach(function() {
-    uspConsentDataStub.restore();
-    gdprConsentDataStub.restore();
-    gppConsentDataStub.restore();
-    coppaConsentDataStub.restore();
-    refererInfoStub.restore();
-    randomStub.restore();
+    uspConsentDataStub?.restore();
+    gdprConsentDataStub?.restore();
+    gppConsentDataStub?.restore();
+    coppaConsentDataStub?.restore();
+    refererInfoStub?.restore();
+    randomStub?.restore();
     window.liQHub = []; // reset
     window.liModuleEnabled = undefined; // reset
     window.liTreatmentRate = undefined; // reset

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -29,13 +29,13 @@ describe('LiveIntentMinimalId', function() {
   });
 
   afterEach(function() {
-    imgStub.restore();
-    getCookieStub.restore();
-    getDataFromLocalStorageStub.restore();
-    logErrorStub.restore();
-    uspConsentDataStub.restore();
-    gdprConsentDataStub.restore();
-    refererInfoStub.restore();
+    imgStub?.restore();
+    getCookieStub?.restore();
+    getDataFromLocalStorageStub?.restore();
+    logErrorStub?.restore();
+    uspConsentDataStub?.restore();
+    gdprConsentDataStub?.restore();
+    refererInfoStub?.restore();
     liveIntentIdSubmodule.setModuleMode('minimal');
     resetLiveIntentIdSubmodule();
   });

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -52,16 +52,16 @@ describe('LiveIntentId', function() {
   });
 
   afterEach(function() {
-    imgStub.restore();
-    getCookieStub.restore();
-    getDataFromLocalStorageStub.restore();
-    logErrorStub.restore();
-    uspConsentDataStub.restore();
-    gdprConsentDataStub.restore();
-    gppConsentDataStub.restore();
-    coppaConsentDataStub.restore();
-    refererInfoStub.restore();
-    randomStub.restore();
+    imgStub?.restore();
+    getCookieStub?.restore();
+    getDataFromLocalStorageStub?.restore();
+    logErrorStub?.restore();
+    uspConsentDataStub?.restore();
+    gdprConsentDataStub?.restore();
+    gppConsentDataStub?.restore();
+    coppaConsentDataStub?.restore();
+    refererInfoStub?.restore();
+    randomStub?.restore();
     window.liModuleEnabled = undefined; // reset
     window.liTreatmentRate = undefined; // reset
     resetLiveIntentIdSubmodule();


### PR DESCRIPTION
## Summary
- prevent errors when restoring LiveIntent stubs after sinon upgrade

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/modules/liveIntentIdSystem_spec.js`
- `npx gulp test --file test/spec/modules/liveIntentIdMinimalSystem_spec.js`
- `npx gulp test --file test/spec/modules/liveIntentExternalIdSystem_spec.js`
- `npx gulp test --file test/spec/modules/liveIntentAnalyticsAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_684221e3e6b4832b9c4d86406f79582d