### PR TITLE
Add regression test for autoplay play() return value

### DIFF
--- a/test/spec/libraries/autoplayDetection_spec.js
+++ b/test/spec/libraries/autoplayDetection_spec.js
@@ -1,0 +1,31 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+function loadAutoplay() {
+  delete require.cache[require.resolve('../../../libraries/autoplayDetection/autoplay.js')];
+  return require('../../../libraries/autoplayDetection/autoplay.js');
+}
+
+describe('autoplay detection', () => {
+  let createElementStub;
+  afterEach(() => {
+    if (createElementStub) {
+      createElementStub.restore();
+    }
+    delete require.cache[require.resolve('../../../libraries/autoplayDetection/autoplay.js')];
+  });
+
+  it('does not throw when play() does not return a promise', () => {
+    const video = {
+      play: sinon.stub().returns(undefined),
+      setAttribute: sinon.stub(),
+      muted: false,
+      src: ''
+    };
+    createElementStub = sinon.stub(document, 'createElement').withArgs('video').returns(video);
+
+    let mod;
+    expect(() => { mod = loadAutoplay(); }).to.not.throw();
+    expect(mod.isAutoplayEnabled()).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary
- test autoplayDetection when HTMLVideoElement.play() doesn't return a promise

## Testing
- `npx gulp test --file test/spec/libraries/autoplayDetection_spec.js` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6847435556b0832b9afb3f10a787bfcc