### PR TITLE
core: handle missing dataset

### DIFF
--- a/modules/gptPreAuction.js
+++ b/modules/gptPreAuction.js
@@ -151,7 +151,7 @@ export const appendPbAdSlot = adUnit => {
   // use data attribute 'data-adslotid' if set
   try {
     const adUnitCodeDiv = document.getElementById(adUnit.code);
-    if (adUnitCodeDiv.dataset.adslotid) {
+    if (adUnitCodeDiv && adUnitCodeDiv.dataset && adUnitCodeDiv.dataset.adslotid) {
       context.pbadslot = adUnitCodeDiv.dataset.adslotid;
       return;
     }

--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -438,6 +438,9 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
 
   describe('isSampled when analytic isforced', function () {
     before(() => {
+      if (utils.getParameterByName.restore) {
+        utils.getParameterByName.restore();
+      }
       sinon.stub(utils, 'getParameterByName').callsFake(par => par === 'greenbids_force_sampling' ? true : undefined);
     });
     it('should return determinist true when sampling flag activated', function () {


### PR DESCRIPTION
## Summary
- prevent errors when dataset is missing in `appendPbAdSlot`
- make Greenbids analytics spec resilient to previous stubs

Attempted running `gulp lint` and `gulp test` but they didn't finish in this environment.


------
https://chatgpt.com/codex/tasks/task_b_6842d61d7868832b91c52051cee2857a