### PR TITLE
test: fix cmp stub restore

### DIFF
--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -486,7 +486,9 @@ describe('consentManagement', function () {
 
       afterEach(function () {
         config.resetConfig();
-        cmpStub.restore();
+        if (window.__tcfapi) {
+          cmpStub.restore();
+        }
         utils.logError.restore();
         utils.logWarn.restore();
         resetConsentData();


### PR DESCRIPTION
## Summary
- avoid restoring cmp stub when `window.__tcfapi` has been deleted

## Testing
- `npx gulp lint` *(fails: process hangs)*
- `npx gulp test --file test/spec/modules/consentManagement_spec.js` *(fails: process hangs)*


------
https://chatgpt.com/codex/tasks/task_b_6842dffeee7c832b9983723bda39f185