### PR TITLE
Core: fix bidResponseFilter test path

### DIFF
--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -5,7 +5,7 @@ import {
   BID_CATEGORY_REJECTION_REASON,
   init,
   MODULE_NAME
-  , reset} from '../../../modules/bidResponseFilter.js';
+  , reset} from '../../../modules/bidResponseFilter/index.js';
 import {config} from '../../../src/config.js';
 import {addBidResponse} from '../../../src/auction.js';
 


### PR DESCRIPTION
## Summary
- fix the import path in `bidResponseFilter_spec.js` to reference the index file

## Testing
- `npx eslint test/spec/modules/bidResponseFilter_spec.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/bidResponseFilter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6871347151c8832b9b13662f9b3cf25f