### PR TITLE
Core: remove no-empty eslint exception

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,7 +133,6 @@ module.exports = [
       'jsdoc/require-yields-check': 'off',
       'jsdoc/tag-lines': 'off',
       'no-var': 'off',
-      'no-empty': 'off',
       'no-void': 'off',
       'array-callback-return': 'off',
       'prefer-const': 'off',

--- a/test/helpers/index_adapter_utils.js
+++ b/test/helpers/index_adapter_utils.js
@@ -137,8 +137,7 @@ function compareOnKeys(lhs, rhs) {
   }
 
   for (let key in rhs) {
-    if (key in lhs) {
-    } else {
+    if (!(key in lhs)) {
       ronly.push(rhs[key]);
     }
   }


### PR DESCRIPTION
## Summary
- remove the `no-empty` exception in `eslint.config.js`
- update `index_adapter_utils.js` helper to satisfy `no-empty` rule

## Testing
- `npx eslint . --cache --cache-strategy content`
- `npx gulp test --file test/spec/unit/pbjs_api_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_68739dd30364832b91f77024dbdc771f