### PR TITLE
test: fix stub handling

### DIFF
--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -1277,6 +1277,7 @@ describe('ID5 ID System', function () {
         let logErrorSpy;
 
         beforeEach(function () {
+          utils.logError.restore?.();
           logErrorSpy = sinon.spy(utils, 'logError');
         });
         afterEach(function () {

--- a/test/spec/modules/idImportLibrary_spec.js
+++ b/test/spec/modules/idImportLibrary_spec.js
@@ -28,6 +28,8 @@ describe('IdImportLibrary Tests', function () {
   });
 
   beforeEach(function () {
+    utils.logInfo.restore?.();
+    utils.logError.restore?.();
     sinon.stub(utils, 'logInfo');
     sinon.stub(utils, 'logError');
   });


### PR DESCRIPTION
## Summary
- prevent double stubbing of utils logging functions in test suites

## Testing
- `npx gulp lint` *(fails: Command timed out)*
- `npx gulp test --file test/spec/modules/idImportLibrary_spec.js` *(fails: Command timed out)*

------
https://chatgpt.com/codex/tasks/task_b_6842d646d610832b929ad05ada4c42ab