### PR TITLE
modules: adjust submodule tests for userId removal

### DIFF
--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -38,9 +38,15 @@ const cstgApiUrl = 'https://prod.euid.eu/v2/token/client-generate';
 const headers = { 'Content-Type': 'application/json' };
 const makeSuccessResponseBody = (token) => btoa(JSON.stringify({ status: 'success', body: { ...apiHelpers.makeTokenResponse(initialToken), advertising_token: token } }));
 const makeOptoutResponseBody = (token) => btoa(JSON.stringify({ status: 'optout', body: { ...apiHelpers.makeTokenResponse(initialToken), advertising_token: token } }));
-const expectToken = (bid, token) => expect(bid?.userId ?? {}).to.deep.include(makeEuidIdentityContainer(token));
-const expectOptout = (bid, token) => expect(bid?.userId ?? {}).to.deep.include(makeEuidOptoutContainer(token));
-const expectNoIdentity = (bid) => expect(bid).to.not.haveOwnProperty('userId');
+function findEuid(bid) {
+  return (bid?.userIdAsEids ?? []).find(e => e.source === 'euid.eu');
+}
+const expectToken = (bid, token) => {
+  const eid = findEuid(bid);
+  expect(eid && eid.uids[0].id).to.equal(token);
+};
+const expectOptout = (bid) => expect(findEuid(bid)).to.be.undefined;
+const expectNoIdentity = (bid) => expect(findEuid(bid)).to.be.undefined;
 
 describe('EUID module', function() {
   let suiteSandbox, restoreSubtleToUndefined = false;

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -960,8 +960,6 @@ describe('ID5 ID System', function () {
         startAuctionHook(wrapAsyncExpects(done, () => {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
-              expect(bid.userId.id5id.uid).is.equal(ID5_STORED_ID);
               expect(bid.userIdAsEids[0]).is.eql({
                 source: ID5_SOURCE,
                 uids: [{
@@ -988,8 +986,6 @@ describe('ID5 ID System', function () {
         startAuctionHook(function () {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property(`userId.euid`);
-              expect(bid.userId.euid.uid).is.equal(EUID_STORED_ID);
               expect(bid.userIdAsEids[0].uids[0].id).is.equal(ID5_STORED_ID);
               expect(bid.userIdAsEids[1]).is.eql({
                 source: EUID_SOURCE,
@@ -1017,8 +1013,6 @@ describe('ID5 ID System', function () {
         startAuctionHook(wrapAsyncExpects(done, function () {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property(`userId.trueLinkId`);
-              expect(bid.userId.trueLinkId.uid).is.equal(TRUE_LINK_STORED_ID);
               expect(bid.userIdAsEids[1]).is.eql({
                 source: TRUE_LINK_SOURCE,
                 uids: [{
@@ -1074,11 +1068,6 @@ describe('ID5 ID System', function () {
         startAuctionHook(wrapAsyncExpects(done, () => {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
-              expect(bid.userId.id5id).is.eql({
-                uid: id5IdEidUid.id,
-                ext: id5IdEidUid.ext
-              });
               expect(bid.userIdAsEids[0]).is.eql({
                 source: IDS_ID5ID.eid.source,
                 uids: [{
@@ -1108,11 +1097,6 @@ describe('ID5 ID System', function () {
         startAuctionHook(wrapAsyncExpects(done, () => {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property(`userId.euid`);
-              expect(bid.userId.euid).is.eql({
-                uid: IDS_EUID.eid.uids[0].id,
-                ext: IDS_EUID.eid.uids[0].ext
-              });
               expect(bid.userIdAsEids[0]).is.eql(IDS_ID5ID.eid);
               expect(bid.userIdAsEids[1]).is.eql(IDS_EUID.eid);
             });
@@ -1137,8 +1121,6 @@ describe('ID5 ID System', function () {
         startAuctionHook(wrapAsyncExpects(done, function () {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property(`userId.trueLinkId`);
-              expect(bid.userId.trueLinkId.uid).is.eql(IDS_TRUE_LINK_ID.eid.uids[0].id);
               expect(bid.userIdAsEids[1]).is.eql(IDS_TRUE_LINK_ID.eid);
             });
           });
@@ -1178,8 +1160,6 @@ describe('ID5 ID System', function () {
         startAuctionHook(wrapAsyncExpects(done, function () {
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property(`userId.otherId`);
-              expect(bid.userId.otherId.uid).is.eql('other-id-value');
               expect(bid.userIdAsEids[1]).is.eql({
                 source: 'other-id.com',
                 inserter: 'id5-sync.com',

--- a/test/spec/modules/idxIdSystem_spec.js
+++ b/test/spec/modules/idxIdSystem_spec.js
@@ -111,8 +111,6 @@ describe('IDx ID System', () => {
       startAuctionHook(() => {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.idx');
-            expect(bid.userId.idx).to.equal(IDX_DUMMY_VALUE);
             const idxIdAsEid = bid.userIdAsEids.find(e => e.source == 'idx.lat');
             expect(idxIdAsEid).to.deep.equal({
               source: 'idx.lat',

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -47,13 +47,26 @@ const getFromAppropriateStorage = () => {
   else return coreStorage.getCookie(moduleCookieName);
 }
 
-const expectToken = (bid, token) => expect(bid?.userId ?? {}).to.deep.include(makeUid2IdentityContainer(token));
-const expectLegacyToken = (bid) => expect(bid.userId).to.deep.include(makeUid2IdentityContainer(legacyToken));
-const expectNoIdentity = (bid) => expect(bid).to.not.haveOwnProperty('userId');
-const expectOptout = (bid, token) => expect(bid?.userId ?? {}).to.deep.include(makeUid2OptoutContainer(token));
+const UID2_SOURCE = 'uidapi.com';
+function findUid2(bid) {
+  return (bid?.userIdAsEids ?? []).find(e => e.source === UID2_SOURCE);
+}
+const expectToken = (bid, token) => {
+  const eid = findUid2(bid);
+  expect(eid && eid.uids[0].id).to.equal(token);
+};
+const expectLegacyToken = (bid) => {
+  const eid = findUid2(bid);
+  expect(eid && eid.uids[0].id).to.equal(legacyToken);
+};
+const expectNoIdentity = (bid) => expect(findUid2(bid)).to.be.undefined;
+const expectOptout = (bid) => expect(findUid2(bid)).to.be.undefined;
 const expectGlobalToHaveToken = (token) => expect(getGlobal().getUserIds()).to.deep.include(makeUid2IdentityContainer(token));
 const expectGlobalToHaveNoUid2 = () => expect(getGlobal().getUserIds()).to.not.haveOwnProperty('uid2');
-const expectNoLegacyToken = (bid) => expect(bid.userId).to.not.deep.include(makeUid2IdentityContainer(legacyToken));
+const expectNoLegacyToken = (bid) => {
+  const eid = findUid2(bid);
+  if (eid) expect(eid.uids[0].id).to.not.equal(legacyToken);
+};
 const expectModuleStorageEmptyOrMissing = () => expect(getFromAppropriateStorage()).to.be.null;
 const expectModuleStorageToContain = (originalAdvertisingToken, latestAdvertisingToken, originalIdentity) => {
   const cookie = JSON.parse(getFromAppropriateStorage());
@@ -240,7 +253,9 @@ describe(`UID2 module`, function () {
       config.setConfig(makePrebidConfig(legacyConfigParams));
       const bid2 = await runAuction();
 
-      expect(bid.userId.uid2.id).to.equal(bid2.userId.uid2.id);
+        const first = findUid2(bid);
+        const second = findUid2(bid2);
+        expect(first && second && first.uids[0].id).to.equal(second.uids[0].id);
     });
   });
 


### PR DESCRIPTION
## Summary
- update idx ID system test to only check userIdAsEids
- adjust EUID test helpers to read from eids
- remove userId checks from ID5 submodule tests
- update UID2 submodule tests for eids

## Testing
- `npx gulp test --file test/spec/modules/idxIdSystem_spec.js --nolint`
- `npx gulp test --file test/spec/modules/euidIdSystem_spec.js --nolint`
- `npx gulp test --file test/spec/modules/id5IdSystem_spec.js --nolint`
- `npx gulp test --file test/spec/modules/uid2IdSystem_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_684ebd13c13c832b8ec1cda3de977af8