### PR TITLE
tests: use loadExternalScriptStub

### DIFF
--- a/test/spec/modules/a1MediaRtdProvider_spec.js
+++ b/test/spec/modules/a1MediaRtdProvider_spec.js
@@ -1,5 +1,5 @@
 import { subModuleObj } from 'modules/a1MediaRtdProvider.js';
-import { loadExternalScript } from '../../../src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 import { A1_AUD_KEY, A1_SEG_KEY, getStorageData, storage } from '../../../modules/a1MediaRtdProvider.js';
 import { expect } from 'chai';
 
@@ -55,15 +55,15 @@ describe('a1MediaRtdProvider', function() {
       it('successfully initialize with load script', function() {
         expect(subModuleObj.init(configWithParams)).to.be.true;
         expect(window.linkback.l).to.be.true;
-        expect(loadExternalScript.called).to.be.true;
-        expect(loadExternalScript.args[0][0]).to.deep.equal('https://linkback.contentsfeed.com/src/lb4test.min.js');
+        expect(loadExternalScriptStub.called).to.be.true;
+        expect(loadExternalScriptStub.args[0][0]).to.deep.equal('https://linkback.contentsfeed.com/src/lb4test.min.js');
       })
 
       it('successfully initialize but script is already exist', function() {
         const linkback = { l: true };
 
         expect(subModuleObj.init(configWithParams)).to.be.true;
-        expect(loadExternalScript.called).to.be.false;
+        expect(loadExternalScriptStub.called).to.be.false;
       })
     });
 

--- a/test/spec/modules/adagioRtdProvider_spec.js
+++ b/test/spec/modules/adagioRtdProvider_spec.js
@@ -5,7 +5,7 @@ import {
   storage,
 } from 'modules/adagioRtdProvider.js';
 import * as utils from 'src/utils.js';
