### PR TITLE
core: categorize uncategorized PRs as maintenance

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,13 +8,13 @@ autolabeler:
 categories:
   - title: '🚀 New Features'
     label: 'feature'
-  - title: '🛠 Maintenance'
-    label: 'maintenance'    
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
       - 'bugfix'
-      - 'bug'      
+      - 'bug'
+  - title: '🛠 Maintenance'
+    labels: []
 change-template: '- $TITLE (#$NUMBER)'
 version-resolver:
   major:


### PR DESCRIPTION
## Summary
- categorize any PR without feature or bug fix labels as maintenance in the release notes

## Testing
- `npx gulp lint`

------
https://chatgpt.com/codex/tasks/task_b_68629905097c832b8f68b0ac132ab7be