### PR TITLE
Core: fix eqeqeq in tests

### DIFF
--- a/test/spec/modules/advangelistsBidAdapter_spec.js
+++ b/test/spec/modules/advangelistsBidAdapter_spec.js
@@ -89,8 +89,8 @@ describe('advangelistsBidAdapter', function () {
         bidRequests.forEach(bid => {
           const _mediaTypes = (bid.mediaTypes && bid.mediaTypes.video ? VIDEO : BANNER);
           advangelistsbidreq.bids[bid.bidId] = {mediaTypes: _mediaTypes,
-            w: _mediaTypes == BANNER ? bid.mediaTypes[_mediaTypes].sizes[0][0] : bid.mediaTypes[_mediaTypes].playerSize[0],
-            h: _mediaTypes == BANNER ? bid.mediaTypes[_mediaTypes].sizes[0][1] : bid.mediaTypes[_mediaTypes].playerSize[1]
+            w: _mediaTypes === BANNER ? bid.mediaTypes[_mediaTypes].sizes[0][0] : bid.mediaTypes[_mediaTypes].playerSize[0],
+            h: _mediaTypes === BANNER ? bid.mediaTypes[_mediaTypes].sizes[0][1] : bid.mediaTypes[_mediaTypes].playerSize[1]
 
           };
         });

--- a/test/spec/modules/c1xBidAdapter_spec.js
+++ b/test/spec/modules/c1xBidAdapter_spec.js
@@ -60,8 +60,8 @@ describe('C1XAdapter', () => {
     ];
     const parseRequest = (data) => {
       const parsedData = '{"' + data.replace(/=|&/g, (foundChar) => {
-        if (foundChar == '=') return '":"';
-        else if (foundChar == '&') return '","';
+        if (foundChar === '=') return '":"';
+        else if (foundChar === '&') return '","';
       }) + '"}'
       return parsedData;
     };

--- a/test/spec/modules/contxtfulBidAdapter_spec.js
+++ b/test/spec/modules/contxtfulBidAdapter_spec.js
@@ -748,7 +748,7 @@ describe('contxtful bid adapter', function () {
 
     it('will contains the receptivity value within the ortb2.user.data with contxtful name', () => {
       const obtained_receptivity_data = bidRequest.data.ortb2.user.data.filter(function (userData) {
-        return userData.name == 'contxtful';
+        return userData.name === 'contxtful';
       });
       expect(obtained_receptivity_data.length).to.equal(1);
       expect(obtained_receptivity_data[0].ext).to.deep.equal(expectedReceptivityData);

--- a/test/spec/modules/contxtfulRtdProvider_spec.js
+++ b/test/spec/modules/contxtfulRtdProvider_spec.js
@@ -835,7 +835,7 @@ describe('contxtfulRtdProvider', function () {
         InitDivStubPositions(config, false, true, false);
         const fakeElem = fakeGetElementById(100, 100, 30, 30);
         sandbox.stub(window.top.document, 'getElementById').returns(function (id) {
-          if (id == 'code1' || id == 'code2') {
+          if (id === 'code1' || id === 'code2') {
             return undefined;
           } else {
             return fakeElem;

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -334,7 +334,7 @@ describe('The Criteo bidding adapter', function () {
       const userSyncs = spec.getUserSyncs(syncOptionsIframeEnabled, undefined, undefined, undefined);
 
       setCookieStub.callsFake((name, value, expires, _, domain) => {
-        if (domain != '.com') {
+        if (domain !== '.com') {
           cookies[name] = value;
         }
       });

--- a/test/spec/modules/datablocksBidAdapter_spec.js
+++ b/test/spec/modules/datablocksBidAdapter_spec.js
@@ -515,11 +515,11 @@ describe('DatablocksAdapter', function() {
         expect(bid.ttl).to.be.a('number');
         expect(bid.mediaType).to.be.a('string');
 
-        if (bid.mediaType == 'banner') {
+        if (bid.mediaType === 'banner') {
           expect(bid.width).to.be.a('number');
           expect(bid.height).to.be.a('number');
           expect(bid.ad).to.be.a('string');
-        } else if (bid.mediaType == 'native') {
+        } else if (bid.mediaType === 'native') {
           expect(bid.native).to.be.a('object');
         }
       })

--- a/test/spec/modules/eclickBidAdapter_spec.js
+++ b/test/spec/modules/eclickBidAdapter_spec.js
@@ -76,7 +76,7 @@ describe('eclickBidAdapter', () => {
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
     it('should return true if there is correct required params and mediatype', () => {
-      bidItem.params.mediaTypes == NATIVE;
+      bidItem.params.mediaTypes === NATIVE;
       expect(spec.isBidRequestValid(bidItem)).to.be.true;
     });
     it('should return true if there is no size', () => {

--- a/test/spec/modules/hadronRtdProvider_spec.js
+++ b/test/spec/modules/hadronRtdProvider_spec.js
@@ -512,7 +512,7 @@ describe('hadronRtdProvider', function () {
       const rtdConfig = {
         params: {
           handleRtd: function (bidConfig, rtd, rtdConfig, pbConfig) {
-            if (rtd.ortb2.user.data[0].segment[0].id == '1776') {
+            if (rtd.ortb2.user.data[0].segment[0].id === '1776') {
               pbConfig.setConfig({ortb2: rtd.ortb2});
             } else {
               pbConfig.setConfig({ortb2: {}});
@@ -580,11 +580,11 @@ describe('hadronRtdProvider', function () {
               var adUnit = adUnits[i];
               for (var j = 0; j < adUnit.bids.length; j++) {
                 var bid = adUnit.bids[j];
-                if (bid.bidder == 'adBuzz') {
+                if (bid.bidder === 'adBuzz') {
                   for (var k = 0; k < rtd.adBuzz.length; k++) {
                     bid.adBuzzData.segments.adBuzz.push(rtd.adBuzz[k]);
                   }
-                } else if (bid.bidder == 'trueBid') {
+                } else if (bid.bidder === 'trueBid') {
                   for (var m = 0; m < rtd.trueBid.length; m++) {
                     bid.trueBidSegments.push(rtd.trueBid[m]);
                   }

--- a/test/spec/modules/impactifyBidAdapter_spec.js
+++ b/test/spec/modules/impactifyBidAdapter_spec.js
@@ -197,12 +197,12 @@ describe('ImpactifyAdapter', function () {
 
     it('should return false when format is not equals to screen or display', () => {
       const bid = utils.deepClone(validBids[0]);
-      if (bid.params.format != 'screen' && bid.params.format != 'display') {
+      if (bid.params.format !== 'screen' && bid.params.format !== 'display') {
         expect(spec.isBidRequestValid(bid)).to.equal(false);
       }
 
       const bid2 = utils.deepClone(validBids[1]);
-      if (bid2.params.format != 'screen' && bid2.params.format != 'display') {
+      if (bid2.params.format !== 'screen' && bid2.params.format !== 'display') {
         expect(spec.isBidRequestValid(bid2)).to.equal(false);
       }
     });

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -4714,7 +4714,7 @@ describe('IndexexchangeAdapter', function () {
       let validBids;
       beforeEach(() => {
         ftStub = sinon.stub(FEATURE_TOGGLES, 'isFeatureEnabled').callsFake((ftName) => {
-          if (ftName == 'pbjs_enable_multiformat') {
+          if (ftName === 'pbjs_enable_multiformat') {
             return true;
           }
           return false;

--- a/test/spec/modules/jixieBidAdapter_spec.js
+++ b/test/spec/modules/jixieBidAdapter_spec.js
@@ -241,7 +241,7 @@ describe('jixie Adapter', function () {
       // get the interceptors ready:
       const getConfigStub = sinon.stub(config, 'getConfig');
       getConfigStub.callsFake(function fakeFn(prop) {
-        if (prop == 'jixie') {
+        if (prop === 'jixie') {
           return testJixieCfg_;
         }
         return null;
@@ -329,7 +329,7 @@ describe('jixie Adapter', function () {
       };
       const getConfigStub = sinon.stub(config, 'getConfig');
       getConfigStub.callsFake(function fakeFn(prop) {
-        if (prop == 'priceGranularity') {
+        if (prop === 'priceGranularity') {
           return content;
         }
         return null;
@@ -346,7 +346,7 @@ describe('jixie Adapter', function () {
       const getConfigStub = sinon.stub(config, 'getConfig');
       const content = {w: 500, h: 400};
       getConfigStub.callsFake(function fakeFn(prop) {
-        if (prop == 'device') {
+        if (prop === 'device') {
           return content;
         }
         return null;
@@ -410,7 +410,7 @@ describe('jixie Adapter', function () {
       // 2 aid is set in the jixie config
       const getConfigStub = sinon.stub(config, 'getConfig');
       getConfigStub.callsFake(function fakeFn(prop) {
-        if (prop == 'jixie') {
+        if (prop === 'jixie') {
           return { aid: '11223344556677889900' };
         }
         return null;

--- a/test/spec/modules/lotamePanoramaIdSystem_spec.js
+++ b/test/spec/modules/lotamePanoramaIdSystem_spec.js
@@ -32,7 +32,7 @@ describe('LotameId', function() {
       'removeDataFromLocalStorage'
     );
     timeStampStub = sinon.stub(utils, 'timestamp').returns(nowTimestamp);
-    if (navigator.userAgent && navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+    if (navigator.userAgent && navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) {
       requestHost = 'https://c.ltmsphrcl.net/id';
     } else {
       requestHost = 'https://id.crwdcntrl.net/id';

--- a/test/spec/modules/nativoBidAdapter_spec.js
+++ b/test/spec/modules/nativoBidAdapter_spec.js
@@ -759,7 +759,7 @@ describe('RequestData', () => {
 
       requestData.addBidRequestDataSource(testBidRequestDataSource)
 
-      expect(requestData.bidRequestDataSources.length == 1)
+      expect(requestData.bidRequestDataSources.length === 1)
     })
 
     it("Doeasn't add a non BidRequestDataSource", () => {
@@ -770,7 +770,7 @@ describe('RequestData', () => {
       requestData.addBidRequestDataSource(1)
       requestData.addBidRequestDataSource(true)
 
-      expect(requestData.bidRequestDataSources.length == 0)
+      expect(requestData.bidRequestDataSources.length === 0)
     })
   })
 

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -578,7 +578,7 @@ describe('onetag', function () {
               }
               if (size !== null) {
                 const keys = Object.keys(size);
-                if (keys.length == 0) {
+                if (keys.length === 0) {
                   return true;
                 }
                 expect(size).to.have.keys('width', 'height');

--- a/test/spec/modules/smartytechBidAdapter_spec.js
+++ b/test/spec/modules/smartytechBidAdapter_spec.js
@@ -146,7 +146,7 @@ function mockBidRequestListData(mediaType, size, customSizes) {
       endpointId: id
     }
 
-    if (mediaType == 'video') {
+    if (mediaType === 'video') {
       mediaTypes = {
         video: {
           playerSize: mockRandomSizeArray(1),

--- a/test/spec/modules/trionBidAdapter_spec.js
+++ b/test/spec/modules/trionBidAdapter_spec.js
@@ -52,7 +52,7 @@ const TRION_BID_RESPONSE = {
 const getPublisherUrl = function () {
   var url = null;
   try {
-    if (window.top == window) {
+    if (window.top === window) {
       url = window.location.href;
     } else {
       try {


### PR DESCRIPTION
## Summary
- address eqeqeq lint failures in modules spec files

## Testing
- `npx eslint test/spec/modules/advangelistsBidAdapter_spec.js test/spec/modules/c1xBidAdapter_spec.js test/spec/modules/contxtfulBidAdapter_spec.js test/spec/modules/contxtfulRtdProvider_spec.js test/spec/modules/criteoBidAdapter_spec.js test/spec/modules/datablocksBidAdapter_spec.js test/spec/modules/eclickBidAdapter_spec.js test/spec/modules/hadronRtdProvider_spec.js test/spec/modules/impactifyBidAdapter_spec.js test/spec/modules/ixBidAdapter_spec.js test/spec/modules/jixieBidAdapter_spec.js test/spec/modules/lotamePanoramaIdSystem_spec.js test/spec/modules/nativoBidAdapter_spec.js test/spec/modules/onetagBidAdapter_spec.js test/spec/modules/smartytechBidAdapter_spec.js test/spec/modules/trionBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/advangelistsBidAdapter_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_68755ce34a44832bbbe1c3268452d7e4