### PR TITLE
Equativ Adapter: fix user pid message handler

### DIFF
--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -160,11 +160,13 @@ export const spec = {
     if (syncOptions.iframeEnabled) {
       window.addEventListener('message', function handler(event) {
         if (event.origin === COOKIE_SYNC_ORIGIN && event.data.action === 'getConsent') {
-          event.source.postMessage({
-            action: 'consentResponse',
-            id: event.data.id,
-            consents: gdprConsent.vendorData.vendor.consents
-          }, event.origin);
+          if (event.source && event.source.postMessage) {
+            event.source.postMessage({
+              action: 'consentResponse',
+              id: event.data.id,
+              consents: gdprConsent.vendorData.vendor.consents
+            }, event.origin);
+          }
 
           if (event.data.pid) {
             storage.setDataInLocalStorage(PID_STORAGE_NAME, event.data.pid);

--- a/test/spec/modules/equativBidAdapter_spec.js
+++ b/test/spec/modules/equativBidAdapter_spec.js
@@ -898,10 +898,22 @@ describe('Equativ bid adapter tests', () => {
 
   describe('getUserSyncs', () => {
     let setDataInLocalStorageStub;
+    let addEventListenerStub;
+    let messageHandler;
 
-    beforeEach(() => setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage'));
-
-    afterEach(() => setDataInLocalStorageStub.restore());
+    beforeEach(() => {
+      setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage');
+      addEventListenerStub = sinon.stub(window, 'addEventListener').callsFake((type, handler) => {
+        if (type === 'message') {
+          messageHandler = handler;
+        }
+        return addEventListenerStub.wrappedMethod.call(this, type, handler);
+      });
+    });
+    afterEach(() => {
+      setDataInLocalStorageStub.restore();
+      addEventListenerStub.restore();
+    });
 
     it('should return empty array if iframe sync not enabled', () => {
       const syncs = spec.getUserSyncs({}, SAMPLE_RESPONSE);
@@ -915,20 +927,15 @@ describe('Equativ bid adapter tests', () => {
         { gdprApplies: true, vendorData: { vendor: { consents: {} } } }
       );
 
-      window.dispatchEvent(new MessageEvent('message', {
-        data: {
-          action: 'getConsent',
-          pid: '7767825890726'
-        },
+      messageHandler.call(window, {
         origin: 'https://apps.smartadserver.com',
-        source: window
-      }));
-
-      setTimeout(() => {
-        expect(setDataInLocalStorageStub.calledOnce).to.be.true;
-        expect(setDataInLocalStorageStub.calledWith('eqt_pid', '7767825890726')).to.be.true;
-        done();
+        data: { action: 'getConsent', pid: '7767825890726' },
+        source: { postMessage: sinon.stub() }
       });
+
+      expect(setDataInLocalStorageStub.calledOnce).to.be.true;
+      expect(setDataInLocalStorageStub.calledWith('eqt_pid', '7767825890726')).to.be.true;
+      done();
     });
 
     it('should not save user pid coming from incorrect origin', (done) => {
@@ -938,19 +945,14 @@ describe('Equativ bid adapter tests', () => {
         { gdprApplies: true, vendorData: { vendor: { consents: {} } } }
       );
 
-      window.dispatchEvent(new MessageEvent('message', {
-        data: {
-          action: 'getConsent',
-          pid: '7767825890726'
-        },
+      messageHandler.call(window, {
         origin: 'https://another-origin.com',
-        source: window
-      }));
-
-      setTimeout(() => {
-        expect(setDataInLocalStorageStub.notCalled).to.be.true;
-        done();
+        data: { action: 'getConsent', pid: '7767825890726' },
+        source: { postMessage: sinon.stub() }
       });
+
+      expect(setDataInLocalStorageStub.notCalled).to.be.true;
+      done();
     });
 
     it('should not save empty pid', (done) => {
@@ -960,19 +962,14 @@ describe('Equativ bid adapter tests', () => {
         { gdprApplies: true, vendorData: { vendor: { consents: {} } } }
       );
 
-      window.dispatchEvent(new MessageEvent('message', {
-        data: {
-          action: 'getConsent',
-          pid: ''
-        },
+      messageHandler.call(window, {
         origin: 'https://apps.smartadserver.com',
-        source: window
-      }));
-
-      setTimeout(() => {
-        expect(setDataInLocalStorageStub.notCalled).to.be.true;
-        done();
+        data: { action: 'getConsent', pid: '' },
+        source: { postMessage: sinon.stub() }
       });
+
+      expect(setDataInLocalStorageStub.notCalled).to.be.true;
+      done();
     });
 
     it('should return array including iframe cookie sync object (gdprApplies=true)', () => {


### PR DESCRIPTION
## Summary
- ensure postMessage is only called when available
- adjust user pid tests to invoke the message handler directly

## Testing
- `npx eslint --cache --cache-strategy content modules/equativBidAdapter.js test/spec/modules/equativBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/equativBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_686434caf9a8832b99d695092116f3dd