### PR TITLE
adapter: stub log functions

### DIFF
--- a/test/spec/modules/mobkoiAnalyticsAdapter_spec.js
+++ b/test/spec/modules/mobkoiAnalyticsAdapter_spec.js
@@ -1,5 +1,5 @@
 import mobkoiAnalyticsAdapter, { DEBUG_EVENT_LEVELS, utils, SUB_PAYLOAD_UNIQUE_FIELDS_LOOKUP, SUB_PAYLOAD_TYPES } from 'modules/mobkoiAnalyticsAdapter.js';
-import {internal} from '../../../src/utils.js';
+import * as prebidUtils from '../../../src/utils.js';
 import adapterManager from '../../../src/adapterManager.js';
 import * as events from 'src/events.js';
 import { EVENTS } from 'src/constants.js';
@@ -214,9 +214,13 @@ describe('mobkoiAnalyticsAdapter', function () {
         }
       });
 
-      sandbox.stub(internal, 'logInfo');
-      sandbox.stub(internal, 'logWarn');
-      sandbox.stub(internal, 'logError');
+      sandbox.stub(prebidUtils.internal, 'logInfo');
+      sandbox.stub(prebidUtils.internal, 'logWarn');
+      sandbox.stub(prebidUtils.internal, 'logError');
+
+      sandbox.stub(prebidUtils, 'logInfo');
+      sandbox.stub(prebidUtils, 'logWarn');
+      sandbox.stub(prebidUtils, 'logError');
 
       // Create spies after enabling analytics to ensure localContext exists
       postAjaxStub = sandbox.stub(utils, 'postAjax');


### PR DESCRIPTION
## Summary
- stub logInfo, logWarn, and logError from src/utils in the Mobkoi analytics spec to silence debug output

## Testing
- `npx gulp lint --files "test/spec/modules/mobkoiAnalyticsAdapter_spec.js"`
- `npx gulp test --nolint --file test/spec/modules/mobkoiAnalyticsAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_685ae4f7f820832b921e9a63992bdca2