### PR TITLE
Multiple Adapters: fix eqeqeq violations

### DIFF
--- a/modules/addefendBidAdapter.js
+++ b/modules/addefendBidAdapter.js
@@ -45,12 +45,12 @@ export const spec = {
       delete o.pageId;
 
       if (vb.sizes && Array.isArray(vb.sizes)) {
-        for (var j = 0; j < vb.sizes.length; j++) {
-          const s = vb.sizes[j];
-          if (Array.isArray(s) && s.length == 2) {
-            o.sizes.push(s[0] + 'x' + s[1]);
+          for (var j = 0; j < vb.sizes.length; j++) {
+            const s = vb.sizes[j];
+            if (Array.isArray(s) && s.length === 2) {
+              o.sizes.push(s[0] + 'x' + s[1]);
+            }
           }
-        }
       }
       bid.bids.push(o);
     }

--- a/modules/adheseBidAdapter.js
+++ b/modules/adheseBidAdapter.js
@@ -30,7 +30,7 @@ export const spec = {
     const refererParams = (refererInfo && refererInfo.page) ? { xf: [base64urlEncode(refererInfo.page)] } : {};
     const globalCustomParams = (adheseConfig && adheseConfig.globalTargets) ? cleanTargets(adheseConfig.globalTargets) : {};
     const commonParams = { ...globalCustomParams, ...gdprParams, ...refererParams };
-    const vastContentAsUrl = !(adheseConfig && adheseConfig.vastContentAsUrl == false);
+      const vastContentAsUrl = !(adheseConfig && adheseConfig.vastContentAsUrl === false);
 
     const slots = validBidRequests.map(bid => ({
       slotname: bidToSlotName(bid),

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -326,8 +326,8 @@ function enrichSlotWithFloors(slot, bidRequest) {
   }
 }
 
-function parseSizes(sizes, parser = s => s) {
-  if (sizes == undefined) {
+  function parseSizes(sizes, parser = s => s) {
+    if (sizes === undefined) {
     return [];
   }
   if (Array.isArray(sizes[0])) { // is there several sizes ? (ie. [[728,90],[200,300]])

--- a/modules/adrelevantisBidAdapter.js
+++ b/modules/adrelevantisBidAdapter.js
@@ -339,7 +339,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
     let jsTrackers = nativeAd.javascript_trackers;
 
-    if (jsTrackers == undefined) {
+      if (jsTrackers === undefined) {
       jsTrackers = jsTrackerDisarmed;
     } else if (isStr(jsTrackers)) {
       jsTrackers = [jsTrackers, jsTrackerDisarmed];

--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -139,7 +139,7 @@ const interpretResponse = (serverResponse, request) => {
           currency: res.cur
         }
 
-        if (b.adomain != undefined || b.adomain != null) {
+        if (b.adomain !== undefined || b.adomain !== null) {
           bid.meta = { advertiserDomains: b.adomain };
         }
 

--- a/modules/viouslyBidAdapter.js
+++ b/modules/viouslyBidAdapter.js
@@ -48,7 +48,7 @@ export const spec = {
     if (bannerParams) {
       const sizes = bannerParams.sizes;
 
-      if (!sizes || parseSizesInput(sizes).length == 0) {
+      if (!sizes || parseSizesInput(sizes).length === 0) {
         logError('mediaTypes.banner.sizes must be set for banner placement at the right format.');
         return false;
       }
@@ -207,7 +207,7 @@ export const spec = {
               nurl: bidResponse.nurl ? bidResponse.nurl : []
             };
 
-            if (bidResponse.type == VIDEO) {
+              if (bidResponse.type === VIDEO) {
               if (bidResponse.ad_url) {
                 bid.vastUrl = bidResponse.ad_url;
               } else {

--- a/modules/vistarsBidAdapter.js
+++ b/modules/vistarsBidAdapter.js
@@ -66,7 +66,7 @@ export const spec = {
     bids.forEach((bid) => {
       bid.meta = bid.meta || {};
       bid.meta.advertiserDomains = bid.meta.advertiserDomains || [];
-      if (bid.meta.advertiserDomains.length == 0) {
+        if (bid.meta.advertiserDomains.length === 0) {
         bid.meta.advertiserDomains.push(ADOMAIN);
       }
 

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -173,9 +173,9 @@ export const spec = {
         return;
       }
 
-      const matchedBid = ((serverResponse.body) || []).find(function (bidResponse) {
-        return bidRequest.params.adslotId == bidResponse.id;
-      });
+        const matchedBid = ((serverResponse.body) || []).find(function (bidResponse) {
+          return bidRequest.params.adslotId === bidResponse.id;
+        });
 
       if (matchedBid) {
         const adUnitSize = bidRequest.sizes.length === 2 && !isArray(bidRequest.sizes[0]) ? bidRequest.sizes : bidRequest.sizes[0];

--- a/modules/zmaticooBidAdapter.js
+++ b/modules/zmaticooBidAdapter.js
@@ -148,8 +148,8 @@ export const spec = {
     if (params.test) {
       payload.test = params.test;
     }
-    if (bidderRequest.gdprConsent) {
-      payload.regs.ext = Object.assign(payload.regs.ext, {gdpr: bidderRequest.gdprConsent.gdprApplies == true ? 1 : 0});
+      if (bidderRequest.gdprConsent) {
+        payload.regs.ext = Object.assign(payload.regs.ext, {gdpr: bidderRequest.gdprConsent.gdprApplies === true ? 1 : 0});
     }
     if (bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies) {
       payload.user.ext = Object.assign(payload.user.ext, {consent: bidderRequest.gdprConsent.consentString});


### PR DESCRIPTION
## Summary
- address eqeqeq lint errors in various bid adapters

## Testing
- `npx eslint modules/addefendBidAdapter.js modules/adheseBidAdapter.js modules/admaticBidAdapter.js modules/adrelevantisBidAdapter.js modules/unicornBidAdapter.js modules/viouslyBidAdapter.js modules/vistarsBidAdapter.js modules/yieldlabBidAdapter.js modules/zmaticooBidAdapter.js modules/adagioBidAdapter.js modules/adkernelBidAdapter.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/addefendBidAdapter_spec.js` *(fails: Karma tests failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68755d01155c832b96fb589e75e4592e