### PR TITLE
Tests: restore auctionManager index stub

### DIFF
--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -221,7 +221,7 @@ describe('native.js', function () {
     let adUnit;
     beforeEach(() => {
       adUnit = {};
-      sinon.stub(auctionManager, 'index').get(() => ({
+      sandbox.stub(auctionManager, 'index').get(() => ({
         getAdUnit: () => adUnit
       }))
     });


### PR DESCRIPTION
## Summary
- ensure native spec stubs auctionManager using sandbox

## Testing
- `npx eslint --cache --cache-strategy content test/spec/native_spec.js`
- `npx gulp test --file test/spec/native_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_687133b249a0832bafbe8cd3a1255648