### PR TITLE
Seedtag Adapter: fix request count field

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -127,7 +127,8 @@ function buildBidRequest(validBidRequest) {
     adUnitCode: validBidRequest.adUnitCode,
     geom: geom(validBidRequest.adUnitCode),
     placement: params.placement,
-    requestCount: validBidRequest.bidderRequestsCount || 1, // FIXME : in unit test the parameter bidderRequestsCount is undefinedt
+    // use the number of bid requests for this ad unit if available
+    requestCount: validBidRequest.bidRequestsCount || 1,
   };
 
   if (hasVideoMediaType(validBidRequest)) {


### PR DESCRIPTION
## Summary
- fix requestCount to use `bidRequestsCount`

## Testing
- `npx eslint --cache --cache-strategy content modules/seedtagBidAdapter.js`
- `npx gulp test --file test/spec/modules/seedtagBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_686674df88b8832b9ff989a3d1fd7839