### PR TITLE
test: clear identitylink local storage

### DIFF
--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -31,6 +31,7 @@ describe('IdentityLinkId tests', function () {
     // remove _lr_retry_request cookie before test
     storage.setCookie('_lr_retry_request', 'true', 'Thu, 01 Jan 1970 00:00:01 GMT');
     storage.setCookie('_lr_env', testEnvelope, 'Thu, 01 Jan 1970 00:00:01 GMT');
+    storage.removeDataFromLocalStorage('_lr_env');
   });
 
   afterEach(function () {


### PR DESCRIPTION
## Summary
- reset `_lr_env` value from local storage in IdentityLinkId tests

## Testing
- `npx eslint test/spec/modules/identityLinkIdSystem_spec.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/identityLinkIdSystem_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6862f363593c832bb4bec82fd9cd75a8