### PR TITLE
Implement eslint caching in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,21 @@ jobs:
     <<: *environment
     steps: *unit_test_steps
 
+  lint:
+    <<: *environment
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - eslint-cache-{{ checksum "package-lock.json" }}-{{ checksum "eslint.config.js" }}-{{ checksum ".gitignore" }}
+      - run:
+          name: 'Run ESLint'
+          command: npx eslint '**/*.{js,ts,tsx}' --cache --cache-strategy content
+      - save_cache:
+          key: eslint-cache-{{ checksum "package-lock.json" }}-{{ checksum "eslint.config.js" }}-{{ checksum ".gitignore" }}
+          paths:
+            - .eslintcache
+
   e2etest:
     <<: *environment
     steps: *endtoend_test_steps
@@ -66,6 +81,7 @@ workflows:
   version: 2
   commit:
     jobs:
+      - lint
       - build
       - e2etest:
           requires:


### PR DESCRIPTION
## Summary
- run eslint with `--cache-strategy content`
- persist `.eslintcache` across CircleCI runs

## Testing
- `npm run lint` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_b_6842b2a46d50832b8aa7c44193e32478