### PR TITLE
core: convert documentLang

### DIFF
--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -1,7 +1,7 @@
 import {hook} from '../hook.js';
 import {getRefererInfo, parseDomain} from '../refererDetection.js';
 import {findRootDomain} from './rootDomain.js';
-import {deepSetValue, getDefinedParams, getDNT, getWinDimensions, getDocument, getWindowSelf, getWindowTop, mergeDeep} from '../utils.js';
+import {deepSetValue, deepAccess, getDefinedParams, getDNT, getWinDimensions, getDocument, getWindowSelf, getWindowTop, mergeDeep} from '../utils.js';
 import {config} from '../config.js';
 import {getHighEntropySUA, getLowEntropySUA} from './sua.js';
 import {PbPromise} from '../utils/promise.js';
@@ -56,6 +56,10 @@ export const enrichFPD = hook('sync', (fpd) => {
       const documentLang = dep.getDocument().documentElement.lang;
       if (documentLang) {
         deepSetValue(ortb2, 'site.ext.data.documentLang', documentLang);
+        if (!deepAccess(ortb2, 'site.content.language')) {
+          const langCode = documentLang.split('-')[0];
+          deepSetValue(ortb2, 'site.content.language', langCode);
+        }
       }
 
       ortb2 = oneClient(ortb2);

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -160,6 +160,7 @@ describe('FPD enrichment', () => {
       });
       return fpd().then(ortb2 => {
         expect(ortb2.site.ext.data.documentLang).to.equal('fr-FR');
+        expect(ortb2.site.content.language).to.equal('fr');
       });
     });
   });


### PR DESCRIPTION
## Summary
- add language fallback from `document.lang`
- test FPD site language conversion

## Testing
- `npx gulp lint`
- `npx gulp test --nolint --file test/spec/fpd/enrichment_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_6848f3898a80832b94a737cc4b8ca070