### PR TITLE
test: fix dmdIdSystem spec stubbing

### DIFF
--- a/test/spec/modules/dmdIdSystem_spec.js
+++ b/test/spec/modules/dmdIdSystem_spec.js
@@ -12,11 +12,16 @@ describe('Dmd ID System', function () {
   };
 
   beforeEach(function () {
+    if (utils.logError.restore && utils.logError.restore.sinon) {
+      utils.logError.restore();
+    }
     logErrorStub = sinon.stub(utils, 'logError');
   });
 
   afterEach(function () {
-    logErrorStub.restore();
+    if (logErrorStub && logErrorStub.restore) {
+      logErrorStub.restore();
+    }
   });
 
   it('should log an error if no configParams were passed into getId', function () {


### PR DESCRIPTION
## Summary
- avoid double wrapping utils.logError in dmd ID system tests

## Testing
- `npx eslint test/spec/modules/dmdIdSystem_spec.js`
- `npx gulp test --file test/spec/modules/dmdIdSystem_spec.js --nolint`
- `npx gulp test --file test/spec/modules/eplanningBidAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6842d5b20f38832b8d72c6620feaedac