### PR TITLE
core: backport userid changes

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -568,28 +568,9 @@ export function enrichEids(ortb2Fragments) {
   return ortb2Fragments;
 }
 
-export function addIdData({adUnits, ortb2Fragments}) {
+export function addIdData({ortb2Fragments}) {
   ortb2Fragments = ortb2Fragments ?? {global: {}, bidder: {}}
   enrichEids(ortb2Fragments);
-  if ([adUnits].some(i => !Array.isArray(i) || !i.length)) {
-    return;
-  }
-  const globalIds = getIds(initializedSubmodules.global);
-  const globalEids = ortb2Fragments.global.user?.ext?.eids || [];
-  adUnits.forEach(adUnit => {
-    if (adUnit.bids && isArray(adUnit.bids)) {
-      adUnit.bids.forEach(bid => {
-        const bidderIds = Object.assign({}, globalIds, getIds(initializedSubmodules.bidder[bid.bidder] ?? {}));
-        const bidderEids = globalEids.concat(ortb2Fragments.bidder?.[bid.bidder]?.user?.ext?.eids || []);
-        if (Object.keys(bidderIds).length > 0) {
-          bid.userId = bidderIds;
-        }
-        if (bidderEids.length > 0) {
-          bid.userIdAsEids = bidderEids;
-        }
-      });
-    }
-  });
 }
 
 const INIT_CANCELED = {};
@@ -724,15 +705,23 @@ export const startAuctionHook = timedAuctionHook('userId', function requestBidsH
 });
 
 /**
- * Append user id data from config to bids to be accessed in adapters when there are no submodules.
- * @param {function} fn required; The next function in the chain, used by hook.js
- * @param {Object} reqBidsConfigObj required; This is the same param that's used in pbjs.requestBids.
+ * Alias bid requests' `userIdAsEids` to `ortb2.user.ext.eids`.
+ * @param {function} next the next hook in the chain
+ * @param {Array} bidderRequests the bidder requests
  */
-export const addUserIdsHook = timedAuctionHook('userId', function requestBidsHook(fn, reqBidsConfigObj) {
-  addIdData(reqBidsConfigObj);
-  // calling fn allows prebid to continue processing
-  fn.call(this, reqBidsConfigObj);
-});
+function aliasEidsHook(next, bidderRequests) {
+  bidderRequests.forEach(bidderRequest => {
+    bidderRequest.bids.forEach(bid =>
+      Object.defineProperty(bid, 'userIdAsEids', {
+        configurable: true,
+        get() {
+          return bidderRequest.ortb2.user?.ext?.eids;
+        }
+      })
+    )
+  })
+  next(bidderRequests);
+}
 
 /**
  * Is startAuctionHook added
@@ -1158,7 +1147,6 @@ function updateSubmodules() {
 
   if (submodules.length) {
     if (!addedStartAuctionHook()) {
-      startAuction.getHooks({hook: addUserIdsHook}).remove();
       startAuction.before(startAuctionHook, 100) // use higher priority than dataController / rtd
       adapterManager.callDataDeletionRequest.before(requestDataDeletion);
       coreGetPPID.after((next) => next(getPPID()));
@@ -1268,10 +1256,7 @@ export function init(config, {mkDelay = delay} = {}) {
   (getGlobal()).refreshUserIds = normalizePromise(refreshUserIds);
   (getGlobal()).getUserIdsAsync = normalizePromise(getUserIdsAsync);
   (getGlobal()).getUserIdsAsEidBySource = getUserIdsAsEidBySource;
-  if (!addedStartAuctionHook()) {
-    // Add ortb2.user.ext.eids even if 0 submodules are added
-    startAuction.before(addUserIdsHook, 100); // use higher priority than dataController / rtd
-  }
+  adapterManager.makeBidRequests.after(aliasEidsHook);
 }
 
 export function resetUserIds() {

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -8,7 +8,6 @@ import {
   init,
   PBJS_USER_ID_OPTOUT_NAME,
   startAuctionHook,
-  addUserIdsHook,
   requestDataDeletion,
   setStoredValue,
   setSubmoduleRegistry,
@@ -177,7 +176,6 @@ describe('User ID', function () {
     sandbox.restore();
     config.resetConfig();
     startAuction.getHooks({hook: startAuctionHook}).remove();
-    startAuction.getHooks({hook: addUserIdsHook}).remove();
   });
 
   after(() => {
@@ -2528,64 +2526,7 @@ describe('User ID', function () {
         })
       })
     });
-
-    describe('submodules not added', () => {
-      const eid = {
-        source: 'example.com',
-        uids: [{id: '1234', atype: 3}]
-      };
-      let adUnits;
-      let startAuctionStub;
-      function saHook(fn, ...args) {
-        return startAuctionStub(...args);
-      }
-      beforeEach(() => {
-        adUnits = [{code: 'au1', bids: [{bidder: 'sampleBidder'}]}];
-        startAuctionStub = sinon.stub();
-        startAuction.before(saHook);
-        config.resetConfig();
-      });
-      afterEach(() => {
-        startAuction.getHooks({hook: saHook}).remove();
-      })
-
-      it('addUserIdsHook', function (done) {
-        addUserIdsHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property('userIdAsEids.0.source');
-              expect(bid).to.have.deep.nested.property('userIdAsEids.0.uids.0.id');
-              expect(bid.userIdAsEids[0].source).to.equal('example.com');
-              expect(bid.userIdAsEids[0].uids[0].id).to.equal('1234');
-            });
-          });
-          done();
-        }, {
-          adUnits,
-          ortb2Fragments: {
-            global: {user: {ext: {eids: [eid]}}},
-            bidder: {}
-          }
-        });
-      });
-
-      it('should add userIdAsEids and merge ortb2.user.ext.eids even if no User ID submodules', async () => {
-        init(config);
-        expect(startAuction.getHooks({hook: startAuctionHook}).length).equal(0);
-        expect(startAuction.getHooks({hook: addUserIdsHook}).length).equal(1);
-        addUserIdsHook(sinon.stub(), {
-          adUnits,
-          ortb2Fragments: {
-            global: {
-              user: {ext: {eids: [eid]}}
-            }
-          }
-        });
-        expect(adUnits[0].bids[0].userIdAsEids[0]).to.eql(eid);
-      });
-    });
   });
-
   describe('handles config with ESP configuration in user sync object', function() {
     describe('Call registerSignalSources to register signal sources with gtag', function () {
       it('pbjs.registerSignalSources should be defined', () => {


### PR DESCRIPTION
## Summary
- backport updates from upstream PR
- remove addUserIdsHook and add aliasEidsHook
- wire aliasing hook after makeBidRequests

## Testing
- `npx eslint modules/userId/index.js test/spec/modules/userId_spec.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/userId_spec.js` *(fails: Karma tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_686fbfe3fb64832ba3df5785d69406ca