### PR TITLE
Core: prevent _lr_env pollution between tests

### DIFF
--- a/test/spec/modules/lockrAIMIdSystem_spec.js
+++ b/test/spec/modules/lockrAIMIdSystem_spec.js
@@ -26,6 +26,12 @@ describe("lockr AIM ID System", function () {
     hook.ready();
   });
 
+  afterEach(() => {
+    coreStorage.removeDataFromLocalStorage(LIVE_RAMP_COOKIE);
+    coreStorage.removeDataFromLocalStorage(UID2_COOKIE);
+    coreStorage.removeDataFromLocalStorage(ID5_COOKIE);
+  });
+
   describe("Check for invalid publisher config and GDPR", function () {
     it("Should fail for invalid config", async function () {
       // no Config


### PR DESCRIPTION
## Summary
- clear LiveRamp and related tokens after each `lockrAIMIdSystem` test

## Testing
- `npx eslint --cache --cache-strategy content test/spec/modules/lockrAIMIdSystem_spec.js modules/identityLinkIdSystem.js test/spec/modules/identityLinkIdSystem_spec.js`
- `npx gulp test --nolint --file test/spec/modules/lockrAIMIdSystem_spec.js`
- `npx gulp test --nolint --file test/spec/modules/identityLinkIdSystem_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_6865af921adc832b80ea677cb01cfff4