### PR TITLE
adapter: handle non-array responses for colombia

### DIFF
--- a/modules/colombiaBidAdapter.js
+++ b/modules/colombiaBidAdapter.js
@@ -65,8 +65,10 @@ export const spec = {
   },
   interpretResponse: function(serverResponse, bidRequest) {
     const bidResponses = [];
-    const res = serverResponse.body || serverResponse;
-    if (!res || res.length === 0) {
+    const res = Array.isArray(serverResponse?.body)
+      ? serverResponse.body
+      : (Array.isArray(serverResponse) ? serverResponse : []);
+    if (res.length === 0) {
       return bidResponses;
     }
     try {


### PR DESCRIPTION
## Summary
- fix `interpretResponse` to safely process non-array response bodies in the Colombia adapter

## Testing
- `gulp lint`
- `gulp test --file test/spec/modules/colombiaBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68422aa3ee78832bad15f357799e3a30