### PR TITLE
test: extend permutive id timeout

### DIFF
--- a/test/spec/modules/permutiveIdentityManagerIdSystem_spec.js
+++ b/test/spec/modules/permutiveIdentityManagerIdSystem_spec.js
@@ -55,7 +55,7 @@ describe('permutiveIdentityManagerIdSystem', () => {
     it('will optionally wait for Permutive SDK if no identities are in local storage already', async () => {
       const cleanup = setWindowPermutive()
       try {
-        const result = permutiveIdentityManagerIdSubmodule.getId({params: {ajaxTimeout: 50}})
+        const result = permutiveIdentityManagerIdSubmodule.getId({params: {ajaxTimeout: 150}})
         expect(result).not.to.be.undefined
         expect(result.id).to.be.undefined
         expect(result.callback).not.to.be.undefined


### PR DESCRIPTION
## Summary
- extend the ajaxTimeout in the Permutive identity manager spec

## Testing
- `npx eslint modules/permutiveIdentityManagerIdSystem.js test/spec/modules/permutiveIdentityManagerIdSystem_spec.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/permutiveIdentityManagerIdSystem_spec.js -nolint` *(fails: hanging during bundling)*


------
https://chatgpt.com/codex/tasks/task_b_6847173aaa94832b8a97ccc8223c6680