### PR TITLE
Core: handle null bid adapter responses

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -382,7 +382,7 @@ export const spec = {
    * @return {Bid[] | {bids: Bid[], fledgeAuctionConfigs: object[]}}
    */
   interpretResponse: (response, request) => {
-    if (typeof response?.body == 'undefined') {
+    if (!response || response.body == null) {
       return []; // no bid
     }
 

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -798,6 +798,9 @@ export const spec = {
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: (response, request) => {
+    if (!response || response.body == null) {
+      return [];
+    }
     const { bids } = converter.fromORTB({ response: response.body, request: request.data });
     const fledgeAuctionConfigs = deepAccess(response.body, 'ext.fledge_auction_configs');
     if (fledgeAuctionConfigs) {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -2145,6 +2145,13 @@ describe('The Criteo bidding adapter', function () {
       expect(bids).to.have.lengthOf(0);
     });
 
+    it('should return an empty array when response body is null', async function () {
+      const bidRequests = [];
+      const request = spec.buildRequests(bidRequests, await addFPDToBidderRequest(bidderRequest));
+      const bids = spec.interpretResponse({body: null}, request);
+      expect(bids).to.have.lengthOf(0);
+    });
+
     it('should return an empty array when parsing a well-formed no bid response', async function () {
       const bidRequests = [];
       const response = {seatbid: []};

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1010,6 +1010,12 @@ describe('PubMatic adapter', () => {
       expect(bidResponse[0]).to.have.property('creativeId');
     });
 
+    it('should return an empty array when response body is null', () => {
+      const request = spec.buildRequests(validBidRequests, bidderRequest);
+      const bidResponse = spec.interpretResponse({ body: null }, request);
+      expect(bidResponse).to.be.an('array').that.is.empty;
+    });
+
     it('should return response and match with input values', () => {
       const request = spec.buildRequests(validBidRequests, bidderRequest);
       const bidResponse = spec.interpretResponse(response, request);


### PR DESCRIPTION
## Summary
- ensure `interpretResponse` handles null responses for Criteo & Pubmatic adapters
- add unit tests

## Testing
- `npx eslint --cache --cache-strategy content modules/criteoBidAdapter.js modules/pubmaticBidAdapter.js test/spec/modules/criteoBidAdapter_spec.js test/spec/modules/pubmaticBidAdapter_spec.js`
- `npx gulp test --file test/spec/modules/criteoBidAdapter_spec.js`
- `npx gulp test --file test/spec/modules/pubmaticBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_686d8879f208832b95c0577fe063dd7e