### PR TITLE
Core: tighten test lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -236,9 +236,7 @@ module.exports = [
       'no-unused-vars': 'off',
       'import/extensions': 'off',
       'camelcase': 'off',
-      'no-loss-of-precision': 'off',
       'no-redeclare': 'off',
-      'import-x/no-duplicates': 'off',
       'no-global-assign': 'off',
       'default-case-last': 'off'
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -236,7 +236,6 @@ module.exports = [
       'no-unused-vars': 'off',
       'import/extensions': 'off',
       'camelcase': 'off',
-      'no-redeclare': 'off',
       'no-loss-of-precision': 'off',
       'import-x/no-duplicates': 'off',
       'no-global-assign': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -236,8 +236,6 @@ module.exports = [
       'no-unused-vars': 'off',
       'import/extensions': 'off',
       'camelcase': 'off',
-      'no-loss-of-precision': 'off',
-      'import-x/no-duplicates': 'off',
       'no-global-assign': 'off',
       'default-case-last': 'off'
     }

--- a/test/spec/modules/dxkultureBidAdapter_spec.js
+++ b/test/spec/modules/dxkultureBidAdapter_spec.js
@@ -152,7 +152,7 @@ const getBidderResponse = () => {
                 bidder: {
                   appnexus: {
                     brand_id: 334553,
-                    auction_id: 514667951122925701,
+                    auction_id: '514667951122925701',
                     bidder_id: 2,
                     bid_ad_type: 0
                   }

--- a/test/spec/modules/eightPodAnalyticsAdapter_spec.js
+++ b/test/spec/modules/eightPodAnalyticsAdapter_spec.js
@@ -1,8 +1,8 @@
 import analyticsAdapter, { storage, queue, trackEvent } from 'modules/eightPodAnalyticsAdapter.js';
 import { expect } from 'chai';
 import adapterManager from 'src/adapterManager.js';
-import eightPodAnalytics from 'modules/eightPodAnalyticsAdapter.js';
 import { EVENTS } from '../../../src/constants.js';
+const eightPodAnalytics = analyticsAdapter;
 
 const {
   BID_WON

--- a/test/spec/modules/impactifyBidAdapter_spec.js
+++ b/test/spec/modules/impactifyBidAdapter_spec.js
@@ -357,7 +357,7 @@ describe('ImpactifyAdapter', function () {
                     bidder: {
                       appnexus: {
                         brand_id: 182979,
-                          auction_id: '8657683934873599656',
+                        auction_id: '8657683934873599656',
                         bidder_id: 2,
                         bid_ad_type: 1,
                         creative_info: {
@@ -495,7 +495,7 @@ describe('ImpactifyAdapter', function () {
                   bidder: {
                     appnexus: {
                       brand_id: 182979,
-                        auction_id: '8657683934873599656',
+                      auction_id: '8657683934873599656',
                       bidder_id: 2,
                       bid_ad_type: 1,
                       creative_info: {

--- a/test/spec/modules/impactifyBidAdapter_spec.js
+++ b/test/spec/modules/impactifyBidAdapter_spec.js
@@ -357,7 +357,7 @@ describe('ImpactifyAdapter', function () {
                     bidder: {
                       appnexus: {
                         brand_id: 182979,
-                        auction_id: 8657683934873599656,
+                          auction_id: '8657683934873599656',
                         bidder_id: 2,
                         bid_ad_type: 1,
                         creative_info: {
@@ -495,7 +495,7 @@ describe('ImpactifyAdapter', function () {
                   bidder: {
                     appnexus: {
                       brand_id: 182979,
-                      auction_id: 8657683934873599656,
+                        auction_id: '8657683934873599656',
                       bidder_id: 2,
                       bid_ad_type: 1,
                       creative_info: {

--- a/test/spec/modules/padsquadBidAdapter_spec.js
+++ b/test/spec/modules/padsquadBidAdapter_spec.js
@@ -65,7 +65,7 @@ const RESPONSE = {
               'bidder': {
                 'appnexus': {
                   'brand_id': 334553,
-                  'auction_id': 514667951122925701,
+                    'auction_id': '514667951122925701',
                   'bidder_id': 2,
                   'bid_ad_type': 0
                 }
@@ -94,7 +94,7 @@ const RESPONSE = {
               'bidder': {
                 'appnexus': {
                   'brand_id': 386046,
-                  'auction_id': 517067951122925501,
+                    'auction_id': '517067951122925501',
                   'bidder_id': 2,
                   'bid_ad_type': 0
                 }

--- a/test/spec/modules/padsquadBidAdapter_spec.js
+++ b/test/spec/modules/padsquadBidAdapter_spec.js
@@ -65,7 +65,7 @@ const RESPONSE = {
               'bidder': {
                 'appnexus': {
                   'brand_id': 334553,
-                    'auction_id': '514667951122925701',
+                  'auction_id': '514667951122925701',
                   'bidder_id': 2,
                   'bid_ad_type': 0
                 }
@@ -94,7 +94,7 @@ const RESPONSE = {
               'bidder': {
                 'appnexus': {
                   'brand_id': 386046,
-                    'auction_id': '517067951122925501',
+                  'auction_id': '517067951122925501',
                   'bidder_id': 2,
                   'bid_ad_type': 0
                 }

--- a/test/spec/modules/pangleBidAdapter_spec.js
+++ b/test/spec/modules/pangleBidAdapter_spec.js
@@ -91,7 +91,7 @@ const RESPONSE = {
               'bidder': {
                 'pangle': {
                   'brand_id': 334553,
-                  'auction_id': 514667951122925701,
+                  'auction_id': '514667951122925701',
                   'bidder_id': 2,
                   'bid_ad_type': 0
                 }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -437,7 +437,7 @@ const RESPONSE_OPENRTB_VIDEO = {
             bidder: {
               appnexus: {
                 brand_id: 1,
-                auction_id: 6673622101799484743,
+                auction_id: '6673622101799484743',
                 bidder_id: 2,
                 bid_ad_type: 1,
               },
@@ -542,7 +542,7 @@ const RESPONSE_OPENRTB_NATIVE = {
             'bidder': {
               'appnexus': {
                 'brand_id': 555545,
-                'auction_id': 4676806524825984103,
+                'auction_id': '4676806524825984103',
                 'bidder_id': 2,
                 'bid_ad_type': 3
               }

--- a/test/spec/modules/pwbidBidAdapter_spec.js
+++ b/test/spec/modules/pwbidBidAdapter_spec.js
@@ -1,9 +1,7 @@
 // import or require modules necessary for the test, e.g.:
 
 import {expect} from 'chai';
-import {spec} from 'modules/pwbidBidAdapter.js';
-import {_checkVideoPlacement, _checkMediaType} from 'modules/pwbidBidAdapter.js'; // this is exported only for testing so maintaining the JS convention of _ to indicate the intent
-import {_parseAdSlot} from 'modules/pwbidBidAdapter.js'; // this is exported only for testing so maintaining the JS convention of _ to indicate the intent
+import {spec, _checkVideoPlacement, _checkMediaType, _parseAdSlot} from 'modules/pwbidBidAdapter.js'; // _ functions exported only for testing so maintaining the JS convention of _ to indicate the intent
 import * as utils from 'src/utils.js';
 
 const sampleRequestBanner = {

--- a/test/spec/modules/tealBidAdapter_spec.js
+++ b/test/spec/modules/tealBidAdapter_spec.js
@@ -139,7 +139,7 @@ const BID_RESPONSE = {
         {
           id: '123456789',
           impid: BID_REQUEST.bidId,
-          price: 0.286000000000000004,
+          price: 0.286,
           adm: '<img src ="//files.prebid.org/creatives/prebid300x250.png" />',
           adomain: [
             'teal.works'
@@ -164,7 +164,7 @@ const BID_RESPONSE = {
                 ]
               }
             },
-            origbidcpm: 0.286000000000000004
+            origbidcpm: 0.286
           }
         }
       ],

--- a/test/spec/modules/yieldliftBidAdapter_spec.js
+++ b/test/spec/modules/yieldliftBidAdapter_spec.js
@@ -61,7 +61,7 @@ const RESPONSE = {
               'bidder': {
                 'appnexus': {
                   'brand_id': 334553,
-                  'auction_id': 514667951122925701,
+                  'auction_id': '514667951122925701',
                   'bidder_id': 2,
                   'bid_ad_type': 0
                 }
@@ -90,7 +90,7 @@ const RESPONSE = {
               'bidder': {
                 'appnexus': {
                   'brand_id': 386046,
-                  'auction_id': 517067951122925501,
+                  'auction_id': '517067951122925501',
                   'bidder_id': 2,
                   'bid_ad_type': 0
                 }


### PR DESCRIPTION
## Summary
- enable `import-x/no-duplicates` and `no-loss-of-precision` for test files
- clean up tests for duplicate imports and large numeric literals

## Testing
- `npx gulp lint`
- `npx gulp test --nolint --file test/spec/modules/prebidServerBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/pwbidBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/tealBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/yieldliftBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/dxkultureBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/eightPodAnalyticsAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/impactifyBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/padsquadBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/pangleBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68710bc70e3c832bb25c906690d765e2