### PR TITLE
adapter: stabilize bliink keywords coppa test

### DIFF
--- a/test/spec/modules/bliinkBidAdapter_spec.js
+++ b/test/spec/modules/bliinkBidAdapter_spec.js
@@ -9,12 +9,7 @@ import {
   getUserIds,
   GVL_ID,
 } from 'modules/bliinkBidAdapter.js';
-import {
-  canAccessWindowTop,
-  getDomLoadingDuration,
-  getWindowSelf,
-  getWindowTop
-} from 'src/utils.js';
+import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 
 /**
@@ -37,9 +32,9 @@ import { config } from 'src/config.js';
  * ortb2Imp: {ext: {data: {pbadslot: string}}}}}
  */
 
-const w = (canAccessWindowTop()) ? getWindowTop() : getWindowSelf();
+const w = (utils.canAccessWindowTop()) ? utils.getWindowTop() : utils.getWindowSelf();
 const connectionType = getEffectiveConnectionType();
-const domLoadingDuration = getDomLoadingDuration(w).toString();
+let domLoadingDuration = utils.getDomLoadingDuration(w).toString();
 const getConfigBid = (placement) => {
   return {
     adUnitCode: '/19968336/test',
@@ -1104,6 +1099,8 @@ describe('BLIINK Adapter keywords & coppa true', function () {
     const metaElement = document.createElement('meta');
     metaElement.name = 'keywords';
     metaElement.content = 'Bliink, Saber, Prebid';
+    sinon.stub(utils, 'getDomLoadingDuration').returns(0);
+    domLoadingDuration = '0';
     configStub = sinon.stub(config, 'getConfig');
     configStub.withArgs('coppa').returns(true);
     querySelectorStub = sinon.stub(document, 'querySelector').returns(metaElement);
@@ -1112,6 +1109,7 @@ describe('BLIINK Adapter keywords & coppa true', function () {
   afterEach(() => {
     querySelectorStub.restore();
     configStub.restore();
+    utils.getDomLoadingDuration.restore();
   });
 
   it('Should build request with keyword and coppa true if exist', () => {

--- a/test/spec/modules/bliinkBidAdapter_spec.js
+++ b/test/spec/modules/bliinkBidAdapter_spec.js
@@ -1098,6 +1098,7 @@ describe('BLIINK Adapter getUserSyncs', function () {
 describe('BLIINK Adapter keywords & coppa true', function () {
   let querySelectorStub;
   let configStub;
+  let originalTitle;
 
   beforeEach(() => {
     window.bliinkBid = {};
@@ -1107,11 +1108,14 @@ describe('BLIINK Adapter keywords & coppa true', function () {
     configStub = sinon.stub(config, 'getConfig');
     configStub.withArgs('coppa').returns(true);
     querySelectorStub = sinon.stub(document, 'querySelector').returns(metaElement);
+    originalTitle = document.title;
+    document.title = '';
   });
 
   afterEach(() => {
     querySelectorStub.restore();
     configStub.restore();
+    document.title = originalTitle;
   });
 
   it('Should build request with keyword and coppa true if exist', () => {


### PR DESCRIPTION
## Summary
- stub `getDomLoadingDuration` when testing keywords with COPPA
- import utils as an object so the stub can be restored

The flakey test came from variability in `getDomLoadingDuration`. Stubbing this function ensures a stable value.

## Testing
- `npx gulp lint` *(fails: no output)*
- `npx gulp test --file test/spec/modules/bliinkBidAdapter_spec.js` *(fails: no output)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6846fe821484832bae502e671f3bcd8d