### PR TITLE
adapter: ensure compass user sync tests run with bidder context

### DIFF
--- a/test/spec/modules/compassBidAdapter_spec.js
+++ b/test/spec/modules/compassBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { spec } from '../../../modules/compassBidAdapter.js';
 import { BANNER, VIDEO, NATIVE } from '../../../src/mediaTypes.js';
 import { getUniqueIdentifierStr } from '../../../src/utils.js';
+import { config } from '../../../src/config.js';
 
 const bidder = 'compass';
 
@@ -480,10 +481,10 @@ describe('CompassBidAdapter', function () {
 
   describe('getUserSyncs', function() {
     it('Should return array of objects with proper sync config , include GDPR', function() {
-      const syncData = spec.getUserSyncs({}, {}, {
+      const syncData = config.runWithBidder(bidder, () => spec.getUserSyncs({}, {}, {
         consentString: 'ALL',
         gdprApplies: true,
-      }, {});
+      }, {}));
       expect(syncData).to.be.an('array').which.is.not.empty;
       expect(syncData[0]).to.be.an('object')
       expect(syncData[0].type).to.be.a('string')
@@ -492,9 +493,9 @@ describe('CompassBidAdapter', function () {
       expect(syncData[0].url).to.equal('https://sa-cs.deliverimp.com/image?pbjs=1&gdpr=1&gdpr_consent=ALL&coppa=0')
     });
     it('Should return array of objects with proper sync config , include CCPA', function() {
-      const syncData = spec.getUserSyncs({}, {}, {}, {
+      const syncData = config.runWithBidder(bidder, () => spec.getUserSyncs({}, {}, {}, {
         consentString: '1---'
-      });
+      }));
       expect(syncData).to.be.an('array').which.is.not.empty;
       expect(syncData[0]).to.be.an('object')
       expect(syncData[0].type).to.be.a('string')
@@ -503,10 +504,10 @@ describe('CompassBidAdapter', function () {
       expect(syncData[0].url).to.equal('https://sa-cs.deliverimp.com/image?pbjs=1&ccpa_consent=1---&coppa=0')
     });
     it('Should return array of objects with proper sync config , include GPP', function() {
-      const syncData = spec.getUserSyncs({}, {}, {}, {}, {
+      const syncData = config.runWithBidder(bidder, () => spec.getUserSyncs({}, {}, {}, {}, {
         gppString: 'abc123',
         applicableSections: [8]
-      });
+      }));
       expect(syncData).to.be.an('array').which.is.not.empty;
       expect(syncData[0]).to.be.an('object')
       expect(syncData[0].type).to.be.a('string')


### PR DESCRIPTION
## Summary
- update Compass adapter tests to run getUserSyncs in bidder context

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/modules/compassBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_684228236ffc832ba8ab3aef19694a86