-import { loadExternalScript } from '../../../src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 import { expect } from 'chai';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 
@@ -106,13 +106,13 @@ describe('Adagio Rtd Provider', function () {
     it('load an external script if localStorageIsEnabled is enabled', function () {
       sandbox.stub(storage, 'localStorageIsEnabled').callsArgWith(0, true)
       adagioRtdSubmodule.init(config);
-      expect(loadExternalScript.called).to.be.true;
+      expect(loadExternalScriptStub.called).to.be.true;
     });
 
     it('do not load an external script if localStorageIsEnabled is disabled', function () {
       sandbox.stub(storage, 'localStorageIsEnabled').callsArgWith(0, false)
       adagioRtdSubmodule.init(config);
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
     });
 
     describe('store session data in localStorage', function () {

--- a/test/spec/modules/airgridRtdProvider_spec.js
+++ b/test/spec/modules/airgridRtdProvider_spec.js
@@ -1,7 +1,7 @@
 import {config} from 'src/config.js';
 import {deepAccess} from 'src/utils.js';
 import * as agRTD from 'modules/airgridRtdProvider.js';
-import {loadExternalScript} from '../../../src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 
 const MATCHED_AUDIENCES = ['travel', 'sport'];
 const RTD_CONFIG = {
@@ -40,7 +40,7 @@ describe('airgrid RTD Submodule', function () {
       expect(agRTD.airgridSubmodule.init(RTD_CONFIG.dataProviders[0])).to.equal(
         true
       );
-      expect(loadExternalScript.called).to.be.true
+      expect(loadExternalScriptStub.called).to.be.true
     });
 
     it('should attach script to DOM with correct config', function () {

--- a/test/spec/modules/anonymisedRtdProvider_spec.js
+++ b/test/spec/modules/anonymisedRtdProvider_spec.js
@@ -1,6 +1,6 @@
 import {config} from 'src/config.js';
 import {getRealTimeData, anonymisedRtdSubmodule, storage} from 'modules/anonymisedRtdProvider.js';
-import { loadExternalScript } from '../../../src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 
 describe('anonymisedRtdProvider', function() {
   let getDataFromLocalStorageStub;
@@ -44,7 +44,7 @@ describe('anonymisedRtdProvider', function() {
         }
       };
       anonymisedRtdSubmodule.init(rtdConfig, {});
-      expect(loadExternalScript.called).to.be.true;
+      expect(loadExternalScriptStub.called).to.be.true;
     });
     it('should not load external script when params.tagConfig.clientId is not set', function () {
       const rtdConfig = {
@@ -53,14 +53,14 @@ describe('anonymisedRtdProvider', function() {
         }
       };
       anonymisedRtdSubmodule.init(rtdConfig, {});
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
     });
     it('should not load external script when params.tagConfig is not defined', function () {
       const rtdConfig = {
         params: {}
       };
       anonymisedRtdSubmodule.init(rtdConfig, {});
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
     });
     it('should not load external script when params.tagConfig.clientId is empty string', function () {
       const rtdConfig = {
@@ -71,7 +71,7 @@ describe('anonymisedRtdProvider', function() {
         }
       };
       anonymisedRtdSubmodule.init(rtdConfig, {});
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
     });
     it('should not load external script when params.tagConfig.clientId is not a string', function () {
       const rtdConfig = {
@@ -82,7 +82,7 @@ describe('anonymisedRtdProvider', function() {
         }
       };
       anonymisedRtdSubmodule.init(rtdConfig, {});
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
     });
     it('should load external script with correct attributes', function () {
       const rtdConfig = {
@@ -98,8 +98,8 @@ describe('anonymisedRtdProvider', function() {
         idw_client_id: 'testId'
       };
 
-      expect(loadExternalScript.args[0][0]).to.deep.equal(expected);
-      expect(loadExternalScript.args[0][5]).to.deep.equal(expectedTagConfig);
+      expect(loadExternalScriptStub.args[0][0]).to.deep.equal(expected);
+      expect(loadExternalScriptStub.args[0][5]).to.deep.equal(expectedTagConfig);
     });
     it('should not load external script when it is already loaded', function () {
       const rtdConfig = {
@@ -113,7 +113,7 @@ describe('anonymisedRtdProvider', function() {
       script.src = 'https://static.anonymised.io/light/loader.js?random=quary';
       document.body.appendChild(script);
       anonymisedRtdSubmodule.init(rtdConfig, {});
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
     });
     it('should load external script from tagUrl when it is set', function () {
       const rtdConfig = {
@@ -127,7 +127,7 @@ describe('anonymisedRtdProvider', function() {
       anonymisedRtdSubmodule.init(rtdConfig, {});
       const expected = 'https://example.io/loader.js';
 
-      expect(loadExternalScript.args[0][0]).to.deep.equal(expected);
+      expect(loadExternalScriptStub.args[0][0]).to.deep.equal(expected);
     });
     it('should not load external script from tagUrl when it is already loaded', function () {
       const rtdConfig = {
@@ -142,7 +142,7 @@ describe('anonymisedRtdProvider', function() {
       script.src = 'https://example.io/loader.js';
       document.body.appendChild(script);
       anonymisedRtdSubmodule.init(rtdConfig, {});
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
     });
   });
 

--- a/test/spec/modules/arcspanRtdProvider_spec.js
+++ b/test/spec/modules/arcspanRtdProvider_spec.js
@@ -1,6 +1,6 @@
 import { arcspanSubmodule } from 'modules/arcspanRtdProvider.js';
 import { expect } from 'chai';
-import { loadExternalScript } from 'src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 
 describe('arcspanRtdProvider', function () {
   describe('init', function () {
@@ -11,22 +11,22 @@ describe('arcspanRtdProvider', function () {
 
     it('successfully initializes with a valid silo ID', function () {
       expect(arcspanSubmodule.init(getGoodConfig())).to.equal(true);
-      expect(loadExternalScript.called).to.be.ok;
-      expect(loadExternalScript.args[0][0]).to.deep.equal('https://silo13.p7cloud.net/as.js');
-      loadExternalScript.resetHistory();
+      expect(loadExternalScriptStub.called).to.be.ok;
+      expect(loadExternalScriptStub.args[0][0]).to.deep.equal('https://silo13.p7cloud.net/as.js');
+      loadExternalScriptStub.resetHistory();
     });
 
     it('fails to initialize with a missing silo ID', function () {
       expect(arcspanSubmodule.init(getBadConfig())).to.equal(false);
-      expect(loadExternalScript.called).to.be.not.ok;
-      loadExternalScript.resetHistory();
+      expect(loadExternalScriptStub.called).to.be.not.ok;
+      loadExternalScriptStub.resetHistory();
     });
 
     it('drops localhost script for test silo', function () {
       expect(arcspanSubmodule.init(getTestConfig())).to.equal(true);
-      expect(loadExternalScript.called).to.be.ok;
-      expect(loadExternalScript.args[0][0]).to.deep.equal('https://localhost:8080/as.js');
-      loadExternalScript.resetHistory();
+      expect(loadExternalScriptStub.called).to.be.ok;
+      expect(loadExternalScriptStub.args[0][0]).to.deep.equal('https://localhost:8080/as.js');
+      loadExternalScriptStub.resetHistory();
     });
   });
 

--- a/test/spec/modules/azerionedgeRtdProvider_spec.js
+++ b/test/spec/modules/azerionedgeRtdProvider_spec.js
@@ -1,6 +1,6 @@
 import { config } from 'src/config.js';
 import * as azerionedgeRTD from 'modules/azerionedgeRtdProvider.js';
-import { loadExternalScript } from '../../../src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 
 describe('Azerion Edge RTD submodule', function () {
   const STORAGE_KEY = 'ht-pa-v1-a';
@@ -17,7 +17,7 @@ describe('Azerion Edge RTD submodule', function () {
 
   const resetAll = () => {
     window.azerionPublisherAudiences.resetHistory();
-    loadExternalScript.resetHistory();
+    loadExternalScriptStub.resetHistory();
   }
 
   let reqBidsConfigObj;
@@ -51,12 +51,12 @@ describe('Azerion Edge RTD submodule', function () {
     });
 
     it('should load external script', function () {
-      expect(loadExternalScript.called).to.be.true;
+      expect(loadExternalScriptStub.called).to.be.true;
     });
 
     it('should load external script with default versioned url', function () {
       const expected = 'https://edge.hyth.io/js/v1/azerion-edge.min.js';
-      expect(loadExternalScript.args[0][0]).to.deep.equal(expected);
+      expect(loadExternalScriptStub.args[0][0]).to.deep.equal(expected);
     });
 
     [
@@ -82,7 +82,7 @@ describe('Azerion Edge RTD submodule', function () {
 
       it('should load external script with publisher id url', function () {
         const expected = `https://edge.hyth.io/js/v1/${key}/azerion-edge.min.js`;
-        expect(loadExternalScript.args[0][0]).to.deep.equal(expected);
+        expect(loadExternalScriptStub.args[0][0]).to.deep.equal(expected);
       });
     });
 

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -1,7 +1,7 @@
 import { ftrackIdSubmodule } from 'modules/ftrackIdSystem.js';
 import * as utils from 'src/utils.js';
 import { uspDataHandler } from 'src/adapterManager.js';
-import { loadExternalScript } from 'src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 import { getGlobal } from 'src/prebidGlobal.js';
 import {attachIdSystem, init, setSubmoduleRegistry} from 'modules/userId/index.js';
 import {createEidsArray} from 'modules/userId/eids.js';
@@ -139,20 +139,20 @@ describe('FTRACK ID System', () => {
 
     it(`should be the only method that gets a new ID aka hits the D9 endpoint`, () => {
       ftrackIdSubmodule.getId(configMock, null, null).callback(() => {});
-      expect(loadExternalScript.called).to.be.ok;
-      expect(loadExternalScript.args[0][0]).to.deep.equal('https://d9.flashtalking.com/d9core');
-      loadExternalScript.resetHistory();
+      expect(loadExternalScriptStub.called).to.be.ok;
+      expect(loadExternalScriptStub.args[0][0]).to.deep.equal('https://d9.flashtalking.com/d9core');
+      loadExternalScriptStub.resetHistory();
 
       ftrackIdSubmodule.decode('value', configMock);
-      expect(loadExternalScript.called).to.not.be.ok;
-      expect(loadExternalScript.args).to.deep.equal([]);
-      loadExternalScript.resetHistory();
+      expect(loadExternalScriptStub.called).to.not.be.ok;
+      expect(loadExternalScriptStub.args).to.deep.equal([]);
+      loadExternalScriptStub.resetHistory();
 
       ftrackIdSubmodule.extendId(configMock, null, {cache: {id: ''}});
-      expect(loadExternalScript.called).to.not.be.ok;
-      expect(loadExternalScript.args).to.deep.equal([]);
+      expect(loadExternalScriptStub.called).to.not.be.ok;
+      expect(loadExternalScriptStub.args).to.deep.equal([]);
 
-      loadExternalScript.restore();
+      loadExternalScriptStub.restore();
     });
 
     describe(`should use the "ids" setting in the config:`, () => {

--- a/test/spec/modules/geoedgeRtdProvider_spec.js
+++ b/test/spec/modules/geoedgeRtdProvider_spec.js
@@ -1,5 +1,5 @@
 import * as utils from '../../../src/utils.js';
-import { loadExternalScript } from '../../../src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 import * as geoedgeRtdModule from '../../../modules/geoedgeRtdProvider.js';
 import { server } from '../../../test/mocks/xhr.js';
 import * as events from '../../../src/events.js';
@@ -105,7 +105,7 @@ describe('Geoedge RTD module', function () {
       it('should load the in page code when gpt params is true', function () {
         geoedgeSubmodule.init(makeConfig(true));
         const isInPageUrl = arg => arg === getInPageUrl(key);
-        expect(loadExternalScript.calledWith(sinon.match(isInPageUrl))).to.equal(true);
+        expect(loadExternalScriptStub.calledWith(sinon.match(isInPageUrl))).to.equal(true);
       });
       it('should set the window.grumi config object when gpt params is true', function () {
         const hasGrumiObj = typeof window.grumi === 'object';
@@ -115,7 +115,7 @@ describe('Geoedge RTD module', function () {
     describe('preloadClient', function () {
       let iframe;
       preloadClient(key);
-      const loadExternalScriptCall = loadExternalScript.getCall(0);
+      const loadExternalScriptCall = loadExternalScriptStub.getCall(0);
       it('should create an invisible iframe and insert it to the DOM', function () {
         iframe = document.getElementById('grumiFrame');
         expect(iframe && iframe.style.display === 'none');

--- a/test/spec/modules/qortexRtdProvider_spec.js
+++ b/test/spec/modules/qortexRtdProvider_spec.js
@@ -1,7 +1,7 @@
 import * as utils from 'src/utils.js';
 import * as events from 'src/events.js';
 import { EVENTS } from '../../../src/constants.js';
-import {loadExternalScript} from 'src/adloader.js';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 import {
   qortexSubmodule as module,
   addContextToRequests,
@@ -164,7 +164,7 @@ describe('qortexRtdProvider', () => {
       const config = cloneDeep(validModuleConfig);
       config.params.tagConfig = validTagConfig;
       expect(module.init(config)).to.be.true;
-      expect(loadExternalScript.calledOnce).to.be.true;
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
     })
   })
 

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import { Renderer, executeRenderer } from 'src/Renderer.js';
 import * as utils from 'src/utils.js';
-import { loadExternalScript } from 'src/adloader.js';
-require('test/mocks/adloaderStub.js');
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 
 describe('Renderer', function () {
   let oldAdUnits;
@@ -174,7 +173,7 @@ describe('Renderer', function () {
       testRenderer.setRender(() => {})
 
       testRenderer.render()
-      expect(loadExternalScript.called).to.be.true;
+      expect(loadExternalScriptStub.called).to.be.true;
     });
 
     it('should load external script instead of publisher-defined one when backupOnly option is true in mediaTypes.video options', function() {
@@ -204,7 +203,7 @@ describe('Renderer', function () {
       testRenderer.setRender(() => {})
 
       testRenderer.render()
-      expect(loadExternalScript.called).to.be.true;
+      expect(loadExternalScriptStub.called).to.be.true;
     });
 
     it('should call loadExternalScript() for script not defined on adUnit, only when .render() is called', function() {
@@ -221,10 +220,10 @@ describe('Renderer', function () {
         id: 1,
         adUnitCode: undefined
       });
-      expect(loadExternalScript.called).to.be.false;
+      expect(loadExternalScriptStub.called).to.be.false;
 
       testRenderer.render()
-      expect(loadExternalScript.called).to.be.true;
+      expect(loadExternalScriptStub.called).to.be.true;
     });
 
     it('call\'s documentResolver when configured', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
