### PR TITLE
core: enforce userId storage types

### DIFF
--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -378,3 +378,25 @@ pbjs.setConfig({
     }
 });
 ```
+
+### Enforcing configured storage type
+
+Set `enforceStorageType` to `true` under `userSync` to prevent ID submodules from
+writing to storage types other than those specified in their configuration. When
+disabled, mismatched writes log a warning but still proceed.
+
+```
+pbjs.setConfig({
+    userSync: {
+        enforceStorageType: true,
+        userIds: [{
+            name: 'pubCommonId',
+            storage: {
+                type: 'html5',
+                name: 'pubcid',
+                expires: 60
+            }
+        }]
+    }
+});
+```


### PR DESCRIPTION
## Summary
- add enforcement of configured storage types for user ID submodules
- expose configuration via `enforceStorageType`
- document enforcing behavior
- test storage enforcement

## Testing
- `npx eslint "**/*.{js,ts,tsx}" --cache --cache-strategy content`
- `npx gulp test --file test/spec/unit/core/storageManager_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_68488709a90c832b8592772a46fd9c00