### PR TITLE
core: handle missing auctionDelay

### DIFF
--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -302,7 +302,8 @@ export const setBidRequestsData = timedAuctionHook('rtd', function setBidRequest
     }
   });
 
-  const shouldDelayAuction = prioritySubModules.length && _moduleConfig.auctionDelay && _moduleConfig.auctionDelay > 0;
+  const auctionDelay = _moduleConfig && _moduleConfig.auctionDelay;
+  const shouldDelayAuction = prioritySubModules.length && auctionDelay && auctionDelay > 0;
   let callbacksExpected = prioritySubModules.length;
   let isDone = false;
   let waitTimeout;
@@ -312,7 +313,7 @@ export const setBidRequestsData = timedAuctionHook('rtd', function setBidRequest
     return exitHook();
   }
 
-  const timeout = shouldDelayAuction ? _moduleConfig.auctionDelay : 0;
+  const timeout = shouldDelayAuction ? auctionDelay : 0;
   waitTimeout = setTimeout(exitHook, timeout);
 
   relevantSubModules.forEach(sm => {


### PR DESCRIPTION
## Summary
- avoid TypeError when Real Time Data module is used without configuration
- guard reading `_moduleConfig.auctionDelay`

## Testing
- `npx eslint modules/rtdModule/index.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/realTimeDataModule_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_6847229b2cd4832bb1517a05824e554a