### PR TITLE
test: avoid double-stubbing logError

### DIFF
--- a/test/spec/modules/growthCodeIdSystem_spec.js
+++ b/test/spec/modules/growthCodeIdSystem_spec.js
@@ -25,13 +25,20 @@ describe('growthCodeIdSystem', () => {
   let logErrorStub;
 
   beforeEach(function () {
+    if (utils.logError.restore) {
+      utils.logError.restore();
+    }
     logErrorStub = sinon.stub(utils, 'logError');
     storage.setDataInLocalStorage('gcid', GCID, null);
     storage.setDataInLocalStorage('customerEids', EIDS, null);
   });
 
   afterEach(function () {
-    logErrorStub.restore();
+    if (logErrorStub && logErrorStub.restore) {
+      logErrorStub.restore();
+    } else if (utils.logError.restore) {
+      utils.logError.restore();
+    }
   });
 
   describe('name', () => {


### PR DESCRIPTION
## Summary
- ensure logError is unwrapped before stubbing in growthCodeId system spec

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/modules/growthCodeIdSystem_spec.js --file test/spec/modules/h12mediaBidAdapter_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_6842d634dcb8832b89e1fde868f3ab2f