### PR TITLE
Core: enforce one-var rule for tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -231,7 +231,6 @@ module.exports = [
       // tests were not subject to many rules and they are now a nightmare
       'no-template-curly-in-string': 'off',
       'no-unused-expressions': 'off',
-      'one-var': 'off',
       'no-undef': 'off',
       'no-unused-vars': 'off',
       'import/extensions': 'off',

--- a/test/helpers/refererDetectionHelper.js
+++ b/test/helpers/refererDetectionHelper.js
@@ -32,9 +32,9 @@ export function buildWindowTree(urls, topReferrer = null, canonicalUrl = null, a
   const topOrigin = getOrigin(urls[0]);
 
   const windowList = urls.map((url, index) => {
-    const thisOrigin = getOrigin(url),
-      sameOriginAsPrevious = index === 0 ? true : (getOrigin(urls[index - 1]) === thisOrigin),
-      sameOriginAsTop = thisOrigin === topOrigin;
+    const thisOrigin = getOrigin(url);
+      const sameOriginAsPrevious = index === 0 ? true : (getOrigin(urls[index - 1]) === thisOrigin);
+      const sameOriginAsTop = thisOrigin === topOrigin;
 
     const win = {
       location: {

--- a/test/mocks/timers.js
+++ b/test/mocks/timers.js
@@ -10,7 +10,7 @@ export function configureTimerInterceptors(debugLog = function() {}, generateSta
   wrappersActive = true;
   let theseWrappersActive = true;
 
-  const originalSetTimeout = setTimeout, originalSetInterval = setInterval, originalClearTimeout = clearTimeout, originalClearInterval = clearInterval;
+  const originalSetTimeout = setTimeout; const originalSetInterval = setInterval; const originalClearTimeout = clearTimeout; const originalClearInterval = clearInterval;
 
   let timerId = -1;
   const timers = [];

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -89,8 +89,8 @@ describe('adLoader', function () {
             }
           }
         }
-      },
-      attrs = {'z': 'A', 'y': 2};
+      };
+      const attrs = {'z': 'A', 'y': 2};
     const script = adLoader.loadExternalScript('someUrl', MODULE_TYPE_PREBID, 'debugging', undefined, doc, attrs);
     expect(script.z).to.equal('A');
     expect(script.y).to.equal(2);

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -304,7 +304,7 @@ describe('FPD enrichment', () => {
   });
 
   describe('privacy sandbox cookieDeprecationLabel', () => {
-    let isAllowed, cdep, shouldCleanupNav = false;
+    let isAllowed; let cdep; let shouldCleanupNav = false;
 
     before(() => {
       if (!navigator.cookieDeprecationLabel) {

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -19,7 +19,7 @@ describe('AdkernelAdn adapter', function () {
         }
       },
       adUnitCode: 'ad-unit-1',
-    }, bid2_pub1 = {
+    }; const bid2_pub1 = {
       bidder: 'adkernelAdn',
       transactionId: 'transact0',
       bidderRequestId: 'req0',
@@ -34,7 +34,7 @@ describe('AdkernelAdn adapter', function () {
           sizes: [[300, 250]]
         }
       }
-    }, bid1_pub2 = {
+    }; const bid1_pub2 = {
       bidder: 'adkernelAdn',
       transactionId: 'transact2',
       bidderRequestId: 'req1',
@@ -50,7 +50,7 @@ describe('AdkernelAdn adapter', function () {
           sizes: [[728, 90]]
         }
       }
-    }, bid_video1 = {
+    }; const bid_video1 = {
       bidder: 'adkernelAdn',
       transactionId: 'transact3',
       bidderRequestId: 'req1',
@@ -69,7 +69,7 @@ describe('AdkernelAdn adapter', function () {
       params: {
         pubId: 7
       }
-    }, bid_video2 = {
+    }; const bid_video2 = {
       bidder: 'adkernelAdn',
       transactionId: 'transact3',
       bidderRequestId: 'req1',
@@ -85,7 +85,7 @@ describe('AdkernelAdn adapter', function () {
       params: {
         pubId: 7
       }
-    }, bid_multiformat = {
+    }; const bid_multiformat = {
       bidder: 'adkernelAdn',
       transactionId: 'f82c64b8-c602-42a4-9791-4a268f6559ed',
       bidderRequestId: 'req-001',
@@ -134,7 +134,7 @@ describe('AdkernelAdn adapter', function () {
         vast_url: 'https://vast.com/vast.xml'
       }],
       syncpages: ['https://dsp.adkernel.com/sync']
-    }, usersyncOnlyResponse = {
+    }; const usersyncOnlyResponse = {
       syncpages: ['https://dsp.adkernel.com/sync']
     };
 

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -23,7 +23,7 @@ describe('Adkernel adapter', function () {
         battr: [6, 7, 9],
         pos: 2
       }
-    }, bid2_zone2 = {
+    }; const bid2_zone2 = {
       bidder: 'adkernel',
       params: {zoneId: 2, host: 'rtb.adkernel.com'},
       adUnitCode: 'ad-unit-2',
@@ -43,7 +43,7 @@ describe('Adkernel adapter', function () {
           ]
         }
       ]
-    }, bid3_host2 = {
+    }; const bid3_host2 = {
       bidder: 'adkernel',
       params: {zoneId: 1, host: 'rtb-private.adkernel.com'},
       adUnitCode: 'ad-unit-2',
@@ -55,7 +55,7 @@ describe('Adkernel adapter', function () {
           sizes: [[728, 90]]
         }
       }
-    }, bid_without_zone = {
+    }; const bid_without_zone = {
       bidder: 'adkernel',
       params: {host: 'rtb-private.adkernel.com'},
       adUnitCode: 'ad-unit-1',
@@ -67,7 +67,7 @@ describe('Adkernel adapter', function () {
           sizes: [[728, 90]]
         }
       }
-    }, bid_without_host = {
+    }; const bid_without_host = {
       bidder: 'adkernel',
       params: {zoneId: 1},
       adUnitCode: 'ad-unit-1',
@@ -79,7 +79,7 @@ describe('Adkernel adapter', function () {
           sizes: [[728, 90]]
         }
       }
-    }, bid_with_wrong_zoneId = {
+    }; const bid_with_wrong_zoneId = {
       bidder: 'adkernel',
       params: {zoneId: 'wrong id', host: 'rtb.adkernel.com'},
       adUnitCode: 'ad-unit-2',
@@ -91,7 +91,7 @@ describe('Adkernel adapter', function () {
           sizes: [[728, 90]]
         }
       }
-    }, bid_video = {
+    }; const bid_video = {
       bidder: 'adkernel',
       transactionId: '866394b8-5d37-4d49-803e-f1bdb595f73e',
       bidId: 'Bid_Video',
@@ -113,7 +113,7 @@ describe('Adkernel adapter', function () {
         }
       },
       adUnitCode: 'ad-unit-1'
-    }, bid_multiformat = {
+    }; const bid_multiformat = {
       bidder: 'adkernel',
       params: {zoneId: 1, host: 'rtb.adkernel.com'},
       mediaTypes: {
@@ -125,8 +125,8 @@ describe('Adkernel adapter', function () {
       bidId: 'Bid_01',
       bidderRequestId: 'req-001',
       auctionId: 'auc-001'
-    },
-    bid_native = {
+    };
+    const bid_native = {
       bidder: 'adkernel',
       params: {zoneId: 1, host: 'rtb.adkernel.com'},
       mediaTypes: {
@@ -225,7 +225,7 @@ describe('Adkernel adapter', function () {
       ext: {
         adk_usersync: [{type: 1, url: 'https://adk.sync.com/sync'}]
       }
-    }, videoBidResponse = {
+    }; const videoBidResponse = {
       id: '47ce4badcf7482',
       seatbid: [{
         bid: [{
@@ -239,7 +239,7 @@ describe('Adkernel adapter', function () {
           mtype: 2
         }]
       }],
-    }, videoBidResponseWithAdm = {
+    }; const videoBidResponseWithAdm = {
       id: '47ce4badcf7482',
       seatbid: [{
         bid: [{
@@ -254,13 +254,13 @@ describe('Adkernel adapter', function () {
           mtype: 2
         }]
       }],
-    },
-    usersyncOnlyResponse = {
+    };
+    const usersyncOnlyResponse = {
       id: 'nobid1',
       ext: {
         adk_usersync: [{type: 2, url: 'https://adk.sync.com/sync'}]
       }
-    }, nativeResponse = {
+    }; const nativeResponse = {
       id: '56fbc713-b737-4651-9050-13376aed9818',
       seatbid: [{
         bid: [{
@@ -297,8 +297,8 @@ describe('Adkernel adapter', function () {
       }],
       bidid: 'pTuOlf5KHUo',
       cur: 'EUR'
-    },
-    multiformat_response = {
+    };
+    const multiformat_response = {
       id: '47ce4badcf7482',
       seatbid: [{
         bid: [{

--- a/test/spec/modules/adtrgtmeBidAdapter_spec.js
+++ b/test/spec/modules/adtrgtmeBidAdapter_spec.js
@@ -589,8 +589,8 @@ describe('Adtrgtme Bid Adapter:', () => {
     });
 
     it('should use placementId value as imp.tagid when using "zid"', () => {
-      const { validBR, bidderRequest } = createRequestMock({}),
-        TEST_ZID = '54321';
+      const { validBR, bidderRequest } = createRequestMock({});
+        const TEST_ZID = '54321';
       validBR[0].params.zid = TEST_ZID;
       const data = spec.buildRequests(validBR, bidderRequest).data;
       expect(data.imp[0].tagid).to.deep.equal(TEST_ZID);

--- a/test/spec/modules/adtrueBidAdapter_spec.js
+++ b/test/spec/modules/adtrueBidAdapter_spec.js
@@ -162,8 +162,8 @@ describe('AdTrueBidAdapter', function () {
               zoneId: '21423',
               publisherId: '1212'
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(true);
       });
       it('invalid bid case: publisherId not passed', function () {
@@ -172,8 +172,8 @@ describe('AdTrueBidAdapter', function () {
             params: {
               zoneId: '21423'
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(false);
       });
       it('valid bid case: zoneId is not passed', function () {
@@ -182,8 +182,8 @@ describe('AdTrueBidAdapter', function () {
             params: {
               publisherId: '1212'
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(false);
       });
       it('should return false if there are no params', () => {

--- a/test/spec/modules/apacdexBidAdapter_spec.js
+++ b/test/spec/modules/apacdexBidAdapter_spec.js
@@ -332,7 +332,7 @@ describe('ApacdexBidAdapter', function () {
     });
     it('should attach bidFloor param when either bid param floorPrice or getFloor function exists', function () {
       const getFloorResponse = { currency: 'USD', floor: 3 };
-      let singleBidRequest, request, payload = null;
+      let singleBidRequest; let request; let payload = null;
 
       // 1 -> floorPrice not defined, getFloor not defined > empty
       singleBidRequest = deepClone(bidRequest[0]);

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -772,7 +772,7 @@ describe('AppNexusAdapter', function () {
 
     it('should attach reserve param when either bid param or getFloor function exists', function () {
       const getFloorResponse = { currency: 'USD', floor: 3 };
-      let request, payload = null;
+      let request; let payload = null;
       const bidRequest = deepClone(bidRequests[0]);
 
       // 1 -> reserve not defined, getFloor not defined > empty

--- a/test/spec/modules/deepintentBidAdapter_spec.js
+++ b/test/spec/modules/deepintentBidAdapter_spec.js
@@ -135,8 +135,8 @@ describe('Deepintent adapter', function () {
           params: {
             tagId: '1232'
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(true);
     });
     it('invalidBid : tagId is not passed', function () {
@@ -146,8 +146,8 @@ describe('Deepintent adapter', function () {
             h: 200,
             w: 300
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
     it('invalidBid : tagId is not a string', function () {
@@ -156,8 +156,8 @@ describe('Deepintent adapter', function () {
           params: {
             tagId: 12345
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
     it('should check for context if video is present', function() {
@@ -176,8 +176,8 @@ describe('Deepintent adapter', function () {
               context: 'instream'
             }
           },
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equal(true);
     });
     it('should error out if context is not present and is Video', function() {
@@ -195,15 +195,15 @@ describe('Deepintent adapter', function () {
               playerSize: [640, 480]
             }
           },
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equal(false);
     })
   });
   describe('request check', function () {
     it('unmutaable bid request check', function () {
-      const oRequest = utils.deepClone(request),
-        bidRequest = spec.buildRequests(request);
+      const oRequest = utils.deepClone(request);
+        const bidRequest = spec.buildRequests(request);
       expect(request).to.deep.equal(oRequest);
     });
     it('bidder connection check', function () {

--- a/test/spec/modules/dexertoBidAdapter_spec.js
+++ b/test/spec/modules/dexertoBidAdapter_spec.js
@@ -83,8 +83,8 @@ describe('dexerto adapter', function () {
           params: {
             placement_id: 110003
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(true);
     });
     it('isBidValid : placement_id is not passed', function () {
@@ -96,15 +96,15 @@ describe('dexerto adapter', function () {
             domain: '',
             bid_floor: 0.5
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
   });
   describe('Validate Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(request),
-        bidRequest = spec.buildRequests(request);
+      const _Request = utils.deepClone(request);
+        const bidRequest = spec.buildRequests(request);
       expect(request).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {

--- a/test/spec/modules/dochaseBidAdapter_spec.js
+++ b/test/spec/modules/dochaseBidAdapter_spec.js
@@ -146,8 +146,8 @@ describe('dochase adapter', function () {
           params: {
             placement_id: 5550
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(true);
     });
     it('isBidValid : placement_id is not passed', function () {
@@ -159,15 +159,15 @@ describe('dochase adapter', function () {
             domain: '',
             bid_floor: 0.5
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
   });
   describe('Validate Banner Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(bannerRequest),
-        bidRequest = spec.buildRequests(bannerRequest);
+      const _Request = utils.deepClone(bannerRequest);
+        const bidRequest = spec.buildRequests(bannerRequest);
       expect(bannerRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {
@@ -233,8 +233,8 @@ describe('dochase adapter', function () {
   });
   describe('Validate Native Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(nativeRequest),
-        bidRequest = spec.buildRequests(nativeRequest);
+      const _Request = utils.deepClone(nativeRequest);
+        const bidRequest = spec.buildRequests(nativeRequest);
       expect(nativeRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {

--- a/test/spec/modules/ehealthcaresolutionsBidAdapter_spec.js
+++ b/test/spec/modules/ehealthcaresolutionsBidAdapter_spec.js
@@ -146,8 +146,8 @@ describe('ehealthcaresolutions adapter', function () {
           params: {
             placement_id: 111520
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(true);
     });
     it('isBidValid : placement_id is not passed', function () {
@@ -159,15 +159,15 @@ describe('ehealthcaresolutions adapter', function () {
             domain: '',
             bid_floor: 0.5
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
   });
   describe('Validate Banner Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(bannerRequest),
-        bidRequest = spec.buildRequests(bannerRequest);
+      const _Request = utils.deepClone(bannerRequest);
+        const bidRequest = spec.buildRequests(bannerRequest);
       expect(bannerRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {
@@ -233,8 +233,8 @@ describe('ehealthcaresolutions adapter', function () {
   });
   describe('Validate Native Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(nativeRequest),
-        bidRequest = spec.buildRequests(nativeRequest);
+      const _Request = utils.deepClone(nativeRequest);
+        const bidRequest = spec.buildRequests(nativeRequest);
       expect(nativeRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -807,7 +807,7 @@ describe('E-Planning Adapter', function () {
       expect(data.vv).to.equal(3);
     });
     it('should return sch parameter', function () {
-      let bidRequests = [validBidWithSchain], schainExpected, schain;
+      let bidRequests = [validBidWithSchain]; let schainExpected; let schain;
       schain = validBidWithSchain.ortb2.source.ext.schain;
       schainExpected = schain.ver + ',' + schain.complete + '!' + schain.nodes.map(node => node.asi + ',' + node.sid + ',' + node.hp + ',' + node.rid + ',' + node.name + ',' + node.domain).join('!');
       const data = spec.buildRequests(bidRequests, bidderRequest).data;

--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -49,7 +49,7 @@ const expectOptout = (bid) => expect(findEuid(bid)).to.be.undefined;
 const expectNoIdentity = (bid) => expect(findEuid(bid)).to.be.undefined;
 
 describe('EUID module', function() {
-  let suiteSandbox, restoreSubtleToUndefined = false;
+  let suiteSandbox; let restoreSubtleToUndefined = false;
 
   const configureEuidResponse = (httpStatus, response) => server.respondWith('POST', apiUrl, (xhr) => xhr.respond(httpStatus, headers, response));
   const configureEuidCstgResponse = (httpStatus, response) => server.respondWith('POST', cstgApiUrl, (xhr) => xhr.respond(httpStatus, headers, response));

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -225,9 +225,9 @@ describe('FTRACK ID System', () => {
     })
 
     it(`should populate localstorage and return the IDS (end-to-end test)`, () => {
-      let ftrackId,
-        ftrackIdExp,
-        forceCallback = false;
+      let ftrackId;
+        let ftrackIdExp;
+        let forceCallback = false;
 
       // Confirm that our item is not in localStorage yet
       expect(window.localStorage.getItem('ftrack-rtd')).to.not.be.ok;
@@ -265,13 +265,13 @@ describe('FTRACK ID System', () => {
           HHID: 'household_test_id',
           DeviceID: 'device_test_id',
           SingleDeviceID: 'single_device_test_id'
-        },
-        MOCK_VALUE_ARRAYS = {
+        };
+        const MOCK_VALUE_ARRAYS = {
           HHID: ['household_test_id', 'a', 'b'],
           DeviceID: ['device_test_id', 'c', 'd'],
           SingleDeviceID: ['single_device_test_id', 'e', 'f']
-        },
-        MOCK_VALUE_BOTH = {
+        };
+        const MOCK_VALUE_BOTH = {
           foo: ['foo', 'a', 'b'],
           bar: 'bar',
           baz: ['baz', 'baz', 'baz']

--- a/test/spec/modules/jixieBidAdapter_spec.js
+++ b/test/spec/modules/jixieBidAdapter_spec.js
@@ -386,7 +386,7 @@ describe('jixie Adapter', function () {
 
     it('it should populate the floor info when available', function () {
       const oneSpecialBidReq = deepClone(bidRequests_[0]);
-      let request, payload = null;
+      let request; let payload = null;
       // 1 floor is not set
       request = spec.buildRequests([oneSpecialBidReq], bidderRequest_);
       payload = JSON.parse(request.data);

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -6,7 +6,7 @@ const utils = require('src/utils');
 const STORAGE = getStorageManager({bidderCode: 'kargo'});
 
 describe('kargo adapter tests', function() {
-  let bid, outstreamBid, testBids, sandbox, clock, frozenNow = new Date(), oldBidderSettings;
+  let bid; let outstreamBid; let testBids; let sandbox; let clock; let frozenNow = new Date(); let oldBidderSettings;
 
   const topUrl = 'https://random.com/this/is/a/url';
   const domain = 'random.com';
@@ -253,14 +253,14 @@ describe('kargo adapter tests', function() {
   });
 
   describe('buildRequests', function() {
-    let bids,
-      bidderRequest,
-      undefinedCurrency,
-      noAdServerCurrency,
-      nonUSDAdServerCurrency,
-      cookies = [],
-      localStorageItems = [],
-      session_id = null;
+    let bids;
+      let bidderRequest;
+      let undefinedCurrency;
+      let noAdServerCurrency;
+      let nonUSDAdServerCurrency;
+      let cookies = [];
+      let localStorageItems = [];
+      let session_id = null;
 
     before(function() {
       sinon.spy(spec, 'buildRequests');

--- a/test/spec/modules/lane4BidAdapter_spec.js
+++ b/test/spec/modules/lane4BidAdapter_spec.js
@@ -146,8 +146,8 @@ describe('lane4 adapter', function () {
           params: {
             placement_id: 110044
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(true);
     });
     it('isBidValid : placement_id is not passed', function () {
@@ -159,15 +159,15 @@ describe('lane4 adapter', function () {
             domain: '',
             bid_floor: 0.5
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
   });
   describe('Validate Banner Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(bannerRequest),
-        bidRequest = spec.buildRequests(bannerRequest);
+      const _Request = utils.deepClone(bannerRequest);
+        const bidRequest = spec.buildRequests(bannerRequest);
       expect(bannerRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {
@@ -233,8 +233,8 @@ describe('lane4 adapter', function () {
   });
   describe('Validate Native Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(nativeRequest),
-        bidRequest = spec.buildRequests(nativeRequest);
+      const _Request = utils.deepClone(nativeRequest);
+        const bidRequest = spec.buildRequests(nativeRequest);
       expect(nativeRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {

--- a/test/spec/modules/lemmaDigitalBidAdapter_spec.js
+++ b/test/spec/modules/lemmaDigitalBidAdapter_spec.js
@@ -138,8 +138,8 @@ describe('lemmaDigitalBidAdapter', function () {
               pubId: 1001,
               adunitId: 1
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(true);
       });
       it('invalid bid case', function () {
@@ -152,8 +152,8 @@ describe('lemmaDigitalBidAdapter', function () {
             params: {
               adunitId: 1
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(false);
       });
       it('invalid bid case: pubId is not number', function () {
@@ -163,8 +163,8 @@ describe('lemmaDigitalBidAdapter', function () {
               pubId: '301',
               adunitId: 1
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(false);
       });
       it('invalid bid case: adunitId is not passed', function () {
@@ -173,8 +173,8 @@ describe('lemmaDigitalBidAdapter', function () {
             params: {
               pubId: 1001
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(false);
       });
       it('invalid bid case: video bid request mimes is not passed', function () {
@@ -189,8 +189,8 @@ describe('lemmaDigitalBidAdapter', function () {
                 maxduration: 30
               }
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          let isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(false);
         validBid.params.video.mimes = [];
         isValid = spec.isBidRequestValid(validBid);

--- a/test/spec/modules/mediaeyesBidAdapter_spec.js
+++ b/test/spec/modules/mediaeyesBidAdapter_spec.js
@@ -62,8 +62,8 @@ describe('mediaeyes adapter', function () {
                 params: {
                     itemId: 'ec1d7389a4a5afa28a23c4',
                 }
-            },
-                isValid = spec.isBidRequestValid(bid);
+            };
+                const isValid = spec.isBidRequestValid(bid);
             expect(isValid).to.equals(true);
         });
         it('isBidValid : itemId is not passed', function () {
@@ -72,15 +72,15 @@ describe('mediaeyes adapter', function () {
                 params: {
 
                 }
-            },
-                isValid = spec.isBidRequestValid(bid);
+            };
+                const isValid = spec.isBidRequestValid(bid);
             expect(isValid).to.equals(false);
         });
     });
     describe('Validate Request', function () {
         it('Immutable bid request validate', function () {
-            const _Request = utils.deepClone(request),
-                bidRequest = spec.buildRequests(request);
+            const _Request = utils.deepClone(request);
+                const bidRequest = spec.buildRequests(request);
             expect(request).to.deep.equal(_Request);
         });
     });

--- a/test/spec/modules/mediafuseBidAdapter_spec.js
+++ b/test/spec/modules/mediafuseBidAdapter_spec.js
@@ -318,7 +318,7 @@ describe('MediaFuseAdapter', function () {
 
     it('should attach reserve param when either bid param or getFloor function exists', function () {
       const getFloorResponse = { currency: 'USD', floor: 3 };
-      let request, payload = null;
+      let request; let payload = null;
       const bidRequest = deepClone(bidRequests[0]);
 
       // 1 -> reserve not defined, getFloor not defined > empty

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -60,9 +60,9 @@ const VALID_BID_REQUEST = [{
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'auctionsCount': 1
-  }],
+  }];
 
-  VALID_BID_REQUEST_WITH_CRID = [{
+  const VALID_BID_REQUEST_WITH_CRID = [{
     'bidder': 'medianet',
     'params': {
       'crid': 'crid',
@@ -118,8 +118,8 @@ const VALID_BID_REQUEST = [{
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'auctionsCount': 1
-  }],
-  VALID_BID_REQUEST_WITH_ORTB2 = [{
+  }];
+  const VALID_BID_REQUEST_WITH_ORTB2 = [{
     'bidder': 'medianet',
     'params': {
       'crid': 'crid',
@@ -176,9 +176,9 @@ const VALID_BID_REQUEST = [{
       }
     },
     'auctionsCount': 1
-  }],
+  }];
   // Protected Audience API Request
-  VALID_BID_REQUEST_WITH_AE_IN_ORTB2IMP = [{
+  const VALID_BID_REQUEST_WITH_AE_IN_ORTB2IMP = [{
     'bidder': 'medianet',
     'params': {
       'crid': 'crid',
@@ -206,9 +206,9 @@ const VALID_BID_REQUEST = [{
       }
     },
     'auctionsCount': 1
-  }],
+  }];
 
-  VALID_BID_REQUEST_WITH_USERID = [{
+  const VALID_BID_REQUEST_WITH_USERID = [{
     'bidder': 'medianet',
     'params': {
       'crid': 'crid',
@@ -266,8 +266,8 @@ const VALID_BID_REQUEST = [{
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'auctionsCount': 1
-  }],
-  VALID_BID_REQUEST_WITH_USERIDASEIDS = [{
+  }];
+  const VALID_BID_REQUEST_WITH_USERIDASEIDS = [{
     'bidder': 'medianet',
     'params': {
       'crid': 'crid',
@@ -332,9 +332,9 @@ const VALID_BID_REQUEST = [{
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'auctionsCount': 1
-  }],
+  }];
 
-  VALID_BID_REQUEST_INVALID_BIDFLOOR = [{
+  const VALID_BID_REQUEST_INVALID_BIDFLOOR = [{
     'bidder': 'medianet',
     'params': {
       'cid': 'customer_id',
@@ -389,8 +389,8 @@ const VALID_BID_REQUEST = [{
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'auctionsCount': 1
-  }],
-  VALID_NATIVE_BID_REQUEST = [{
+  }];
+  const VALID_NATIVE_BID_REQUEST = [{
     'bidder': 'medianet',
     'params': {
       'cid': 'customer_id',
@@ -504,8 +504,8 @@ const VALID_BID_REQUEST = [{
         ]
       }
     }
-  }],
-  VALID_AUCTIONDATA = {
+  }];
+  const VALID_AUCTIONDATA = {
     'timeout': config.getConfig('bidderTimeout'),
     'refererInfo': {
       referer: 'http://media.net/prebidtest',
@@ -515,8 +515,8 @@ const VALID_BID_REQUEST = [{
       topmostLocation: 'http://media.net/topmost',
       reachedTop: true
     }
-  },
-  VALID_PAYLOAD_INVALID_BIDFLOOR = {
+  };
+  const VALID_PAYLOAD_INVALID_BIDFLOOR = {
     'site': {
       'page': 'http://media.net/prebidtest',
       'domain': 'media.net',
@@ -616,8 +616,8 @@ const VALID_BID_REQUEST = [{
     }],
     'ortb2': {},
     'tmax': config.getConfig('bidderTimeout')
-  },
-  VALID_PAYLOAD_NATIVE = {
+  };
+  const VALID_PAYLOAD_NATIVE = {
     'site': {
       'page': 'http://media.net/prebidtest',
       'domain': 'media.net',
@@ -718,8 +718,8 @@ const VALID_BID_REQUEST = [{
     }],
     'ortb2': {},
     'tmax': config.getConfig('bidderTimeout')
-  },
-  VALID_PAYLOAD = {
+  };
+  const VALID_PAYLOAD = {
     'site': {
       'page': 'http://media.net/prebidtest',
       'domain': 'media.net',
@@ -818,8 +818,8 @@ const VALID_BID_REQUEST = [{
     }],
     'ortb2': {},
     'tmax': config.getConfig('bidderTimeout')
-  },
-  VALID_PAYLOAD_WITH_USERID = {
+  };
+  const VALID_PAYLOAD_WITH_USERID = {
     'site': {
       'page': 'http://media.net/prebidtest',
       'domain': 'media.net',
@@ -925,8 +925,8 @@ const VALID_BID_REQUEST = [{
     }],
     'ortb2': {},
     'tmax': config.getConfig('bidderTimeout')
-  },
-  VALID_PAYLOAD_WITH_USERIDASEIDS = {
+  };
+  const VALID_PAYLOAD_WITH_USERIDASEIDS = {
     'site': {
       'page': 'http://media.net/prebidtest',
       'domain': 'media.net',
@@ -1042,8 +1042,8 @@ const VALID_BID_REQUEST = [{
       },
     },
     'tmax': config.getConfig('bidderTimeout')
-  },
-  VALID_PAYLOAD_WITH_CRID = {
+  };
+  const VALID_PAYLOAD_WITH_CRID = {
     'site': {
       'page': 'http://media.net/prebidtest',
       'domain': 'media.net',
@@ -1146,9 +1146,9 @@ const VALID_BID_REQUEST = [{
     }],
     'ortb2': {},
     'tmax': config.getConfig('bidderTimeout')
-  },
+  };
   // Protected Audience API Valid Payload
-  VALID_PAYLOAD_PAAPI = {
+  const VALID_PAYLOAD_PAAPI = {
     'site': {
       'domain': 'media.net',
       'page': 'http://media.net/prebidtest',
@@ -1226,9 +1226,9 @@ const VALID_BID_REQUEST = [{
     ],
     'ortb2': {},
     'tmax': 3000
-  },
+  };
 
-  VALID_VIDEO_BID_REQUEST = [{
+  const VALID_VIDEO_BID_REQUEST = [{
     'bidder': 'medianet',
     'params': {
       'cid': 'customer_id',
@@ -1247,9 +1247,9 @@ const VALID_BID_REQUEST = [{
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'auctionsCount': 1
-  }],
+  }];
 
-  VALID_PAYLOAD_PAGE_META = (() => {
+  const VALID_PAYLOAD_PAGE_META = (() => {
     let PAGE_META;
     try {
       PAGE_META = JSON.parse(JSON.stringify(VALID_PAYLOAD));
@@ -1258,70 +1258,70 @@ const VALID_BID_REQUEST = [{
       'canonical_url': 'http://localhost:9999/canonical-test',
     });
     return PAGE_META;
-  })(),
-  VALID_PARAMS = {
+  })();
+  const VALID_PARAMS = {
     bidder: 'medianet',
     params: {
       cid: '8CUV090'
     }
-  },
-  VALID_PARAMS_TS = {
+  };
+  const VALID_PARAMS_TS = {
     bidder: 'trustedstack',
     params: {
       cid: 'TS012345'
     }
-  },
-  PARAMS_MISSING = {
+  };
+  const PARAMS_MISSING = {
     bidder: 'medianet',
-  },
-  PARAMS_MISSING_TS = {
+  };
+  const PARAMS_MISSING_TS = {
     bidder: 'trustedstack',
-  },
-  PARAMS_WITHOUT_CID = {
+  };
+  const PARAMS_WITHOUT_CID = {
     bidder: 'medianet',
     params: {}
-  },
-  PARAMS_WITHOUT_CID_TS = {
+  };
+  const PARAMS_WITHOUT_CID_TS = {
     bidder: 'trustedstack',
     params: {}
-  },
-  PARAMS_WITH_INTEGER_CID = {
+  };
+  const PARAMS_WITH_INTEGER_CID = {
     bidder: 'medianet',
     params: {
       cid: 8867587
     }
-  },
-  PARAMS_WITH_INTEGER_CID_TS = {
+  };
+  const PARAMS_WITH_INTEGER_CID_TS = {
     bidder: 'trustedstack',
     params: {
       cid: 8867587
     }
-  },
-  PARAMS_WITH_EMPTY_CID = {
+  };
+  const PARAMS_WITH_EMPTY_CID = {
     bidder: 'medianet',
     params: {
       cid: ''
     }
-  },
-  PARAMS_WITH_EMPTY_CID_TS = {
+  };
+  const PARAMS_WITH_EMPTY_CID_TS = {
     bidder: 'trustedstack',
     params: {
       cid: ''
     }
-  },
-  SYNC_OPTIONS_BOTH_ENABLED = {
+  };
+  const SYNC_OPTIONS_BOTH_ENABLED = {
     iframeEnabled: true,
     pixelEnabled: true,
-  },
-  SYNC_OPTIONS_PIXEL_ENABLED = {
+  };
+  const SYNC_OPTIONS_PIXEL_ENABLED = {
     iframeEnabled: false,
     pixelEnabled: true,
-  },
-  SYNC_OPTIONS_IFRAME_ENABLED = {
+  };
+  const SYNC_OPTIONS_IFRAME_ENABLED = {
     iframeEnabled: true,
     pixelEnabled: false,
-  },
-  SERVER_CSYNC_RESPONSE = [{
+  };
+  const SERVER_CSYNC_RESPONSE = [{
     body: {
       ext: {
         csUrl: [{
@@ -1333,16 +1333,16 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  }],
-  ENABLED_SYNC_IFRAME = [{
+  }];
+  const ENABLED_SYNC_IFRAME = [{
     type: 'iframe',
     url: 'iframe-url'
-  }],
-  ENABLED_SYNC_PIXEL = [{
+  }];
+  const ENABLED_SYNC_PIXEL = [{
     type: 'image',
     url: 'pixel-url'
-  }],
-  SERVER_RESPONSE_CPM_MISSING = {
+  }];
+  const SERVER_RESPONSE_CPM_MISSING = {
     body: {
       'id': 'd90ca32f-3877-424a-b2f2-6a68988df57a',
       'bidList': [{
@@ -1364,8 +1364,8 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  },
-  SERVER_RESPONSE_CPM_ZERO = {
+  };
+  const SERVER_RESPONSE_CPM_ZERO = {
     body: {
       'id': 'd90ca32f-3877-424a-b2f2-6a68988df57a',
       'bidList': [{
@@ -1388,8 +1388,8 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  },
-  SERVER_RESPONSE_NOBID = {
+  };
+  const SERVER_RESPONSE_NOBID = {
     body: {
       'id': 'd90ca32f-3877-424a-b2f2-6a68988df57a',
       'bidList': [{
@@ -1410,11 +1410,11 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  },
-  SERVER_RESPONSE_NOBODY = {
+  };
+  const SERVER_RESPONSE_NOBODY = {
 
-  },
-  SERVER_RESPONSE_EMPTY_BIDLIST = {
+  };
+  const SERVER_RESPONSE_EMPTY_BIDLIST = {
     body: {
       'id': 'd90ca32f-3877-424a-b2f2-6a68988df57a',
       'bidList': 'bid',
@@ -1429,8 +1429,8 @@ const VALID_BID_REQUEST = [{
       }
     }
 
-  },
-  SERVER_RESPONSE_VALID_BID = {
+  };
+  const SERVER_RESPONSE_VALID_BID = {
     body: {
       'id': 'd90ca32f-3877-424a-b2f2-6a68988df57a',
       'bidList': [{
@@ -1453,9 +1453,9 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  },
+  };
   // Protected Audience API Response
-  SERVER_RESPONSE_PAAPI = {
+  const SERVER_RESPONSE_PAAPI = {
     body: {
       'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
       'bidList': [{
@@ -1511,9 +1511,9 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  },
+  };
   // Protected Audience API OpenRTB Response
-  SERVER_RESPONSE_PAAPI_ORTB = {
+  const SERVER_RESPONSE_PAAPI_ORTB = {
     body: {
       'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
       'bidList': [{
@@ -1572,9 +1572,9 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  },
+  };
 
-  SERVER_VIDEO_OUTSTREAM_RESPONSE_VALID_BID = {
+  const SERVER_VIDEO_OUTSTREAM_RESPONSE_VALID_BID = {
     body: {
       'id': 'd90ca32f-3877-424a-b2f2-6a68988df57a',
       'bidList': [{
@@ -1609,8 +1609,8 @@ const VALID_BID_REQUEST = [{
         }]
       }
     }
-  },
-  SERVER_VALID_BIDS = [{
+  };
+  const SERVER_VALID_BIDS = [{
     'no_bid': false,
     'requestId': '27210feac00e96',
     'ad': 'ad',
@@ -1619,8 +1619,8 @@ const VALID_BID_REQUEST = [{
     'creativeId': '375068987',
     'netRevenue': true,
     'cpm': 0.1
-  }],
-  BID_REQUEST_SIZE_AS_1DARRAY = [{
+  }];
+  const BID_REQUEST_SIZE_AS_1DARRAY = [{
     'bidder': 'medianet',
     'params': {
       'cid': 'customer_id',
@@ -1674,8 +1674,8 @@ const VALID_BID_REQUEST = [{
     'bidderRequestId': '1e9b1f07797c1c',
     'auctionId': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'auctionsCount': 1
-  }],
-  VALID_BIDDER_REQUEST_WITH_GDPR = {
+  }];
+  const VALID_BIDDER_REQUEST_WITH_GDPR = {
     'gdprConsent': {
       'consentString': 'consentString',
       'gdprApplies': true,
@@ -1690,8 +1690,8 @@ const VALID_BID_REQUEST = [{
       topmostLocation: 'http://media.net/topmost',
       reachedTop: true
     }
-  },
-  VALID_PAYLOAD_FOR_GDPR = {
+  };
+  const VALID_PAYLOAD_FOR_GDPR = {
     'site': {
       'domain': 'media.net',
       'page': 'http://media.net/prebidtest',
@@ -1792,8 +1792,8 @@ const VALID_BID_REQUEST = [{
     }],
     'ortb2': {},
     'tmax': 3000,
-  },
-  VALID_BIDDER_REQUEST_WITH_GPP_IN_ORTB2 = {
+  };
+  const VALID_BIDDER_REQUEST_WITH_GPP_IN_ORTB2 = {
     ortb2: {
       regs: {
         gpp: 'DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN',
@@ -1809,8 +1809,8 @@ const VALID_BID_REQUEST = [{
       topmostLocation: 'http://media.net/topmost',
       reachedTop: true
     }
-  },
-  VALID_PAYLOAD_FOR_GPP_ORTB2 = {
+  };
+  const VALID_PAYLOAD_FOR_GPP_ORTB2 = {
     'site': {
       'page': 'http://media.net/prebidtest',
       'domain': 'media.net',

--- a/test/spec/modules/nextrollBidAdapter_spec.js
+++ b/test/spec/modules/nextrollBidAdapter_spec.js
@@ -258,8 +258,8 @@ describe('nextrollBidAdapter', function() {
 
     it('Should interpret all assets', () => {
       const allAssetsResponse = utils.deepClone(responseBody)
-      const iconUrl = imgUrl + '?icon=true', iconW = 10, iconH = 15
-      const logoUrl = imgUrl + '?logo=true', logoW = 20, logoH = 25
+      const iconUrl = imgUrl + '?icon=true'; const iconW = 10; const iconH = 15
+      const logoUrl = imgUrl + '?logo=true'; const logoW = 20; const logoH = 25
       const bodyText = 'Some body text'
 
       allAssetsResponse.body.seatbid[0].bid[0].adm.assets.push(...[

--- a/test/spec/modules/orbitsoftBidAdapter_spec.js
+++ b/test/spec/modules/orbitsoftBidAdapter_spec.js
@@ -14,8 +14,8 @@ describe('Orbitsoft adapter', function () {
               placementId: '123',
               requestUrl: ENDPOINT_URL
             }
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
 
         expect(isValid).to.equal(true);
       });
@@ -23,8 +23,8 @@ describe('Orbitsoft adapter', function () {
       it('should reject invalid bid', function () {
         const invalidBid = {
             bidder: 'orbitsoft'
-          },
-          isValid = spec.isBidRequestValid(invalidBid);
+          };
+          const isValid = spec.isBidRequestValid(invalidBid);
 
         expect(isValid).to.equal(false);
       });
@@ -66,8 +66,8 @@ describe('Orbitsoft adapter', function () {
               }
             },
             refererInfo: {referer: REFERRER_URL},
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(true);
 
         const buildRequest = spec.buildRequests([validBid])[0];
@@ -106,8 +106,8 @@ describe('Orbitsoft adapter', function () {
               }
             },
             refererInfo: {referer: REFERRER_URL},
-          },
-          isValid = spec.isBidRequestValid(validBid);
+          };
+          const isValid = spec.isBidRequestValid(validBid);
         expect(isValid).to.equal(true);
 
         const buildRequest = spec.buildRequests([validBid])[0];
@@ -122,8 +122,8 @@ describe('Orbitsoft adapter', function () {
             params: {
               placementId: '123'
             }
-          },
-          isValid = spec.isBidRequestValid(invalidBid);
+          };
+          const isValid = spec.isBidRequestValid(invalidBid);
 
         expect(isValid).to.equal(false);
       });
@@ -134,8 +134,8 @@ describe('Orbitsoft adapter', function () {
             params: {
               requestUrl: ENDPOINT_URL
             }
-          },
-          isValid = spec.isBidRequestValid(invalidBid);
+          };
+          const isValid = spec.isBidRequestValid(invalidBid);
 
         expect(isValid).to.equal(false);
       });
@@ -190,8 +190,8 @@ describe('Orbitsoft adapter', function () {
               callback_uid: '265b29b70cc106',
               cpm: 0
             }
-          },
-          bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
+          };
+          const bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
 
         expect(bids).to.be.lengthOf(0);
       });
@@ -213,8 +213,8 @@ describe('Orbitsoft adapter', function () {
               width: 0,
               height: 0
             }
-          },
-          bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
+          };
+          const bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
 
         expect(bids).to.be.lengthOf(0);
       });
@@ -229,8 +229,8 @@ describe('Orbitsoft adapter', function () {
             }
           }
         ];
-        const serverResponse = {error: 'error'},
-          bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
+        const serverResponse = {error: 'error'};
+          const bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
 
         expect(bids).to.be.lengthOf(0);
       });
@@ -245,8 +245,8 @@ describe('Orbitsoft adapter', function () {
             }
           }
         ];
-        const serverResponse = {},
-          bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
+        const serverResponse = {};
+          const bids = spec.interpretResponse(serverResponse, {'bidRequest': bidRequests[0]});
 
         expect(bids).to.be.lengthOf(0);
       });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -598,9 +598,9 @@ describe('s2s configuration', () => {
 });
 
 describe('S2S Adapter', function () {
-  let adapter,
-    addBidResponse = sinon.spy(),
-    done = sinon.spy();
+  let adapter;
+    let addBidResponse = sinon.spy();
+    let done = sinon.spy();
 
   addBidResponse.reject = sinon.spy();
 

--- a/test/spec/modules/pwbidBidAdapter_spec.js
+++ b/test/spec/modules/pwbidBidAdapter_spec.js
@@ -519,8 +519,8 @@ describe('PubWiseAdapter', function () {
           params: {
             siteId: 'xxxxxx'
           }
-        },
-        isValid = spec.isBidRequestValid(validBid);
+        };
+        const isValid = spec.isBidRequestValid(validBid);
       expect(isValid).to.equal(true);
     });
 
@@ -531,8 +531,8 @@ describe('PubWiseAdapter', function () {
             siteId: 'xxxxxx',
             gender: 'M',
           }
-        },
-        isValid = spec.isBidRequestValid(validBid);
+        };
+        const isValid = spec.isBidRequestValid(validBid);
       expect(isValid).to.equal(true);
     });
 
@@ -542,8 +542,8 @@ describe('PubWiseAdapter', function () {
           params: {
             gender: 'M',
           }
-        },
-        isValid = spec.isBidRequestValid(inValidBid);
+        };
+        const isValid = spec.isBidRequestValid(inValidBid);
       expect(isValid).to.equal(false);
     });
 
@@ -553,8 +553,8 @@ describe('PubWiseAdapter', function () {
           params: {
             siteId: 123456
           }
-        },
-        isValid = spec.isBidRequestValid(validBid);
+        };
+        const isValid = spec.isBidRequestValid(validBid);
       expect(isValid).to.equal(false);
     });
   });

--- a/test/spec/modules/relevatehealthBidAdapter_spec.js
+++ b/test/spec/modules/relevatehealthBidAdapter_spec.js
@@ -87,8 +87,8 @@ describe('relevatehealth adapter', function() {
           params: {
             placement_id: 110011
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(true);
     });
     it('isBidValid : placement_id is not passed', function() {
@@ -100,15 +100,15 @@ describe('relevatehealth adapter', function() {
             domain: '',
             bid_floor: 0.5
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
   });
   describe('Validate Request', function() {
     it('Immutable bid request validate', function() {
-      const _Request = utils.deepClone(request),
-        bidRequest = spec.buildRequests(request);
+      const _Request = utils.deepClone(request);
+        const bidRequest = spec.buildRequests(request);
       expect(request).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function() {

--- a/test/spec/modules/tapnativeBidAdapter_spec.js
+++ b/test/spec/modules/tapnativeBidAdapter_spec.js
@@ -146,8 +146,8 @@ describe('tapnative adapter', function () {
           params: {
             placement_id: 111520
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(true);
     });
     it('isBidValid : placement_id is not passed', function () {
@@ -159,15 +159,15 @@ describe('tapnative adapter', function () {
             domain: '',
             bid_floor: 0.5
           }
-        },
-        isValid = spec.isBidRequestValid(bid);
+        };
+        const isValid = spec.isBidRequestValid(bid);
       expect(isValid).to.equals(false);
     });
   });
   describe('Validate Banner Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(bannerRequest),
-        bidRequest = spec.buildRequests(bannerRequest);
+      const _Request = utils.deepClone(bannerRequest);
+        const bidRequest = spec.buildRequests(bannerRequest);
       expect(bannerRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {
@@ -233,8 +233,8 @@ describe('tapnative adapter', function () {
   });
   describe('Validate Native Request', function () {
     it('Immutable bid request validate', function () {
-      const _Request = utils.deepClone(nativeRequest),
-        bidRequest = spec.buildRequests(nativeRequest);
+      const _Request = utils.deepClone(nativeRequest);
+        const bidRequest = spec.buildRequests(nativeRequest);
       expect(nativeRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -102,7 +102,7 @@ const testCookieAndLocalStorage = (description, test, only = false) => {
 };
 
 describe(`UID2 module`, function () {
-  let suiteSandbox, testSandbox, timerSpy, fullTestTitle, restoreSubtleToUndefined = false;
+  let suiteSandbox; let testSandbox; let timerSpy; let fullTestTitle; let restoreSubtleToUndefined = false;
   before(function () {
     timerSpy = configureTimerInterceptors(debugOutput);
     hook.ready();

--- a/test/spec/modules/winrBidAdapter_spec.js
+++ b/test/spec/modules/winrBidAdapter_spec.js
@@ -228,7 +228,7 @@ describe('WinrAdapter', function () {
 
     it('should attach reserve param when either bid param or getFloor function exists', function () {
       const getFloorResponse = { currency: 'USD', floor: 3 };
-      let request, payload = null;
+      let request; let payload = null;
       const bidRequest = deepClone(bidRequests[0]);
 
       // 1 -> reserve not defined, getFloor not defined > empty

--- a/test/spec/refererDetection_spec.js
+++ b/test/spec/refererDetection_spec.js
@@ -12,8 +12,8 @@ describe('Referer detection', () => {
   describe('Non cross-origin scenarios', () => {
     describe('No iframes', () => {
       it('Should return the current window location and no canonical URL', () => {
-        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/'),
-          result = detectReferer(testWindow)();
+        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/');
+          const result = detectReferer(testWindow)();
 
         sinon.assert.match(result, {
           topmostLocation: 'https://example.com/some/page',
@@ -30,8 +30,8 @@ describe('Referer detection', () => {
       });
 
       it('Should return the current window location and a canonical URL', () => {
-        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
-          result = detectReferer(testWindow)();
+        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/', 'https://example.com/canonical/page');
+          const result = detectReferer(testWindow)();
 
         sinon.assert.match(result, {
           topmostLocation: 'https://example.com/some/page',
@@ -49,8 +49,8 @@ describe('Referer detection', () => {
 
       it('Should set page and canonical to pageUrl value set in config if present, even if canonical url is also present in head', () => {
         config.setConfig({'pageUrl': 'https://www.set-from-config.com/path'});
-        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
-          result = detectReferer(testWindow)();
+        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/', 'https://example.com/canonical/page');
+          const result = detectReferer(testWindow)();
 
         sinon.assert.match(result, {
           topmostLocation: 'https://example.com/some/page',
@@ -68,8 +68,8 @@ describe('Referer detection', () => {
 
       it('Should set page with query params if canonical url is present without query params but the current page does have them', () => {
         config.setConfig({'pageUrl': 'https://www.set-from-config.com/path'});
-        const testWindow = buildWindowTree(['https://example.com/some/page?query1=123&query2=456'], 'https://othersite.com/', 'https://example.com/canonical/page'),
-          result = detectReferer(testWindow)();
+        const testWindow = buildWindowTree(['https://example.com/some/page?query1=123&query2=456'], 'https://othersite.com/', 'https://example.com/canonical/page');
+          const result = detectReferer(testWindow)();
 
         sinon.assert.match(result, {
           topmostLocation: 'https://example.com/some/page?query1=123&query2=456',
@@ -88,8 +88,8 @@ describe('Referer detection', () => {
 
     describe('Friendly iframes', () => {
       it('Should return the top window location and no canonical URL', () => {
-        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/'),
-          result = detectReferer(testWindow)();
+        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/');
+          const result = detectReferer(testWindow)();
 
         sinon.assert.match(result, {
           topmostLocation: 'https://example.com/some/page',
@@ -110,8 +110,8 @@ describe('Referer detection', () => {
       });
 
       it('Should return the top window location and a canonical URL', () => {
-        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
-          result = detectReferer(testWindow)();
+        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/', 'https://example.com/canonical/page');
+          const result = detectReferer(testWindow)();
 
         sinon.assert.match(result, {
           topmostLocation: 'https://example.com/some/page',
@@ -134,8 +134,8 @@ describe('Referer detection', () => {
       it('Should override canonical URL (and page) with config pageUrl', () => {
         config.setConfig({'pageUrl': 'https://testurl.com'});
 
-        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
-          result = detectReferer(testWindow)();
+        const testWindow = buildWindowTree(['https://example.com/some/page', 'https://example.com/other/page', 'https://example.com/third/page'], 'https://othersite.com/', 'https://example.com/canonical/page');
+          const result = detectReferer(testWindow)();
 
         sinon.assert.match(result, {
           topmostLocation: 'https://example.com/some/page',
@@ -159,8 +159,8 @@ describe('Referer detection', () => {
 
   describe('Cross-origin scenarios', () => {
     it('Should return the top URL and no canonical URL with one cross-origin iframe', () => {
-      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad'], 'https://othersite.com/', 'https://canonical.example.com/'),
-        result = detectReferer(testWindow)();
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad'], 'https://othersite.com/', 'https://canonical.example.com/');
+        const result = detectReferer(testWindow)();
 
       sinon.assert.match(result, {
         location: 'https://example.com/some/page',
@@ -180,8 +180,8 @@ describe('Referer detection', () => {
     });
 
     it('Should return the top URL and no canonical URL with one cross-origin iframe and one friendly iframe', () => {
-      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://safe.frame/ad'], 'https://othersite.com/', 'https://canonical.example.com/'),
-        result = detectReferer(testWindow)();
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://safe.frame/ad'], 'https://othersite.com/', 'https://canonical.example.com/');
+        const result = detectReferer(testWindow)();
 
       sinon.assert.match(result, {
         topmostLocation: 'https://example.com/some/page',
@@ -202,8 +202,8 @@ describe('Referer detection', () => {
     });
 
     it('Should return the second iframe location with three cross-origin windows and no ancestorOrigins', () => {
-      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://otherfr.ame/ad'], 'https://othersite.com/', 'https://canonical.example.com/'),
-        result = detectReferer(testWindow)();
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://otherfr.ame/ad'], 'https://othersite.com/', 'https://canonical.example.com/');
+        const result = detectReferer(testWindow)();
 
       sinon.assert.match(result, {
         topmostLocation: 'https://safe.frame/ad',
@@ -224,8 +224,8 @@ describe('Referer detection', () => {
     });
 
     it('Should return the top window origin with three cross-origin windows with ancestorOrigins', () => {
-      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://otherfr.ame/ad'], 'https://othersite.com/', 'https://canonical.example.com/', true),
-        result = detectReferer(testWindow)();
+      const testWindow = buildWindowTree(['https://example.com/some/page', 'https://safe.frame/ad', 'https://otherfr.ame/ad'], 'https://othersite.com/', 'https://canonical.example.com/', true);
+        const result = detectReferer(testWindow)();
 
       sinon.assert.match(result, {
         topmostLocation: 'https://example.com/',

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -713,7 +713,7 @@ describe('adapterManager tests', function () {
 
     describe('BID_REQUESTED event', function () {
       // function to count BID_REQUESTED events
-      let cnt, count = () => cnt++;
+      let cnt; let count = () => cnt++;
 
       beforeEach(function () {
         prebidServerAdapterMock.callBids.resetHistory();
@@ -1103,7 +1103,7 @@ describe('adapterManager tests', function () {
 
     describe('BID_REQUESTED event', function () {
       // function to count BID_REQUESTED events
-      let cnt, count = () => cnt++;
+      let cnt; let count = () => cnt++;
 
       beforeEach(function () {
         prebidServerAdapterMock.callBids.resetHistory();

--- a/test/spec/unit/core/auctionIndex_spec.js
+++ b/test/spec/unit/core/auctionIndex_spec.js
@@ -131,7 +131,7 @@ describe('auction index', () => {
   });
 
   describe('getOrtb2', () => {
-    let bidderRequests, adUnits = [];
+    let bidderRequests; let adUnits = [];
     beforeEach(() => {
       bidderRequests = [
         {bidderRequestId: 'ber1', ortb2: {}, bids: [{bidId: 'b1', adUnitId: 'au1'}, {}]},

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -9,17 +9,17 @@ import { getWinDimensions, internal } from '../../src/utils.js';
 var assert = require('assert');
 
 describe('Utils', function () {
-  var obj_string = 's',
-    obj_number = 1,
-    obj_object = {},
-    obj_array = [],
-    obj_function = function () {};
+  var obj_string = 's';
+    var obj_number = 1;
+    var obj_object = {};
+    var obj_array = [];
+    var obj_function = function () {};
 
-  var type_string = 'String',
-    type_number = 'Number',
-    type_object = 'Object',
-    type_array = 'Array',
-    type_function = 'Function';
+  var type_string = 'String';
+    var type_number = 'Number';
+    var type_object = 'Object';
+    var type_array = 'Array';
+    var type_function = 'Function';
 
   describe('canAccessWindowTop', function () {
     let sandbox;
@@ -1218,8 +1218,8 @@ describe('Utils', function () {
 
   describe('setScriptAttributes', () => {
     it('correctly adds attributes from an object', () => {
-      const script = document.createElement('script'),
-        attrs = {
+      const script = document.createElement('script');
+        const attrs = {
           'data-first_prop': '1',
           'data-second_prop': 'b',
           'id': 'newId'


### PR DESCRIPTION
## Summary
- remove `one-var` override for tests
- run `eslint --fix` on test files
- fix remaining lint violations

## Testing
- `gulp lint`
- `gulp test --file test/spec/adloader_spec.js --nolint`
- `gulp test --file test/spec/utils_spec.js --nolint`
- `gulp test --file test/spec/modules/winrBidAdapter_spec.js --nolint`
- `gulp test --file test/spec/modules/medianetBidAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6871110d2d40832b84de0cc2b18f806e