### PR TITLE
Add babel cache to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ aliases:
   - &save_dep_cache
       paths:
         - node_modules
+        - node_modules/.cache/babel-loader
       key: v1-dependencies-{{ checksum "package.json" }}
 
   - &install

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -78,7 +78,7 @@ module.exports = {
         use: [
           {
             loader: 'babel-loader',
-            options: Object.assign({}, babelConfig, helpers.getAnalyticsOptions()),
+            options: Object.assign({}, babelConfig, helpers.getAnalyticsOptions(), {cacheDirectory: true}),
           }
         ]
       },
@@ -88,7 +88,7 @@ module.exports = {
         use: [
           {
             loader: 'babel-loader',
-            options: babelConfig
+            options: Object.assign({}, babelConfig, {cacheDirectory: true})
           }
         ],
       }

--- a/webpack.debugging.js
+++ b/webpack.debugging.js
@@ -21,7 +21,8 @@ module.exports = {
         exclude: path.resolve('./node_modules'), // required to prevent loader from choking non-Prebid.js node_modules
         use: [
           {
-            loader: 'babel-loader'
+            loader: 'babel-loader',
+            options: {cacheDirectory: true}
           }
         ]
       },


### PR DESCRIPTION
## Summary
- cache babel compilation in CircleCI
- enable `cacheDirectory` for babel-loader

## Testing
- `npm test` *(fails: build timed out)*

------
https://chatgpt.com/codex/tasks/task_b_6842bddf7500832b976980f3d83047c2