### PR TITLE
core: default disable BrowserStack accessibility

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,5 +1,10 @@
 const shared = require('./wdio.shared.conf.js');
 
+// Added by Codex agent - disable BrowserStack Accessibility by default
+if (!Object.prototype.hasOwnProperty.call(process.env, 'BROWSERSTACK_ACCESSIBILITY')) {
+  process.env.BROWSERSTACK_ACCESSIBILITY = 'false';
+}
+
 const browsers = Object.fromEntries(
   Object.entries(require('./browsers.json'))
     .filter(([k, v]) => {


### PR DESCRIPTION
## Summary
- set `BROWSERSTACK_ACCESSIBILITY` to `'false'` when not defined so e2e runs don't attempt accessibility builds

## Testing
- `npx gulp lint --files wdio.conf.js`
- `npx gulp test --nolint --file test/spec/unit/adRendering_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_686421626de8832bb8a1b4bc8f7365a3