### PR TITLE
adapter: stabilize BLIINK keywords coppa test

### DIFF
--- a/test/spec/modules/bliinkBidAdapter_spec.js
+++ b/test/spec/modules/bliinkBidAdapter_spec.js
@@ -9,12 +9,7 @@ import {
   getUserIds,
   GVL_ID,
 } from 'modules/bliinkBidAdapter.js';
-import {
-  canAccessWindowTop,
-  getDomLoadingDuration,
-  getWindowSelf,
-  getWindowTop
-} from 'src/utils.js';
+import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 
 /**
@@ -37,9 +32,9 @@ import { config } from 'src/config.js';
  * ortb2Imp: {ext: {data: {pbadslot: string}}}}}
  */
 
-const w = (canAccessWindowTop()) ? getWindowTop() : getWindowSelf();
+const w = (utils.canAccessWindowTop()) ? utils.getWindowTop() : utils.getWindowSelf();
 const connectionType = getEffectiveConnectionType();
-const domLoadingDuration = getDomLoadingDuration(w).toString();
+let domLoadingDuration = utils.getDomLoadingDuration(w).toString();
 const getConfigBid = (placement) => {
   return {
     adUnitCode: '/19968336/test',
@@ -1104,6 +1099,8 @@ describe('BLIINK Adapter keywords & coppa true', function () {
     const metaElement = document.createElement('meta');
     metaElement.name = 'keywords';
     metaElement.content = 'Bliink, Saber, Prebid';
+    sinon.stub(utils, 'getDomLoadingDuration').returns(0);
+    domLoadingDuration = '0';
     configStub = sinon.stub(config, 'getConfig');
     configStub.withArgs('coppa').returns(true);
     querySelectorStub = sinon.stub(document, 'querySelector').returns(metaElement);
@@ -1112,6 +1109,7 @@ describe('BLIINK Adapter keywords & coppa true', function () {
   afterEach(() => {
     querySelectorStub.restore();
     configStub.restore();
+    utils.getDomLoadingDuration.restore();
   });
 
   it('Should build request with keyword and coppa true if exist', () => {

--- a/test/spec/modules/bliinkBidAdapter_spec.js
+++ b/test/spec/modules/bliinkBidAdapter_spec.js
@@ -1098,6 +1098,7 @@ describe('BLIINK Adapter getUserSyncs', function () {
 describe('BLIINK Adapter keywords & coppa true', function () {
   let querySelectorStub;
   let configStub;
+  let originalTitle;
 
   beforeEach(() => {
     window.bliinkBid = {};
@@ -1107,11 +1108,14 @@ describe('BLIINK Adapter keywords & coppa true', function () {
     configStub = sinon.stub(config, 'getConfig');
     configStub.withArgs('coppa').returns(true);
     querySelectorStub = sinon.stub(document, 'querySelector').returns(metaElement);
+    originalTitle = document.title;
+    document.title = '';
   });
 
   afterEach(() => {
     querySelectorStub.restore();
     configStub.restore();
+    document.title = originalTitle;
   });
 
   it('Should build request with keyword and coppa true if exist', () => {


### PR DESCRIPTION
## Summary
- ensure document title is consistent in BLIINK keyword/coppa spec

## Testing
- `gulp lint --files 'test/spec/modules/bliinkBidAdapter_spec.js'` *(fails: Task never defined)*
- `gulp test --file test/spec/modules/bliinkBidAdapter_spec.js` *(fails: environment limitation)*

------
https://chatgpt.com/codex/tasks/task_b_6846f556faa4832b9b657483d0932c1e