### PR TITLE
adapter: fix ua expectation in tests

### DIFF
--- a/test/spec/modules/mediaforceBidAdapter_spec.js
+++ b/test/spec/modules/mediaforceBidAdapter_spec.js
@@ -131,66 +131,68 @@ describe('mediaforce bid adapter', function () {
     const timeout = 1500;
     const auctionId = '210a474e-88f0-4646-837f-4253b7cf14fb';
 
-    const expectedData = {
-      // id property removed as it is specific for each request generated
-      tmax: timeout,
-      ext: {
-        mediaforce: {
-          hb_key: auctionId
-        }
-      },
-      site: {
-        id: defaultBid.params.publisher_id,
-        publisher: {id: defaultBid.params.publisher_id},
-        ref: encodeURIComponent(refererInfo.ref),
-        page: pageUrl,
-      },
-      device: {
-        ua: navigator.userAgent,
-        dnt: dnt,
-        js: 1,
-        language: language,
-      },
-      imp: [{
-        tagid: defaultBid.params.placement_id,
-        secure: secure,
-        bidfloor: 0,
+    function createExpectedData() {
+      return {
+        // id property removed as it is specific for each request generated
+        tmax: timeout,
         ext: {
           mediaforce: {
-            transactionId: defaultBid.ortb2Imp.ext.tid,
+            hb_key: auctionId
           }
         },
-        banner: {w: 300, h: 250},
-        native: {
-          ver: '1.2',
-          request: {
-            assets: [
-              {id: 1, title: {len: 800}, required: 1},
-              {id: 3, img: {w: 300, h: 250, type: 3}, required: 1},
-              {id: 5, data: {type: 1}, required: 0}
-            ],
-            context: 1,
-            plcmttype: 1,
-            ver: '1.2'
-          }
+        site: {
+          id: defaultBid.params.publisher_id,
+          publisher: {id: defaultBid.params.publisher_id},
+          ref: encodeURIComponent(refererInfo.ref),
+          page: pageUrl,
         },
-        video: {
-          mimes: ['video/mp4'],
-          minduration: 5,
-          maxduration: 30,
-          protocols: [2, 3],
-          w: 640,
-          h: 480,
-          startdelay: 0,
-          linearity: 1,
-          skip: 1,
-          skipmin: 5,
-          skipafter: 10,
-          playbackmethod: [1],
-          api: [1, 2]
-        }
-      }],
-    };
+        device: {
+          ua: navigator.userAgent,
+          dnt: dnt,
+          js: 1,
+          language: language,
+        },
+        imp: [{
+          tagid: defaultBid.params.placement_id,
+          secure: secure,
+          bidfloor: 0,
+          ext: {
+            mediaforce: {
+              transactionId: defaultBid.ortb2Imp.ext.tid,
+            }
+          },
+          banner: {w: 300, h: 250},
+          native: {
+            ver: '1.2',
+            request: {
+              assets: [
+                {id: 1, title: {len: 800}, required: 1},
+                {id: 3, img: {w: 300, h: 250, type: 3}, required: 1},
+                {id: 5, data: {type: 1}, required: 0}
+              ],
+              context: 1,
+              plcmttype: 1,
+              ver: '1.2'
+            }
+          },
+          video: {
+            mimes: ['video/mp4'],
+            minduration: 5,
+            maxduration: 30,
+            protocols: [2, 3],
+            w: 640,
+            h: 480,
+            startdelay: 0,
+            linearity: 1,
+            skip: 1,
+            skipmin: 5,
+            skipafter: 10,
+            playbackmethod: [1],
+            api: [1, 2]
+          }
+        }],
+      };
+    }
 
     const multiBid = [
       {
@@ -248,7 +250,7 @@ describe('mediaforce bid adapter', function () {
       let [request] = spec.buildRequests(bidRequests, bidderRequest);
       let data = JSON.parse(request.data);
 
-      let expectedDataCopy = utils.deepClone(expectedData);
+      let expectedDataCopy = utils.deepClone(createExpectedData());
       assert.exists(data.id);
 
       expectedDataCopy.id = data.id
@@ -309,7 +311,7 @@ describe('mediaforce bid adapter', function () {
 
       let data = JSON.parse(request.data);
 
-      let expectedDataCopy = utils.deepClone(expectedData);
+      let expectedDataCopy = utils.deepClone(createExpectedData());
       assert.exists(data.id);
 
       expectedDataCopy.id = data.id

--- a/test/spec/modules/mgidBidAdapter_spec.js
+++ b/test/spec/modules/mgidBidAdapter_spec.js
@@ -20,7 +20,6 @@ describe('Mgid bid adapter', function () {
     utils.logError.restore();
     utils.logWarn.restore();
   });
-  const ua = navigator.userAgent;
   const screenHeight = screen.height;
   const screenWidth = screen.width;
   const dnt = (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1') ? 1 : 0;
@@ -449,7 +448,7 @@ describe('Mgid bid adapter', function () {
       expect(data.site.domain).to.deep.equal(domain);
       expect(data.site.page).to.deep.equal(page);
       expect(data.cur).to.deep.equal(['USD']);
-      expect(data.device.ua).to.deep.equal(ua);
+      expect(data.device.ua).to.deep.equal(navigator.userAgent);
       expect(data.device.dnt).equal(dnt);
       expect(data.device.h).equal(screenHeight);
       expect(data.device.w).equal(screenWidth);
@@ -461,7 +460,7 @@ describe('Mgid bid adapter', function () {
       expect(request).to.deep.equal({
         'method': 'POST',
         'url': 'https://prebid.mgid.com/prebid/1',
-        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${ua}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"banner":{"w":300,"h":250}}],"tmax":3000}`,
+        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${navigator.userAgent}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"banner":{"w":300,"h":250}}],"tmax":3000}`,
       });
     });
     it('should not return native imp if minimum asset list not requested', function () {
@@ -499,7 +498,7 @@ describe('Mgid bid adapter', function () {
       expect(data.site.domain).to.deep.equal(domain);
       expect(data.site.page).to.deep.equal(page);
       expect(data.cur).to.deep.equal(['USD']);
-      expect(data.device.ua).to.deep.equal(ua);
+      expect(data.device.ua).to.deep.equal(navigator.userAgent);
       expect(data.device.dnt).equal(dnt);
       expect(data.device.h).equal(screenHeight);
       expect(data.device.w).equal(screenWidth);
@@ -511,7 +510,7 @@ describe('Mgid bid adapter', function () {
       expect(request).to.deep.equal({
         'method': 'POST',
         'url': 'https://prebid.mgid.com/prebid/1',
-        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${ua}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"native":{"request":{"plcmtcnt":1,"assets":[{"id":1,"required":1,"title":{"len":80}},{"id":2,"required":0,"img":{"type":3,"w":80,"h":80}},{"id":11,"required":0,"data":{"type":1}}]}}}],"tmax":3000}`,
+        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${navigator.userAgent}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"native":{"request":{"plcmtcnt":1,"assets":[{"id":1,"required":1,"title":{"len":80}},{"id":2,"required":0,"img":{"type":3,"w":80,"h":80}},{"id":11,"required":0,"data":{"type":1}}]}}}],"tmax":3000}`,
       });
     });
     it('should return proper native imp with image altered', function () {
@@ -537,7 +536,7 @@ describe('Mgid bid adapter', function () {
       expect(data.site.domain).to.deep.equal(domain);
       expect(data.site.page).to.deep.equal(page);
       expect(data.cur).to.deep.equal(['USD']);
-      expect(data.device.ua).to.deep.equal(ua);
+      expect(data.device.ua).to.deep.equal(navigator.userAgent);
       expect(data.device.dnt).equal(dnt);
       expect(data.device.h).equal(screenHeight);
       expect(data.device.w).equal(screenWidth);
@@ -548,7 +547,7 @@ describe('Mgid bid adapter', function () {
       expect(request).to.deep.equal({
         'method': 'POST',
         'url': 'https://prebid.mgid.com/prebid/1',
-        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${ua}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"native":{"request":{"plcmtcnt":1,"assets":[{"id":1,"required":1,"title":{"len":80}},{"id":2,"required":1,"img":{"type":3,"w":492,"h":328,"wmin":50,"hmin":50}},{"id":3,"required":0,"img":{"type":1,"w":50,"h":50}},{"id":11,"required":0,"data":{"type":1}}]}}}],"tmax":3000}`,
+        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${navigator.userAgent}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"native":{"request":{"plcmtcnt":1,"assets":[{"id":1,"required":1,"title":{"len":80}},{"id":2,"required":1,"img":{"type":3,"w":492,"h":328,"wmin":50,"hmin":50}},{"id":3,"required":0,"img":{"type":1,"w":50,"h":50}},{"id":11,"required":0,"data":{"type":1}}]}}}],"tmax":3000}`,
       });
     });
     it('should return proper native imp with sponsoredBy', function () {
@@ -573,7 +572,7 @@ describe('Mgid bid adapter', function () {
       expect(data.site.domain).to.deep.equal(domain);
       expect(data.site.page).to.deep.equal(page);
       expect(data.cur).to.deep.equal(['USD']);
-      expect(data.device.ua).to.deep.equal(ua);
+      expect(data.device.ua).to.deep.equal(navigator.userAgent);
       expect(data.device.dnt).equal(dnt);
       expect(data.device.h).equal(screenHeight);
       expect(data.device.w).equal(screenWidth);
@@ -584,7 +583,7 @@ describe('Mgid bid adapter', function () {
       expect(request).to.deep.equal({
         'method': 'POST',
         'url': 'https://prebid.mgid.com/prebid/1',
-        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${ua}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"native":{"request":{"plcmtcnt":1,"assets":[{"id":1,"required":1,"title":{"len":80}},{"id":2,"required":0,"img":{"type":3,"w":80,"h":80}},{"id":4,"required":0,"data":{"type":1}}]}}}],"tmax":3000}`,
+        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${navigator.userAgent}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"native":{"request":{"plcmtcnt":1,"assets":[{"id":1,"required":1,"title":{"len":80}},{"id":2,"required":0,"img":{"type":3,"w":80,"h":80}},{"id":4,"required":0,"data":{"type":1}}]}}}],"tmax":3000}`,
       });
     });
     it('should return proper banner request', function () {
@@ -606,7 +605,7 @@ describe('Mgid bid adapter', function () {
       expect(data.site.domain).to.deep.equal(domain);
       expect(data.site.page).to.deep.equal(page);
       expect(data.cur).to.deep.equal(['USD']);
-      expect(data.device.ua).to.deep.equal(ua);
+      expect(data.device.ua).to.deep.equal(navigator.userAgent);
       expect(data.device.dnt).equal(dnt);
       expect(data.device.h).equal(screenHeight);
       expect(data.device.w).equal(screenWidth);
@@ -618,7 +617,7 @@ describe('Mgid bid adapter', function () {
       expect(request).to.deep.equal({
         'method': 'POST',
         'url': 'https://prebid.mgid.com/prebid/1',
-        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${ua}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"banner":{"w":300,"h":600,"format":[{"w":300,"h":600},{"w":300,"h":250}],"pos":1}}],"tmax":3000}`,
+        'data': `{"site":{"domain":"${domain}","page":"${page}"},"cur":["USD"],"geo":{"utcoffset":${utcOffset}},"device":{"ua":"${navigator.userAgent}","js":1,"dnt":${dnt},"h":${screenHeight},"w":${screenWidth},"language":"${lang}"},"ext":{"mgid_ver":"${mgid_ver}","prebid_ver":"${version}"},"imp":[{"tagid":"2/div","secure":${secure},"ext":{"gpid":"/1111/gpid"},"banner":{"w":300,"h":600,"format":[{"w":300,"h":600},{"w":300,"h":250}],"pos":1}}],"tmax":3000}`,
       });
     });
     it('should proper handle ortb2 data', function () {


### PR DESCRIPTION
## Summary
- ensure UA expectations match runtime environment in mediaforce and mgid bid adapter specs

## Testing
- `npx eslint test/spec/modules/mgidBidAdapter_spec.js test/spec/modules/mediaforceBidAdapter_spec.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/mediaforceBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/mgidBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_6848d0f32ed0832baadf7630fc5f9d5c