### PR TITLE
CI: stabilize e2e runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,7 @@ jobs:
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
     steps:
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -28,7 +28,8 @@ function getCapabilities() {
         osVersion: browser.os_version,
         networkLogs: true,
         consoleLogs: 'verbose',
-        buildName: `Prebidjs E2E (${browser.browser} ${browser.browser_version}) ${new Date().toLocaleString()}`
+        buildName: `Prebidjs E2E (${browser.browser} ${browser.browser_version}) ${new Date().toLocaleString()}`,
+        localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER
       },
       acceptInsecureCerts: true,
     });


### PR DESCRIPTION
## Summary
- set a unique BrowserStack local identifier for every workflow run
- pass that identifier through the e2e job

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/adUnits_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_68739adb14a0832b829a0cbda112236e