### PR TITLE
ci: restrict workflow triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,24 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      # workflows run only on master, legacy branches, or branches beginning
+      # with prebid-. Updated by Codex agent.
+      - build:
+          filters:
+            branches:
+              only:
+                - master
+                - /.*legacy.*/
+                - /prebid-.*/
       - e2etest:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
+                - /.*legacy.*/
+                - /prebid-.*/
 
 experimental:
   pipelines: true


### PR DESCRIPTION
## Summary
- restrict CircleCI tests to run only for `master`, branches containing `legacy`, or starting with `prebid-`
- drop unsupported `pull_requests` filter

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686298de6488832bb8aeb28bc1e175fb