### PR TITLE
test: use fake timers

### DIFF
--- a/test/spec/modules/instreamTracking_spec.js
+++ b/test/spec/modules/instreamTracking_spec.js
@@ -11,6 +11,7 @@ const VIDEO_CACHE_KEY = '4cf395af-8fee-4960-af0e-88d44e399f14';
 
 let sandbox;
 
+let clock;
 function enableInstreamTracking(regex) {
   let configStub = sandbox.stub(config, 'getConfig');
   configStub.withArgs('instreamTracking').returns(Object.assign(
@@ -147,10 +148,12 @@ function getMockInput(mediaType) {
 describe('Instream Tracking', function () {
   beforeEach(function () {
     sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers();
   });
 
   afterEach(function () {
     sandbox.restore();
+    clock.restore();
   });
 
   describe('gaurd checks', function () {
@@ -168,13 +171,13 @@ describe('Instream Tracking', function () {
       assert.isNotOk(trackInstreamDeliveredImpressions({adUnits: [], bidsReceived: [], bidderRequests: []}));
     });
 
-    it('checks for instream bids', function (done) {
+    it('checks for instream bids', function () {
       enableInstreamTracking();
       assert.isNotOk(trackInstreamDeliveredImpressions(getMockInput('banner')), 'should not start tracking when banner bids are present')
       assert.isNotOk(trackInstreamDeliveredImpressions(getMockInput(OUTSTREAM)), 'should not start tracking when outstream bids are present')
       mockPerformanceApi({});
       assert.isOk(trackInstreamDeliveredImpressions(getMockInput(INSTREAM)), 'should start tracking when instream bids are present')
-      setTimeout(done, 10);
+      clock.tick(10);
     });
   });
 
@@ -185,37 +188,31 @@ describe('Instream Tracking', function () {
       spyEventsOn = sandbox.spy(events, 'emit');
     });
 
-    it('BID WON event is not emitted when no video cache key entries are present', function (done) {
+    it('BID WON event is not emitted when no video cache key entries are present', function () {
       enableInstreamTracking();
       trackInstreamDeliveredImpressions(getMockInput(INSTREAM));
       mockPerformanceApi({});
-      setTimeout(function () {
-        assert.isNotOk(spyEventsOn.calledWith('bidWon'))
-        done()
-      }, 10);
+      clock.tick(10);
+      assert.isNotOk(spyEventsOn.calledWith('bidWon'));
     });
 
-    it('BID WON event is not emitted when ad server call is sent', function (done) {
+    it('BID WON event is not emitted when ad server call is sent', function () {
       enableInstreamTracking();
       mockPerformanceApi({adServerCallSent: true});
-      setTimeout(function () {
-        assert.isNotOk(spyEventsOn.calledWith('bidWon'))
-        done()
-      }, 10);
+      clock.tick(10);
+      assert.isNotOk(spyEventsOn.calledWith('bidWon'));
     });
 
-    it('BID WON event is emitted when video cache key is present', function (done) {
+    it('BID WON event is emitted when video cache key is present', function () {
       enableInstreamTracking(/cache/);
       const bidWonSpy = sandbox.spy();
       events.on('bidWon', bidWonSpy);
       mockPerformanceApi({adServerCallSent: true, videoPresent: true});
 
       trackInstreamDeliveredImpressions(getMockInput(INSTREAM));
-      setTimeout(function () {
-        assert.isOk(spyEventsOn.calledWith('bidWon'))
-        assert(bidWonSpy.args[0][0].videoCacheKey, VIDEO_CACHE_KEY, 'Video cache key in bid won should be equal to video cache call');
-        done()
-      }, 10);
+      clock.tick(10);
+      assert.isOk(spyEventsOn.calledWith('bidWon'));
+      assert(bidWonSpy.args[0][0].videoCacheKey, VIDEO_CACHE_KEY, 'Video cache key in bid won should be equal to video cache call');
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace real timers with fake timers in tests

## Testing
- `npx gulp test --file test/spec/modules/instreamTracking_spec.js --nolint`
- `npx gulp test --file test/spec/modules/yieldoneAnalyticsAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6862fe1e86ec832b8fac148c774674af