### PR TITLE
Core: fix e2e fixtures import

### DIFF
--- a/test/fake-server/fake-responder.js
+++ b/test/fake-server/fake-responder.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 const deepEqual = require('deep-equal');
-const generateFixtures = require('./fixtures.js');
+const generateFixtures = require('./fixtures/index.js');
 const path = require('path');
 
 // path to the fixture directory


### PR DESCRIPTION
## Summary
- restore the fake server fixtures import

The e2e tests failed because `fake-responder.js` required `./fixtures.js` which doesn't exist. This caused a `MODULE_NOT_FOUND` error during the BrowserStack run as seen in the logs. Restoring the import to point to `fixtures/index.js` resolves the missing module.

## Testing
- `npx eslint test/fake-server/fake-responder.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/unit/utils/focusTimeout_spec.js --nolint` *(failed: command hung due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6872a41a7e58832b96a91b8b7fd35746