### PR TITLE
test: expose sinon globally

### DIFF
--- a/test/test_deps.js
+++ b/test/test_deps.js
@@ -28,6 +28,8 @@ window.addEventListener('unhandledrejection', function (ev) {
 })
 
 const sinon = require('sinon');
+// patched by Codex bot to ensure sinon is globally available for Safari tests
+globalThis.sinon = sinon;
 if (!sinon.sandbox) {
   sinon.sandbox = {create: sinon.createSandbox.bind(sinon)};
 }


### PR DESCRIPTION
## Summary
- assign sinon to the global object so Safari can find it

## Testing
- `npx eslint test/test_deps.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/adloader_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_6846f109b388832b84766898212618d6