### PR TITLE
libraries: convert timeoutqueue to typescript

### DIFF
--- a/libraries/timeoutQueue/timeoutQueue.js
+++ b/libraries/timeoutQueue/timeoutQueue.js
@@ -1,22 +1,22 @@
 export function timeoutQueue() {
-  const queue = new Set();
-  return {
-    submit(timeout, onResume, onTimeout) {
-      const item = {
-        onResume,
-        timerId: setTimeout(() => {
-          queue.delete(item);
-          onTimeout();
-        }, timeout)
-      };
-      queue.add(item);
-    },
-    resume() {
-      for (const item of queue) {
-        queue.delete(item);
-        clearTimeout(item.timerId);
-        item.onResume();
-      }
-    }
-  };
+    const queue = new Set();
+    return {
+        submit(timeout, onResume, onTimeout) {
+            const item = {
+                onResume,
+                timerId: setTimeout(() => {
+                    queue.delete(item);
+                    onTimeout();
+                }, timeout)
+            };
+            queue.add(item);
+        },
+        resume() {
+            for (const item of queue) {
+                queue.delete(item);
+                clearTimeout(item.timerId);
+                item.onResume();
+            }
+        }
+    };
 }

--- a/libraries/timeoutQueue/timeoutQueue.ts
+++ b/libraries/timeoutQueue/timeoutQueue.ts
@@ -1,0 +1,32 @@
+export interface TimeoutQueueItem {
+  onResume: () => void;
+  timerId: ReturnType<typeof setTimeout>;
+}
+
+export interface TimeoutQueue {
+  submit(timeout: number, onResume: () => void, onTimeout: () => void): void;
+  resume(): void;
+}
+
+export function timeoutQueue(): TimeoutQueue {
+  const queue = new Set<TimeoutQueueItem>();
+  return {
+    submit(timeout: number, onResume: () => void, onTimeout: () => void) {
+      const item: TimeoutQueueItem = {
+        onResume,
+        timerId: setTimeout(() => {
+          queue.delete(item);
+          onTimeout();
+        }, timeout)
+      };
+      queue.add(item);
+    },
+    resume() {
+      for (const item of queue) {
+        queue.delete(item);
+        clearTimeout(item.timerId);
+        item.onResume();
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- convert `timeoutQueue` to TypeScript

## Testing
- `npx eslint libraries/timeoutQueue/timeoutQueue.ts libraries/timeoutQueue/timeoutQueue.js test/spec/libraries/timeoutQueue_spec.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/libraries/timeoutQueue_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_68653d326ca0832b9a219380a9482460