### PR TITLE
core: update submodule id tests

### DIFF
--- a/test/spec/modules/lmpIdSystem_spec.js
+++ b/test/spec/modules/lmpIdSystem_spec.js
@@ -114,8 +114,6 @@ describe('LMPID System', () => {
       startAuctionHook(() => {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.lmpid');
-            expect(bid.userId.lmpid).to.equal('stored-lmpid');
             const lmpidAsEid = bid.userIdAsEids.find(e => e.source == 'loblawmedia.ca');
             expect(lmpidAsEid).to.deep.equal({
               source: 'loblawmedia.ca',

--- a/test/spec/modules/zeotapIdPlusIdSystem_spec.js
+++ b/test/spec/modules/zeotapIdPlusIdSystem_spec.js
@@ -178,8 +178,6 @@ describe('Zeotap ID System', function() {
       startAuctionHook(function() {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
-            expect(bid).to.have.deep.nested.property('userId.IDP');
-            expect(bid.userId.IDP).to.equal(ZEOTAP_COOKIE);
             const zeotapIdAsEid = bid.userIdAsEids.find(e => e.source == 'zeotap.com');
             expect(zeotapIdAsEid).to.deep.equal({
               source: 'zeotap.com',


### PR DESCRIPTION
## Summary
- remove bid.userId checks from LMP and Zeotap ID system tests

## Testing
- `npx gulp lint --files "test/spec/modules/lmpIdSystem_spec.js,test/spec/modules/zeotapIdPlusIdSystem_spec.js"`
- `npx gulp test --nolint --file test/spec/modules/lmpIdSystem_spec.js`
- `npx gulp test --nolint --file test/spec/modules/zeotapIdPlusIdSystem_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_684ec03578e0832b8f3be06d7e8c56ae