### PR TITLE
adapter: stabilize bliink keywords coppa test

### DIFF
--- a/test/spec/modules/bliinkBidAdapter_spec.js
+++ b/test/spec/modules/bliinkBidAdapter_spec.js
@@ -9,12 +9,7 @@ import {
   getUserIds,
   GVL_ID,
 } from 'modules/bliinkBidAdapter.js';
-import {
-  canAccessWindowTop,
-  getDomLoadingDuration,
-  getWindowSelf,
-  getWindowTop
-} from 'src/utils.js';
+import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 
 /**
@@ -37,9 +32,9 @@ import { config } from 'src/config.js';
  * ortb2Imp: {ext: {data: {pbadslot: string}}}}}
  */
 
-const w = (canAccessWindowTop()) ? getWindowTop() : getWindowSelf();
+const w = (utils.canAccessWindowTop()) ? utils.getWindowTop() : utils.getWindowSelf();
 const connectionType = getEffectiveConnectionType();
-const domLoadingDuration = getDomLoadingDuration(w).toString();
+let domLoadingDuration = utils.getDomLoadingDuration(w).toString();
 const getConfigBid = (placement) => {
   return {
     adUnitCode: '/19968336/test',
@@ -1104,6 +1099,8 @@ describe('BLIINK Adapter keywords & coppa true', function () {
     const metaElement = document.createElement('meta');
     metaElement.name = 'keywords';
     metaElement.content = 'Bliink, Saber, Prebid';
+    sinon.stub(utils, 'getDomLoadingDuration').returns(0);
+    domLoadingDuration = '0';
     configStub = sinon.stub(config, 'getConfig');
     configStub.withArgs('coppa').returns(true);
     querySelectorStub = sinon.stub(document, 'querySelector').returns(metaElement);
@@ -1112,6 +1109,7 @@ describe('BLIINK Adapter keywords & coppa true', function () {
   afterEach(() => {
     querySelectorStub.restore();
     configStub.restore();
+    utils.getDomLoadingDuration.restore();
   });
 
   it('Should build request with keyword and coppa true if exist', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
