### PR TITLE
Core: fix test import for enrichmentLiftMeasurement

### DIFF
--- a/test/spec/modules/enrichmentLiftMeasurement_spec.js
+++ b/test/spec/modules/enrichmentLiftMeasurement_spec.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { getCalculatedSubmodules, internals, init, reset, storeSplitsMethod, storeTestConfig, suppressionMethod, getStoredTestConfig, compareConfigs, STORAGE_KEY } from "../../../modules/enrichmentLiftMeasurement.js";
+import { getCalculatedSubmodules, internals, init, reset, storeSplitsMethod, storeTestConfig, suppressionMethod, getStoredTestConfig, compareConfigs, STORAGE_KEY } from "../../../modules/enrichmentLiftMeasurement/index.js";
 import {server} from 'test/mocks/xhr.js';
 import { config } from "../../../src/config.js"
 import { isInteger } from "../../../src/utils.js";


### PR DESCRIPTION
## Summary
- correct import path in enrichmentLiftMeasurement_spec.js

## Testing
- `npx eslint --cache --cache-strategy content test/spec/modules/enrichmentLiftMeasurement_spec.js`
- `npx gulp test --file test/spec/modules/enrichmentLiftMeasurement_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6871503428b8832bb4e0723aa8e8a811