### PR TITLE
Libraries: fix eqeqeq violations

### DIFF
--- a/libraries/advangUtils/index.js
+++ b/libraries/advangUtils/index.js
@@ -133,7 +133,7 @@ export function createRequestData(bid, bidderRequest, isVideo, getBidParam, getS
   let sizes = [];
   const coppa = config.getConfig('coppa');
 
-  if (typeof paramSize !== 'undefined' && paramSize != '') {
+  if (typeof paramSize !== 'undefined' && paramSize !== '') {
     sizes = parseSizes(paramSize);
   } else {
     sizes = getSizes(bid);

--- a/libraries/audUtils/bidderUtils.js
+++ b/libraries/audUtils/bidderUtils.js
@@ -93,7 +93,7 @@ const formatResponse = (bidResponse, mediaType, assets) => {
           response.ttl = 300;
           response.dealId = bidReq.dealId;
           response.mediaType = mediaType;
-          if (mediaType == 'native') {
+          if (mediaType === 'native') {
             const nativeResp = JSON.parse(bidReq.adm).native;
             const nativeData = {
               clickUrl: nativeResp.link.url,
@@ -205,7 +205,7 @@ const getNativeAssestData = (params, assets) => {
 const getAssetData = (paramId, asset) => {
   let resp = '';
   for (let i = 0; i < asset.length; i++) {
-    if (asset[i].id == paramId) {
+    if (asset[i].id === paramId) {
       switch (asset[i].data.type) {
         case 1 : resp = 'sponsored';
           break;
@@ -222,7 +222,7 @@ const getAssetData = (paramId, asset) => {
 const getAssetImageDataType = (paramId, asset) => {
   let resp = '';
   for (let i = 0; i < asset.length; i++) {
-    if (asset[i].id == paramId) {
+    if (asset[i].id === paramId) {
       switch (asset[i].img.type) {
         case 1 : resp = 'icon';
           break;

--- a/libraries/braveUtils/buildAndInterpret.js
+++ b/libraries/braveUtils/buildAndInterpret.js
@@ -22,7 +22,7 @@ export const buildRequests = (validBidRequests, bidderRequest, endpointURL, defa
     device: bidderRequest.ortb2?.device || { w: screen.width, h: screen.height, language: navigator.language?.split('-')[0], ua: navigator.userAgent },
     site: prepareSite(validBidRequests[0], bidderRequest),
     tmax: bidderRequest.timeout,
-    regs: { ext: {}, coppa: config.getConfig('coppa') == true ? 1 : 0 },
+    regs: { ext: {}, coppa: config.getConfig('coppa') === true ? 1 : 0 },
     user: { ext: {} },
     imp
   };

--- a/libraries/connectionInfo/connectionUtils.js
+++ b/libraries/connectionInfo/connectionUtils.js
@@ -27,7 +27,7 @@ export function getConnectionType() {
         case '5g':
           return 7;
         default:
-          return connection.type == 'cellular' ? 3 : 0;
+          return connection.type === 'cellular' ? 3 : 0;
       }
   }
 }

--- a/libraries/cookieSync/cookieSync.js
+++ b/libraries/cookieSync/cookieSync.js
@@ -19,7 +19,7 @@ export function cookieSync(syncOptions, gdprConsent, uspConsent, bidderCode, coo
 
   if (syncOptions.iframeEnabled) {
     window.addEventListener('message', function handler(event) {
-      if (!event.data || event.origin != cookieOrigin) {
+      if (!event.data || event.origin !== cookieOrigin) {
         return;
       }
 

--- a/libraries/precisoUtils/bidUtils.js
+++ b/libraries/precisoUtils/bidUtils.js
@@ -27,7 +27,7 @@ export const buildRequests = (endpoint) => (validBidRequests = [], bidderRequest
     badv: validBidRequests[0].ortb2.badv || validBidRequests[0].params.badv,
     wlang: validBidRequests[0].ortb2.wlang || validBidRequests[0].params.wlang,
   };
-  if (req.device && req.device != 'undefined') {
+  if (req.device && req.device !== 'undefined') {
     req.device.geo = {
       country: req.user.geo.country,
       region: req.user.geo.region,

--- a/libraries/userAgentUtils/index.js
+++ b/libraries/userAgentUtils/index.js
@@ -48,11 +48,11 @@ export const getBrowser = () => {
  * @returns {number}
  */
 export const getOS = () => {
-  if (navigator.userAgent.indexOf('Android') != -1) return osTypes.ANDROID;
-  if (navigator.userAgent.indexOf('like Mac') != -1) return osTypes.IOS;
-  if (navigator.userAgent.indexOf('Win') != -1) return osTypes.WINDOWS;
-  if (navigator.userAgent.indexOf('Mac') != -1) return osTypes.MAC;
-  if (navigator.userAgent.indexOf('Linux') != -1) return osTypes.LINUX;
-  if (navigator.appVersion.indexOf('X11') != -1) return osTypes.UNIX;
+  if (navigator.userAgent.indexOf('Android') !== -1) return osTypes.ANDROID;
+  if (navigator.userAgent.indexOf('like Mac') !== -1) return osTypes.IOS;
+  if (navigator.userAgent.indexOf('Win') !== -1) return osTypes.WINDOWS;
+  if (navigator.userAgent.indexOf('Mac') !== -1) return osTypes.MAC;
+  if (navigator.userAgent.indexOf('Linux') !== -1) return osTypes.LINUX;
+  if (navigator.appVersion.indexOf('X11') !== -1) return osTypes.UNIX;
   return osTypes.OTHER;
 };


### PR DESCRIPTION
## Summary
- enforce strict equality checks in libraries utilities
- include unit test runs for affected files

## Testing
- `npx eslint libraries --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/libraries/userAgentUtils_spec.js`
- `npx gulp test --nolint --file test/spec/libraries/precisoUtils/bidUtils_spec.js`
- `npx gulp test --nolint --file test/spec/modules/nexverseBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68755cf7b960832b89ec488f33b13fee