### PR TITLE
Core: enforce no tabs in test files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -242,8 +242,6 @@ module.exports = [
       'no-redeclare': 'off',
       'no-global-assign': 'off',
       'default-case-last': 'off',
-      '@stylistic/no-mixed-spaces-and-tabs': 'off',
-      '@stylistic/no-tabs': 'off',
       '@stylistic/no-trailing-spaces': 'error',
     }
   },

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -170,7 +170,7 @@ describe('Adloox Analytics Adapter', function () {
 
         const uri = utils.parseUrl(analyticsAdapter.url(analyticsOptions.js));
         const isLinkPreloadAsScript = function(arg) {
-          const href_uri = utils.parseUrl(arg.href);	// IE11 requires normalisation (hostname always includes port)
+          const href_uri = utils.parseUrl(arg.href);  // IE11 requires normalisation (hostname always includes port)
           return arg.tagName === 'LINK' && arg.getAttribute('rel') === 'preload' && arg.getAttribute('as') === 'script' && href_uri.href === uri.href;
         };
 

--- a/test/spec/modules/admaruBidAdapter_spec.js
+++ b/test/spec/modules/admaruBidAdapter_spec.js
@@ -17,7 +17,7 @@ describe('Admaru Adapter', function () {
     let bid = {
       'bidder': 'admaru',
       'params': {
-    	  'pub_id': '1234',
+        'pub_id': '1234',
         'adspace_id': '1234'
       },
       'adUnitCode': 'adunit-code',
@@ -53,7 +53,7 @@ describe('Admaru Adapter', function () {
       {
         'bidder': 'admaru',
         'params': {
-        	'pub_id': '1234',
+          'pub_id': '1234',
           'adspace_id': '1234'
         },
         'adUnitCode': 'adunit-code',
@@ -95,7 +95,7 @@ describe('Admaru Adapter', function () {
       {
         'bidder': 'admaru',
         'params': {
-        	'pub_id': '1234',
+          'pub_id': '1234',
           'adspace_id': '1234'
         },
         'adUnitCode': 'adunit-code',

--- a/test/spec/modules/admediaBidAdapter_spec.js
+++ b/test/spec/modules/admediaBidAdapter_spec.js
@@ -10,8 +10,8 @@ describe('admediaBidAdapter', function () {
   describe('isBidRequestValid', function () {
     let bid = {
       adUnitCode: 'adunit-code',
-	  bidder: 'admedia',
-	  bidId: 'g7ghhs78',
+    bidder: 'admedia',
+    bidId: 'g7ghhs78',
       mediaTypes: {banner: {sizes: [[300, 250]]}},
       params: {
         placementId: '782332',
@@ -34,7 +34,7 @@ describe('admediaBidAdapter', function () {
         mediaTypes: {banner: {sizes: [[300, 250]]}},
         params: {
           placementId: '782332',
-		  aid: '86858'
+      aid: '86858'
         },
         refererInfo: {
           page: 'https://test.com'
@@ -59,70 +59,70 @@ describe('admediaBidAdapter', function () {
       method: 'POST',
       url: ENDPOINT_URL,
       data: {
-		  'id': '782332',
-		  'aid': '86858',
-		  'tags': [
+      'id': '782332',
+      'aid': '86858',
+      'tags': [
           {
-			  'sizes': [
+        'sizes': [
               '300x250'
-			  ],
-			  'id': '782332',
-			  'aid': '86858'
+        ],
+        'id': '782332',
+        'aid': '86858'
           }
-		  ],
-		  'bidId': '2556388472b168',
-		  'referer': 'https%3A%2F%test.com'
+      ],
+      'bidId': '2556388472b168',
+      'referer': 'https%3A%2F%test.com'
       }
     };
     let serverResponse = {
       body:
-			  {
-			    'tags': [
-				  {
-			        'requestId': '2b8bf2ac497ae',
-			        'ad': "<img src='https://dummyimage.com/300x250/000150/fff.jpg&text=Admedia'>",
-			        'width': 300,
-			        'height': 250,
-			        'cpm': 0.71,
-			        'currency': 'USD',
-			        'ttl': 200,
-			        'creativeId': 128,
-			        'netRevenue': true,
-			        'meta': {
-					  'advertiserDomains': [
-			            'https://www.test.com'
-					  ]
-			        }
-				  }
-			    ]
-			  }
+        {
+          'tags': [
+          {
+              'requestId': '2b8bf2ac497ae',
+              'ad': "<img src='https://dummyimage.com/300x250/000150/fff.jpg&text=Admedia'>",
+              'width': 300,
+              'height': 250,
+              'cpm': 0.71,
+              'currency': 'USD',
+              'ttl': 200,
+              'creativeId': 128,
+              'netRevenue': true,
+              'meta': {
+            'advertiserDomains': [
+                  'https://www.test.com'
+            ]
+              }
+          }
+          ]
+        }
 
     };
     it('should get the correct bid response', function () {
       let expectedResponse =
-		  {
-		    'tags': [
-			  {
-			    'requestId': '2b8bf2ac497ae',
-			    'ad': "<img src='https://dummyimage.com/300x250/000150/fff.jpg&text=Admedia'>",
-			    'width': 300,
-			    'height': 250,
-			    'cpm': 0.71,
-			    'currency': 'USD',
-			    'ttl': 200,
-			    'creativeId': 128,
-			    'netRevenue': true,
-			    'meta': {
-				  'advertiserDomains': [
-			        'https://www.test.com'
-				  ]
-			    }
-			  }
-		    ]
-		  }
+      {
+        'tags': [
+        {
+          'requestId': '2b8bf2ac497ae',
+          'ad': "<img src='https://dummyimage.com/300x250/000150/fff.jpg&text=Admedia'>",
+          'width': 300,
+          'height': 250,
+          'cpm': 0.71,
+          'currency': 'USD',
+          'ttl': 200,
+          'creativeId': 128,
+          'netRevenue': true,
+          'meta': {
+          'advertiserDomains': [
+              'https://www.test.com'
+          ]
+          }
+        }
+        ]
+      }
       let result = spec.interpretResponse(serverResponse, bidRequest);
-	  expect(result).to.be.an('array').that.is.not.empty;
-	  expect(Object.keys(result[0])).to.have.members(
+    expect(result).to.be.an('array').that.is.not.empty;
+    expect(Object.keys(result[0])).to.have.members(
         Object.keys(expectedResponse.tags[0])
       );
     });

--- a/test/spec/modules/advertisingBidAdapter_spec.js
+++ b/test/spec/modules/advertisingBidAdapter_spec.js
@@ -1483,7 +1483,7 @@ describe('advertisingBidAdapter ', function () {
       ortb2Imp: {
         ext: {
           gpid: '/1111/homepage-video',
-	          data: {
+            data: {
             pbadslot: '/1111/homepage-video'
           }
         }
@@ -1516,7 +1516,7 @@ describe('advertisingBidAdapter ', function () {
       ortb2Imp: {
         ext: {
           gpid: '/1111/homepage-banner',
-	          data: {
+            data: {
             pbadslot: '/1111/homepage-banner'
           }
         }

--- a/test/spec/modules/anonymisedRtdProvider_spec.js
+++ b/test/spec/modules/anonymisedRtdProvider_spec.js
@@ -33,7 +33,7 @@ describe('anonymisedRtdProvider', function() {
 
   describe('anonymisedRtdSubmodule', function() {
     it('successfully instantiates', function () {
-		  expect(anonymisedRtdSubmodule.init()).to.equal(true);
+      expect(anonymisedRtdSubmodule.init()).to.equal(true);
     });
     it('should load external script when params.tagConfig.clientId is set', function () {
       const rtdConfig = {

--- a/test/spec/modules/bedigitechBidAdapter_spec.js
+++ b/test/spec/modules/bedigitechBidAdapter_spec.js
@@ -83,9 +83,9 @@ describe('BedigitechAdapter', function () {
           'currency': 'USD',
           'height': 250,
           'id': 'bedigitechMyidfdfdf',
-          'netRevenue':	true,
-          'requestTime':	1686306237,
-          'timeToRespond':	300,
+          'netRevenue': true,
+          'requestTime': 1686306237,
+          'timeToRespond': 300,
           'ttl': 300,
           'width': 300
         }
@@ -107,10 +107,10 @@ describe('BedigitechAdapter', function () {
           'meta': {
             'mediaType': BANNER,
           },
-          'netRevenue':	true,
+          'netRevenue': true,
           'requestId': 'bedigitechMyidfdfdf',
-          'requestTimestamp':	1686306237,
-          'timeToRespond':	300,
+          'requestTimestamp': 1686306237,
+          'timeToRespond': 300,
           'ttl': 300,
           'width': 300,
           'bidderCode': 'bedigitech',

--- a/test/spec/modules/blueconicRtdProvider_spec.js
+++ b/test/spec/modules/blueconicRtdProvider_spec.js
@@ -14,7 +14,7 @@ describe('blueconicRtdProvider', function() {
 
   describe('blueconicSubmodule', function() {
     it('successfully instantiates', function () {
-		  expect(blueconicSubmodule.init()).to.equal(true);
+      expect(blueconicSubmodule.init()).to.equal(true);
     });
   });
 

--- a/test/spec/modules/connectadBidAdapter_spec.js
+++ b/test/spec/modules/connectadBidAdapter_spec.js
@@ -296,7 +296,7 @@ describe('ConnectAd Adapter', function () {
         };
 
         let bidRequest = {
-		      ortb2: {
+          ortb2: {
             regs: {
               ext: {
                 dsa

--- a/test/spec/modules/datablocksBidAdapter_spec.js
+++ b/test/spec/modules/datablocksBidAdapter_spec.js
@@ -184,123 +184,123 @@ let bid_request = {
     withCredentials: true
   },
   data: {
-	    'id': 'c09c6e47-8bdb-4884-a46d-93165322b368',
-	    'imp': [{
-	        'id': '1',
-	        'tagid': '/19968336/header-bid-tag-0',
-	        'placement_id': 0,
-	        'secure': true,
-	        'banner': {
-	            'w': 300,
-	            'h': 250,
-	            'format': [{
-	                'w': 300,
-	                'h': 250
-	            }, {
-	                'w': 300,
-	                'h': 600
-	            }]
-	        }
-	    }, {
-	        'id': '2',
-	        'tagid': '/19968336/header-bid-tag-1',
-	        'placement_id': 12345,
-	        'secure': true,
-	        'banner': {
-	            'w': 729,
-	            'h': 90,
-	            'format': [{
-	                'w': 729,
-	                'h': 90
-	            }, {
-	                'w': 970,
-	                'h': 250
-	            }]
-	        }
-	    }, {
-	        'id': '3',
-	        'tagid': '/19968336/prebid_multiformat_test',
-	        'placement_id': 0,
-	        'secure': true,
-	        'native': {
-	            'ver': '1.2',
-	            'request': {
-	                'assets': [{
-	                    'required': 1,
-	                    'id': 1,
-	                    'title': {}
-	                }, {
-	                    'required': 1,
-	                    'id': 3,
-	                    'img': {
-	                        'type': 3
-	                    }
-	                }, {
-	                    'required': 1,
-	                    'id': 5,
-	                    'data': {
-	                        'type': 1
-	                    }
-	                }],
-	                'context': 1,
-	                'plcmttype': 1,
-	                'ver': '1.2'
-	            }
-	        }
-	    }],
-	    'site': {
-	        'domain': 'test.datablocks.net',
-	        'page': 'https://test.datablocks.net/index.html',
-	        'schain': {},
-	        'ext': {
-	            'p_domain': 'https://test.datablocks.net',
-	            'rt': true,
-	            'frames': 0,
-	            'stack': ['https://test.datablocks.net/index.html'],
-	            'timeout': 3000
-	        },
-	        'keywords': 'HTML, CSS, JavaScript'
-	    },
-	    'device': {
-	        'ip': 'peer',
-	        'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36',
-	        'js': 1,
-	        'language': 'en',
-	        'buyerid': '1234567',
-	        'ext': {
-	            'pb_eids': [{
-	                'source': 'criteo.com',
-	                'uids': [{
-	                    'id': 'test',
-	                    'atype': 1
-	                }]
-	            }],
-	            'syncs': {
-	                '1000': 'db_4044853',
-	                '1001': true
-	            },
-	            'coppa': 0,
-	            'gdpr': {},
-	            'usp': {},
-	            'client_info': {
-	                'wiw': 2560,
-	                'wih': 1281,
-	                'saw': 2560,
-	                'sah': 1417,
-	                'scd': 24,
-	                'sw': 2560,
-	                'sh': 1440,
-	                'whl': 4,
-	                'wxo': 0,
-	                'wyo': 0,
-	                'wpr': 2,
-	                'is_bot': false,
-	                'is_hid': false,
-	                'vs': 'hidden'
-	            },
-	            'fpd': {}
-	        }
-	    }
+      'id': 'c09c6e47-8bdb-4884-a46d-93165322b368',
+      'imp': [{
+          'id': '1',
+          'tagid': '/19968336/header-bid-tag-0',
+          'placement_id': 0,
+          'secure': true,
+          'banner': {
+              'w': 300,
+              'h': 250,
+              'format': [{
+                  'w': 300,
+                  'h': 250
+              }, {
+                  'w': 300,
+                  'h': 600
+              }]
+          }
+      }, {
+          'id': '2',
+          'tagid': '/19968336/header-bid-tag-1',
+          'placement_id': 12345,
+          'secure': true,
+          'banner': {
+              'w': 729,
+              'h': 90,
+              'format': [{
+                  'w': 729,
+                  'h': 90
+              }, {
+                  'w': 970,
+                  'h': 250
+              }]
+          }
+      }, {
+          'id': '3',
+          'tagid': '/19968336/prebid_multiformat_test',
+          'placement_id': 0,
+          'secure': true,
+          'native': {
+              'ver': '1.2',
+              'request': {
+                  'assets': [{
+                      'required': 1,
+                      'id': 1,
+                      'title': {}
+                  }, {
+                      'required': 1,
+                      'id': 3,
+                      'img': {
+                          'type': 3
+                      }
+                  }, {
+                      'required': 1,
+                      'id': 5,
+                      'data': {
+                          'type': 1
+                      }
+                  }],
+                  'context': 1,
+                  'plcmttype': 1,
+                  'ver': '1.2'
+              }
+          }
+      }],
+      'site': {
+          'domain': 'test.datablocks.net',
+          'page': 'https://test.datablocks.net/index.html',
+          'schain': {},
+          'ext': {
+              'p_domain': 'https://test.datablocks.net',
+              'rt': true,
+              'frames': 0,
+              'stack': ['https://test.datablocks.net/index.html'],
+              'timeout': 3000
+          },
+          'keywords': 'HTML, CSS, JavaScript'
+      },
+      'device': {
+          'ip': 'peer',
+          'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36',
+          'js': 1,
+          'language': 'en',
+          'buyerid': '1234567',
+          'ext': {
+              'pb_eids': [{
+                  'source': 'criteo.com',
+                  'uids': [{
+                      'id': 'test',
+                      'atype': 1
+                  }]
+              }],
+              'syncs': {
+                  '1000': 'db_4044853',
+                  '1001': true
+              },
+              'coppa': 0,
+              'gdpr': {},
+              'usp': {},
+              'client_info': {
+                  'wiw': 2560,
+                  'wih': 1281,
+                  'saw': 2560,
+                  'sah': 1417,
+                  'scd': 24,
+                  'sw': 2560,
+                  'sh': 1440,
+                  'whl': 4,
+                  'wxo': 0,
+                  'wyo': 0,
+                  'wpr': 2,
+                  'is_bot': false,
+                  'is_hid': false,
+                  'vs': 'hidden'
+              },
+              'fpd': {}
+          }
+      }
   }
 }
 

--- a/test/spec/modules/djaxBidAdapter_spec.js
+++ b/test/spec/modules/djaxBidAdapter_spec.js
@@ -18,7 +18,7 @@ describe('Djax Adapter', function() {
     let bid = {
       'bidder': 'djax',
       'params': {
-    	  'publisherId': 2
+        'publisherId': 2
       },
       'adUnitCode': 'adunit-code',
       'mediaTypes': {
@@ -44,7 +44,7 @@ describe('Djax Adapter', function() {
       {
         'bidder': 'djax',
         'params': {
-        	'publisherId': 2
+          'publisherId': 2
         },
         'adUnitCode': 'adunit-code',
         'mediaTypes': {
@@ -73,7 +73,7 @@ describe('Djax Adapter', function() {
       {
         'bidder': 'djax',
         'params': {
-        	'publisherId': 2
+          'publisherId': 2
         },
         'adUnitCode': 'adunit-code',
         'mediaTypes': {

--- a/test/spec/modules/finativeBidAdapter_spec.js
+++ b/test/spec/modules/finativeBidAdapter_spec.js
@@ -104,19 +104,19 @@ describe('Finative adapter', function () {
         id: '4b516b80-886e-4ec0-82ae-9209e6d625fb',
         seatbid: [
           {
-          	seat: 'finative',
-          	bid: [{
+            seat: 'finative',
+            bid: [{
               adm: {
-            	native: {
-            		assets: [
-            			{id: 0, title: {text: 'this is a title'}}
-            		],
-            		imptrackers: ['https://domain.for/imp/tracker?price=${AUCTION_PRICE}'],
-            		link: {
-            			clicktrackers: ['https://domain.for/imp/tracker?price=${AUCTION_PRICE}'],
-            			url: 'https://domain.for/ad/'
-            		}
-            	}
+              native: {
+                assets: [
+                  {id: 0, title: {text: 'this is a title'}}
+                ],
+                imptrackers: ['https://domain.for/imp/tracker?price=${AUCTION_PRICE}'],
+                link: {
+                  clicktrackers: ['https://domain.for/imp/tracker?price=${AUCTION_PRICE}'],
+                  url: 'https://domain.for/ad/'
+                }
+              }
               },
               impid: 1,
               price: 0.55
@@ -163,11 +163,11 @@ describe('Finative adapter', function () {
       const regExpPrice = new RegExp('price=' + bid.price);
 
       result[0].native.clickTrackers.forEach(function (clickTracker) {
-        	assert.ok(clickTracker.search(regExpPrice) > -1);
+          assert.ok(clickTracker.search(regExpPrice) > -1);
       });
 
       result[0].native.impressionTrackers.forEach(function (impTracker) {
-        	assert.ok(impTracker.search(regExpPrice) > -1);
+          assert.ok(impTracker.search(regExpPrice) > -1);
       });
     });
   });

--- a/test/spec/modules/growthCodeRtdProvider_spec.js
+++ b/test/spec/modules/growthCodeRtdProvider_spec.js
@@ -26,7 +26,7 @@ describe('growthCodeRtdProvider', function() {
           cbObj.success('{"status":"ok","version":"1.0.0","results":1,"items":[{"bidder":"client_a","attachment_point":"data","parameters":"{\\"client_a\\":{\\"user\\":{\\"ext\\":{\\"data\\":{\\"eids\\":[{\\"source\\":\\"\\",\\"uids\\":[{\\"id\\":\\"4254074976bb6a6d970f5f693bd8a75c\\",\\"atype\\":3,\\"ext\\":{\\"stype\\":\\"hemmd5\\"}},{\\"id\\":\\"d0ee291572ffcfba0bf7edb2b1c90ca7c32d255e5040b8b50907f5963abb1898\\",\\"atype\\":3,\\"ext\\":{\\"stype\\":\\"hemsha256\\"}}]}]}}}}}"}],"expires_at":1685029931}')
         }
       });
-		  expect(growthCodeRtdProvider.init(null, null)).to.equal(false);
+      expect(growthCodeRtdProvider.init(null, null)).to.equal(false);
       ajaxStub.restore()
     });
     it('successfully instantiates', function () {

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -339,7 +339,7 @@ describe('invibesBidAdapter:', function () {
     });
 
     it('sends bid request to default endpoint 1 via GET', function () {
-	  const request = spec.buildRequests([{
+    const request = spec.buildRequests([{
         bidId: 'b1',
         bidder: BIDDER_CODE,
         params: {
@@ -1259,7 +1259,7 @@ describe('invibesBidAdapter:', function () {
         AuctionStartTime: Date.now(),
         CreativeHtml: '<!-- Creative -->'
       },
-	  UseAdUnitCode: true
+    UseAdUnitCode: true
     };
 
     var buildResponse = function(placementId, cid, blcids, creativeId, ShouldSetLId) {

--- a/test/spec/modules/liveIntentRtdProvider_spec.js
+++ b/test/spec/modules/liveIntentRtdProvider_spec.js
@@ -22,16 +22,16 @@ describe('LiveIntent Rtd Provider', function () {
       bidderRequestId: '2a038c6820142b',
       bids: [
         {
-        	bidder: 'appnexus',
-        	userId: {
-        		lipb: {
-        			segments: [
-        				'asa_1231',
-        				'lalo_4311',
-        				'liurl_99123'
-        			]
-        		}
-        	}
+          bidder: 'appnexus',
+          userId: {
+            lipb: {
+              segments: [
+                'asa_1231',
+                'lalo_4311',
+                'liurl_99123'
+              ]
+            }
+          }
         }
       ]
     }
@@ -47,8 +47,8 @@ describe('LiveIntent Rtd Provider', function () {
         bidderRequestId: '2a038c6820142b',
         bids: [
           {
-            	bidder: 'appnexus',
-            	ortb2: {}
+              bidder: 'appnexus',
+              ortb2: {}
           }
         ]
       }

--- a/test/spec/modules/mediagoBidAdapter_spec.js
+++ b/test/spec/modules/mediagoBidAdapter_spec.js
@@ -51,7 +51,7 @@ describe('mediago:BidAdapterTests', function () {
         },
         ortb2: {
           site: {
-        	cat: ['IAB2'],
+          cat: ['IAB2'],
             keywords: 'power tools, drills, tools=industrial',
             content: {
               keywords: 'video, source=streaming'

--- a/test/spec/modules/nobidBidAdapter_spec.js
+++ b/test/spec/modules/nobidBidAdapter_spec.js
@@ -251,20 +251,20 @@ describe('Nobid Adapter', function () {
     });
 
     it('sends bid request to site id', function () {
-	  const request = spec.buildRequests(bidRequests);
-	  const payload = JSON.parse(request.data);
-	  expect(payload.a).to.exist;
-	  expect(payload.a[0].sid).to.equal(2);
-	  expect(payload.a[0].at).to.equal('banner');
-	  expect(payload.a[0].params.siteId).to.equal(2);
+    const request = spec.buildRequests(bidRequests);
+    const payload = JSON.parse(request.data);
+    expect(payload.a).to.exist;
+    expect(payload.a[0].sid).to.equal(2);
+    expect(payload.a[0].at).to.equal('banner');
+    expect(payload.a[0].params.siteId).to.equal(2);
     });
 
     it('sends bid request to ad type', function () {
-  	  const request = spec.buildRequests(bidRequests);
-  	  const payload = JSON.parse(request.data);
-  	  expect(payload.a).to.exist;
-  	  expect(payload.a[0].at).to.equal('banner');
-  	});
+      const request = spec.buildRequests(bidRequests);
+      const payload = JSON.parse(request.data);
+      expect(payload.a).to.exist;
+      expect(payload.a[0].at).to.equal('banner');
+    });
 
     it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests);
@@ -381,7 +381,7 @@ describe('Nobid Adapter', function () {
         auctionId: '1d1a030790a475',
         mediaTypes: {
           video: {
-        	playerSize: [640, 480],
+          playerSize: [640, 480],
             context: 'instream'
           }
         }
@@ -471,7 +471,7 @@ describe('Nobid Adapter', function () {
         auctionId: '1d1a030790a475',
         mediaTypes: {
           video: {
-        	playerSize: [640, 480],
+          playerSize: [640, 480],
             context: 'outstream'
           }
         }
@@ -634,20 +634,20 @@ describe('Nobid Adapter', function () {
     });
 
     it('sends bid request to site id', function () {
-	  const request = spec.buildRequests(bidRequests);
-	  const payload = JSON.parse(request.data);
-	  expect(payload.a).to.exist;
-	  expect(payload.a[0].sid).to.equal(2);
-	  expect(payload.a[0].at).to.equal('banner');
-	  expect(payload.a[0].params.siteId).to.equal(2);
+    const request = spec.buildRequests(bidRequests);
+    const payload = JSON.parse(request.data);
+    expect(payload.a).to.exist;
+    expect(payload.a[0].sid).to.equal(2);
+    expect(payload.a[0].at).to.equal('banner');
+    expect(payload.a[0].params.siteId).to.equal(2);
     });
 
     it('sends bid request to ad type', function () {
-  	  const request = spec.buildRequests(bidRequests);
-  	  const payload = JSON.parse(request.data);
-  	  expect(payload.a).to.exist;
-  	  expect(payload.a[0].at).to.equal('banner');
-  	});
+      const request = spec.buildRequests(bidRequests);
+      const payload = JSON.parse(request.data);
+      expect(payload.a).to.exist;
+      expect(payload.a[0].at).to.equal('banner');
+    });
 
     it('sends bid request to ENDPOINT via POST', function () {
       const request = spec.buildRequests(bidRequests);
@@ -905,7 +905,7 @@ describe('Nobid Adapter', function () {
           adm: ADMARKUP_300x250,
           price: '' + PRICE_300x250,
           meta: {
-        	  advertiserDomains: ADOMAINS
+            advertiserDomains: ADOMAINS
           }
         }
       ]
@@ -1065,8 +1065,8 @@ describe('Nobid Adapter', function () {
     });
 
     it('should get correct user sync when !iframeEnabled', function () {
-	  let pixel = spec.getUserSyncs({})
-	  expect(pixel.length).to.equal(0);
+    let pixel = spec.getUserSyncs({})
+    expect(pixel.length).to.equal(0);
     });
   });
 

--- a/test/spec/modules/optoutBidAdapter_spec.js
+++ b/test/spec/modules/optoutBidAdapter_spec.js
@@ -94,7 +94,7 @@ describe('optoutAdapterTest', function () {
     it('bidRequest with config for currency', function () {
       config.setConfig({
         currency: {
-       	    adServerCurrency: 'USD',
+             adServerCurrency: 'USD',
           granularityMultiplier: 1
         }
       })

--- a/test/spec/modules/oxxionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/oxxionAnalyticsAdapter_spec.js
@@ -169,7 +169,7 @@ describe('Oxxion Analytics', function () {
           'advertiserDomains': [
             'example.com'
           ],
-	  'demandSource': 'something'
+    'demandSource': 'something'
         },
         'renderer': 'something',
         'originalCpm': 25.02521,

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -56,8 +56,8 @@ describe('PubMatic adapter', () => {
     },
     ortb2Imp: {
       ext: {
-        	tid: '92489f71-1bf2-49a0-adf9-000cea934729',
-        	gpid: '/1111/homepage-leftnav',
+          tid: '92489f71-1bf2-49a0-adf9-000cea934729',
+          gpid: '/1111/homepage-leftnav',
         data: {
           pbadslot: '/1111/homepage-leftnav',
           adserver: {
@@ -74,7 +74,7 @@ describe('PubMatic adapter', () => {
   videoBid = {
     'seat': 'seat-id',
     'ext': {
-		  'buyid': 'BUYER-ID-987'
+      'buyid': 'BUYER-ID-987'
     },
     'bid': [{
       'id': '74858439-49D7-4169-BA5D-44A046315B2F',
@@ -96,7 +96,7 @@ describe('PubMatic adapter', () => {
   firstResponse = {
     'seat': 'seat-id',
     'ext': {
-		  'buyid': 'BUYER-ID-987'
+      'buyid': 'BUYER-ID-987'
     },
     'bid': [{
       'id': '74858439-49D7-4169-BA5D-44A046315B2F',
@@ -117,16 +117,16 @@ describe('PubMatic adapter', () => {
   };
   response = {
     'body': {
-		  cur: 'USD',
-		  id: '93D3BAD6-E2E2-49FB-9D89-920B1761C865',
-		  seatbid: [firstResponse]
+      cur: 'USD',
+      id: '93D3BAD6-E2E2-49FB-9D89-920B1761C865',
+      seatbid: [firstResponse]
     }
   };
   videoResponse = {
     'body': {
-		  cur: 'USD',
-		  id: '93D3BAD6-E2E2-49FB-9D89-920B1761C865',
-		  seatbid: [videoBid]
+      cur: 'USD',
+      id: '93D3BAD6-E2E2-49FB-9D89-920B1761C865',
+      seatbid: [videoBid]
     }
   }
   let validBidRequests = [firstBid];
@@ -165,16 +165,16 @@ describe('PubMatic adapter', () => {
     it('should return false if publisherId is missing', () => {
       const bid = utils.deepClone(validBidRequests[0]);
       delete bid.params.publisherId;
-	  	const isValid = spec.isBidRequestValid(bid);
-	  	expect(isValid).to.equal(false);
-  	});
+      const isValid = spec.isBidRequestValid(bid);
+      expect(isValid).to.equal(false);
+    });
 
     it('should return false if publisherId is not of type string', () => {
       const bid = utils.deepClone(validBidRequests[0]);
       bid.params.publisherId = 5890;
-	    const isValid = spec.isBidRequestValid(bid);
-	    expect(isValid).to.equal(false);
-  	});
+      const isValid = spec.isBidRequestValid(bid);
+      expect(isValid).to.equal(false);
+    });
 
     if (FEATURES.VIDEO) {
       describe('VIDEO', () => {
@@ -193,8 +193,8 @@ describe('PubMatic adapter', () => {
           }
         });
         it('should return false if mimes are missing in a video impression request', () => {
-			  	const isValid = spec.isBidRequestValid(videoBidRequest);
-			  	expect(isValid).to.equal(false);
+          const isValid = spec.isBidRequestValid(videoBidRequest);
+          expect(isValid).to.equal(false);
         });
 
         it('should return false if context is missing in a video impression request', () => {
@@ -393,7 +393,7 @@ describe('PubMatic adapter', () => {
         expect(imp[0]).to.have.property('banner').to.have.property('pos').equal(0);
       });
 
-	  	if (FEATURES.VIDEO) {
+      if (FEATURES.VIDEO) {
         describe('VIDEO', () => {
           beforeEach(() => {
             utilsLogWarnMock = sinon.stub(utils, 'logWarn');
@@ -467,8 +467,8 @@ describe('PubMatic adapter', () => {
             expect(imp[0]).to.have.property('video').to.have.property('h');
           });
         });
-	  	}
-	  	if (FEATURES.NATIVE) {
+      }
+      if (FEATURES.NATIVE) {
         describe('NATIVE', () => {
           beforeEach(() => {
             utilsLogWarnMock = sinon.stub(utils, 'logWarn');
@@ -512,7 +512,7 @@ describe('PubMatic adapter', () => {
             expect(imp[0]).to.have.property('native');
           });
         });
-	 		}
+       }
       //   describe('MULTIFORMAT', () => {
       //     let multiFormatBidderRequest;
       //     it('should have both banner & video impressions', () => {
@@ -839,14 +839,14 @@ describe('PubMatic adapter', () => {
           pubrender: 0,
           datatopub: 2,
           transparency: [
-    			  {
+            {
               domain: 'platform1domain.com',
               dsaparams: [1]
-    			  },
-    			  {
+            },
+            {
               domain: 'SSP2domain.com',
               dsaparams: [1, 2]
-    			  }
+            }
           ]
         };
         beforeEach(() => {
@@ -954,32 +954,32 @@ describe('PubMatic adapter', () => {
       });
 
       // describe('USER ID/ EIDS', () => {
-      // 	let copiedBidderRequest;
-      // 	beforeEach(() => {
-      // 		copiedBidderRequest = utils.deepClone(bidderRequest);
-      // 		copiedBidderRequest.bids[0].userId = {
-      // 			id5id : {
-      // 				uid: 'id5id-xyz-user-id'
-      // 			}
-      // 		}
-      // 		copiedBidderRequest.bids[0].userIdAsEids = [{
-      // 			source: 'id5-sync.com',
-      // 			uids: [{
-      // 				'id': "ID5*G3_osFE_-UHoUjSuA4T8-f51U-JTNOoGcb2aMpx1APnDy8pDwkKCzXCcoSb1HXIIw9AjWBOWmZ3QbMUDTXKq8MPPW8h0II9mBYkP4F_IXkvD-XG64NuFFDPKvez1YGGx",
-      // 				'atype': 1,
-      // 				'ext': {
-      // 					'linkType': 2,
-      // 					'pba': 'q6Vzr0jEebxzmvS8aSrVQJFoJnOxs9gKBKCOLw1y6ew='
-      // 				}
-      // 			}]
-      // 		}]
-      // 	});
+      //   let copiedBidderRequest;
+      //   beforeEach(() => {
+      //     copiedBidderRequest = utils.deepClone(bidderRequest);
+      //     copiedBidderRequest.bids[0].userId = {
+      //       id5id : {
+      //         uid: 'id5id-xyz-user-id'
+      //       }
+      //     }
+      //     copiedBidderRequest.bids[0].userIdAsEids = [{
+      //       source: 'id5-sync.com',
+      //       uids: [{
+      //         'id': "ID5*G3_osFE_-UHoUjSuA4T8-f51U-JTNOoGcb2aMpx1APnDy8pDwkKCzXCcoSb1HXIIw9AjWBOWmZ3QbMUDTXKq8MPPW8h0II9mBYkP4F_IXkvD-XG64NuFFDPKvez1YGGx",
+      //         'atype': 1,
+      //         'ext': {
+      //           'linkType': 2,
+      //           'pba': 'q6Vzr0jEebxzmvS8aSrVQJFoJnOxs9gKBKCOLw1y6ew='
+      //         }
+      //       }]
+      //     }]
+      //   });
 
-      // 	it('should send gpid if specified', () => {
-      // 		const request = spec.buildRequests(validBidRequests, copiedBidderRequest);
-      // 		expect(request.data).to.have.property('user');
-      // 		expect(request.data.user).to.have.property('eids');
-      // 	});
+      //   it('should send gpid if specified', () => {
+      //     const request = spec.buildRequests(validBidRequests, copiedBidderRequest);
+      //     expect(request.data).to.have.property('user');
+      //     expect(request.data.user).to.have.property('eids');
+      //   });
       // });
     });
   });

--- a/test/spec/modules/pwbidBidAdapter_spec.js
+++ b/test/spec/modules/pwbidBidAdapter_spec.js
@@ -586,7 +586,7 @@ describe('PubWiseAdapter', function () {
     });
 
     it('identifies banner adm type', function() {
-      let adm = '<div style="box-sizing: border-box;width:298px;height:248px;border: 1px solid rgba(0,0,0,.25);border-radius:10px;">↵	<h3 style="margin-top:80px;text-align: center;">PubWise Test Bid</h3>↵</div>';
+      let adm = '<div style="box-sizing: border-box;width:298px;height:248px;border: 1px solid rgba(0,0,0,.25);border-radius:10px;">↵  <h3 style="margin-top:80px;text-align: center;">PubWise Test Bid</h3>↵</div>';
       let newBid = {mediaType: 'unknown'};
       _checkMediaType({adm}, newBid);
       expect(newBid.mediaType).to.equal('banner', adm + ' Is a Banner adm');

--- a/test/spec/modules/relevadRtdProvider_spec.js
+++ b/test/spec/modules/relevadRtdProvider_spec.js
@@ -67,7 +67,7 @@ const adUnitsCommon = [
 describe('relevadRtdProvider', function() {
   describe('relevadSubmodule', function() {
     it('successfully instantiates', function () {
-		      expect(relevadSubmodule.init()).to.equal(true);
+          expect(relevadSubmodule.init()).to.equal(true);
     });
   });
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1039,13 +1039,13 @@ describe('the rubicon adapter', function () {
                   'ext': { 'segtax': 1 },
                   'segment': [
                     { 'id': '987' }
-		    ]
-		  }, {
-		    'name': 'www.dataprovider1.com',
-		    'ext': { 'segtax': 2 },
-		    'segment': [
-		      { 'id': '432' }
-		    ]
+        ]
+      }, {
+        'name': 'www.dataprovider1.com',
+        'ext': { 'segtax': 2 },
+        'segment': [
+          { 'id': '432' }
+        ]
                 }, {
                   'name': 'www.dataprovider1.com',
                   'ext': { 'segtax': 5 },

--- a/test/spec/modules/seedingAllianceAdapter_spec.js
+++ b/test/spec/modules/seedingAllianceAdapter_spec.js
@@ -146,8 +146,8 @@ describe('SeedingAlliance adapter', function () {
         id: 'bidid1',
         seatbid: [
           {
-          	seat: 'seedingAlliance',
-          	bid: [{
+            seat: 'seedingAlliance',
+            bid: [{
               adm: JSON.stringify({
                 native: {
                   assets: [
@@ -175,8 +175,8 @@ describe('SeedingAlliance adapter', function () {
         id: 'bidid1',
         seatbid: [
           {
-          	seat: 'seedingAlliance',
-          	bid: [{
+            seat: 'seedingAlliance',
+            bid: [{
               adm: '<iframe src="https://domain.tld/cds/delivery?wp=0.90"></iframe>',
               impid: 1,
               price: 0.90,

--- a/test/spec/modules/sizeMappingV2_spec.js
+++ b/test/spec/modules/sizeMappingV2_spec.js
@@ -24,8 +24,8 @@ const AD_UNITS = [{
   mediaTypes: {
     banner: {
       sizeConfig: [
-        { minViewPort: [0, 0], sizes: [] },		// remove if < 750px
-        { minViewPort: [750, 0], sizes: [[300, 250], [300, 600]] },		// between 750px and 1199px
+        { minViewPort: [0, 0], sizes: [] },    // remove if < 750px
+        { minViewPort: [750, 0], sizes: [[300, 250], [300, 600]] },    // between 750px and 1199px
         { minViewPort: [1200, 0], sizes: [[970, 90], [728, 90], [300, 250]] }, // between 1200px and 1599px
         { minViewPort: [1600, 0], sizes: [[1000, 300], [970, 90], [728, 90], [300, 250]] } // greater than 1600px
       ]

--- a/test/spec/modules/smarticoBidAdapter_spec.js
+++ b/test/spec/modules/smarticoBidAdapter_spec.js
@@ -102,34 +102,34 @@ describe('smarticoBidAdapter', function () {
       }}];
     let result = spec.interpretResponse(serverResponse, bidRequest);
     it('should contain correct creativeId', function () {
-	  expect(result[0].creativeId).to.equal(expectedResponse[0].creativeId)
+    expect(result[0].creativeId).to.equal(expectedResponse[0].creativeId)
     });
     it('should contain correct cpm', function () {
-	  expect(result[0].cpm).to.equal(expectedResponse[0].cpm)
+    expect(result[0].cpm).to.equal(expectedResponse[0].cpm)
     });
     it('should contain correct width', function () {
-	  expect(result[0].width).to.equal(expectedResponse[0].width)
+    expect(result[0].width).to.equal(expectedResponse[0].width)
     });
     it('should contain correct height', function () {
-	  expect(result[0].height).to.equal(expectedResponse[0].height)
+    expect(result[0].height).to.equal(expectedResponse[0].height)
     });
     it('should contain correct requestId', function () {
-	  expect(result[0].requestId).to.equal(expectedResponse[0].requestId)
+    expect(result[0].requestId).to.equal(expectedResponse[0].requestId)
     });
     it('should contain correct ttl', function () {
-	  expect(result[0].ttl).to.equal(expectedResponse[0].ttl)
+    expect(result[0].ttl).to.equal(expectedResponse[0].ttl)
     });
     it('should contain correct netRevenue', function () {
-	  expect(result[0].netRevenue).to.equal(expectedResponse[0].netRevenue)
+    expect(result[0].netRevenue).to.equal(expectedResponse[0].netRevenue)
     });
     it('should contain correct netRevenue', function () {
-	  expect(result[0].currency).to.equal(expectedResponse[0].currency)
+    expect(result[0].currency).to.equal(expectedResponse[0].currency)
     });
     it('should contain correct ad content', function () {
-	  expect(result[0].ad).to.equal(expectedResponse[0].ad)
+    expect(result[0].ad).to.equal(expectedResponse[0].ad)
     });
     it('should contain correct meta content', function () {
-	  expect(result[0].meta).to.deep.equal(expectedResponse[0].meta)
+    expect(result[0].meta).to.deep.equal(expectedResponse[0].meta)
     });
   });
 });

--- a/test/spec/modules/stvBidAdapter_spec.js
+++ b/test/spec/modules/stvBidAdapter_spec.js
@@ -81,55 +81,55 @@ describe('stvAdapter', function() {
         'userIdAsEids': [
           {
             'source': 'id5-sync.com',
-		    'uids': [{
+        'uids': [{
               'id': '1234',
               'ext': {
                 'linkType': 'abc'
               }
             }]
-		  },
+      },
           {
             'source': 'netid.de',
-		    'uids': [{
+        'uids': [{
               'id': '2345'
             }]
-		  },
+      },
           {
             'source': 'uidapi.com',
-		    'uids': [{
+        'uids': [{
               'id': '3456'
             }]
-		  },
+      },
           {
             'source': 'pubcid.org',
-		    'uids': [{
+        'uids': [{
               'id': '4567'
             }]
-		  },
+      },
           {
             'source': 'liveramp.com',
-		    'uids': [{
+        'uids': [{
               'id': '5678'
             }]
-		  },
+      },
           {
             'source': 'criteo.com',
-		    'uids': [{
+        'uids': [{
               'id': '6789'
             }]
-		  },
+      },
           {
             'source': 'utiq.com',
-		    'uids': [{
+        'uids': [{
               'id': '7890'
             }]
-		  },
+      },
           {
             'source': 'euid.eu',
-		    'uids': [{
+        'uids': [{
               'id': '8901'
             }]
-		  }
+      }
         ]
       },
       {
@@ -147,55 +147,55 @@ describe('stvAdapter', function() {
         'userIdAsEids': [
           {
             'source': 'id5-sync.com',
-		    'uids': [{
+        'uids': [{
               'id': '1234',
               'ext': {
                 'linkType': 'abc'
               }
             }]
-		  },
+      },
           {
             'source': 'netid.de',
-		    'uids': [{
+        'uids': [{
               'id': '2345'
             }]
-		  },
+      },
           {
             'source': 'uidapi.com',
-		    'uids': [{
+        'uids': [{
               'id': '3456'
             }]
-		  },
+      },
           {
             'source': 'pubcid.org',
-		    'uids': [{
+        'uids': [{
               'id': '4567'
             }]
-		  },
+      },
           {
             'source': 'liveramp.com',
-		    'uids': [{
+        'uids': [{
               'id': '5678'
             }]
-		  },
+      },
           {
             'source': 'criteo.com',
-		    'uids': [{
+        'uids': [{
               'id': '6789'
             }]
-		  },
+      },
           {
             'source': 'utiq.com',
-		    'uids': [{
+        'uids': [{
               'id': '7890'
             }]
-		  },
+      },
           {
             'source': 'euid.eu',
-		    'uids': [{
+        'uids': [{
               'id': '8901'
             }]
-		  }
+      }
         ]
       }, {
         'bidder': 'stv',

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -505,15 +505,15 @@ describe('Utils', function () {
   });
 
   describe('contains', function () {
-    	it('should return true if the input string contains in the input obj', function () {
+      it('should return true if the input string contains in the input obj', function () {
       var output = utils.contains('123', '1');
       assert.deepEqual(output, true);
-    	});
+      });
 
-    	it('should return false if the input string do not contain in the input obj', function () {
+      it('should return false if the input string do not contain in the input obj', function () {
       var output = utils.contains('234', '1');
       assert.deepEqual(output, false);
-    	});
+      });
 
     it('should return false if the input string is empty', function () {
       var output = utils.contains();
@@ -522,37 +522,37 @@ describe('Utils', function () {
   });
 
   describe('_map', function () {
-    	it('return empty array when input object is empty', function () {
+      it('return empty array when input object is empty', function () {
       var input = {};
       var callback = function () {};
 
       var output = utils._map(input, callback);
       assert.deepEqual(output, []);
-    	});
+      });
 
-    	it('return value array with vaild input object', function () {
+      it('return value array with vaild input object', function () {
       var input = { a: 'A', b: 'B' };
       var callback = function (v) { return v; };
 
       var output = utils._map(input, callback);
       assert.deepEqual(output, ['A', 'B']);
-    	});
+      });
 
-    	it('return value array with vaild input object_callback func changed 1', function () {
+      it('return value array with vaild input object_callback func changed 1', function () {
       var input = { a: 'A', b: 'B' };
       var callback = function (v, k) { return v + k; };
 
       var output = utils._map(input, callback);
       assert.deepEqual(output, ['Aa', 'Bb']);
-    	});
+      });
 
-    	it('return value array with vaild input object_callback func changed 2', function () {
+      it('return value array with vaild input object_callback func changed 2', function () {
       var input = { a: 'A', b: 'B' };
       var callback = function (v, k, o) { return o; };
 
       var output = utils._map(input, callback);
       assert.deepEqual(output, [input, input]);
-    	});
+      });
   });
 
   describe('createInvisibleIframe', function () {


### PR DESCRIPTION
## Summary
- remove no-tabs exceptions from test lint rules
- replace tab characters in tests and fix spacing
- correct key spacing in Bedigitech bid adapter spec

## Testing
- `npx eslint 'test/**/*.js' --cache --cache-strategy content`
- `TEST_PAT="{adlooxAnalyticsAdapter_spec.js,admaruBidAdapter_spec.js,admediaBidAdapter_spec.js,advertisingBidAdapter_spec.js,anonymisedRtdProvider_spec.js,bedigitechBidAdapter_spec.js,blueconicRtdProvider_spec.js,connectadBidAdapter_spec.js,datablocksBidAdapter_spec.js,djaxBidAdapter_spec.js,finativeBidAdapter_spec.js,growthCodeRtdProvider_spec.js,invibesBidAdapter_spec.js,liveIntentRtdProvider_spec.js,mediagoBidAdapter_spec.js,nobidBidAdapter_spec.js,optoutBidAdapter_spec.js,oxxionAnalyticsAdapter_spec.js,pubmaticBidAdapter_spec.js,pwbidBidAdapter_spec.js,relevadRtdProvider_spec.js,rubiconBidAdapter_spec.js,seedingAllianceAdapter_spec.js,sizeMappingV2_spec.js,smarticoBidAdapter_spec.js,stvBidAdapter_spec.js,utils_spec.js}" npx gulp test --nolint` *(fails: expected null not to be null)*

------
https://chatgpt.com/codex/tasks/task_b_6866c8df9640832ba27b5ca8bc5e0238