### PR TITLE
Core: convert urlUtils to TypeScript

### DIFF
--- a/libraries/urlUtils/urlUtils.js
+++ b/libraries/urlUtils/urlUtils.js
@@ -1,7 +1,0 @@
-export function tryAppendQueryString(existingUrl, key, value) {
-  if (value) {
-    return existingUrl + key + '=' + encodeURIComponent(value) + '&';
-  }
-
-  return existingUrl;
-}

--- a/libraries/urlUtils/urlUtils.ts
+++ b/libraries/urlUtils/urlUtils.ts
@@ -1,0 +1,7 @@
+export function tryAppendQueryString(existingUrl: string, key: string, value: string): string {
+  if (value) {
+    return `${existingUrl}${key}=${encodeURIComponent(value)}&`;
+  }
+
+  return existingUrl;
+}


### PR DESCRIPTION
## Summary
- convert `libraries/urlUtils/urlUtils.js` to TypeScript
- keep the same API for modules by generating `urlUtils.ts`

## Testing
- `npx gulp lint --files 'libraries/urlUtils/urlUtils.ts'`
- `npx gulp test --file test/spec/libraries/urlUtils_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_686521801dd0832b969b7583e997dda4