### PR TITLE
tests: fix videojs provider reinit test

### DIFF
--- a/test/spec/modules/videoModule/submodules/videojsVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/videojsVideoProvider_spec.js
@@ -71,17 +71,20 @@ describe('videojsProvider', function () {
       expect(mockVideojs.calledOnce).to.be.true
     });
 
-    it('should not reinstantiate the player', function () {
+    it('should not reinstantiate the player', function (done) {
       const div = document.createElement('div');
       div.setAttribute('id', 'test-div');
       document.body.appendChild(div);
-      const player = videojs(div, {})
-      config.playerConfig = {};
-      config.divId = 'test-div'
-      const provider = VideojsProvider(config, videojs, adState, timeState, callbackStorage, utils);
-      provider.init();
-      expect(videojs.getPlayer('test-div')).to.be.equal(player)
-      videojs.getPlayer('test-div').dispose()
+      const player = videojs(div, {});
+      player.ready(() => {
+        config.playerConfig = {};
+        config.divId = 'test-div';
+        const provider = VideojsProvider(config, videojs, adState, timeState, callbackStorage, utils);
+        provider.init();
+        expect(videojs.getPlayer('test-div')).to.be.equal(player);
+        videojs.getPlayer('test-div').dispose();
+        done();
+      });
     });
 
     it('should trigger setup complete when player is already insantiated', function () {


### PR DESCRIPTION
## Summary
- stabilize `videojsVideoProvider` unit test by waiting for the player to be ready

## Testing
- `npx gulp lint --files test/spec/modules/videoModule/submodules/videojsVideoProvider_spec.js`
- `npx gulp test --file test/spec/modules/videoModule/submodules/videojsVideoProvider_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_68470ad19a3c832bbb6769e87081f550