### PR TITLE
Adapters: fix eqeqeq linting

### DIFF
--- a/modules/advertisingBidAdapter.js
+++ b/modules/advertisingBidAdapter.js
@@ -176,7 +176,7 @@ export const spec = {
   buildVideoImpressions: function(adSizes, bid, tagIdOrPlacementId, pos, videoOrBannerKey) {
     const imps = [];
     adSizes.forEach((size, i) => {
-      if (!size || size.length != 2) {
+      if (!size || size.length !== 2) {
         return;
       }
       const size0 = size[0];
@@ -287,7 +287,7 @@ export const spec = {
             ttl,
           };
 
-          if (bid.adomain != undefined || bid.adomain != null) {
+          if (bid.adomain != null) {
             bidObj.meta = { advertiserDomains: bid.adomain };
           }
 

--- a/modules/betweenBidAdapter.js
+++ b/modules/betweenBidAdapter.js
@@ -198,7 +198,7 @@ function getRr() {
 
   if (typeof rr !== 'undefined' && rr.length > 0) {
     return encodeURIComponent(rr);
-  } else if (typeof rr !== 'undefined' && rr == '') {
+  } else if (typeof rr !== 'undefined' && rr === '') {
     return 'direct';
   }
 }
@@ -232,7 +232,7 @@ function get_pubdata(adds) {
     let index = 0;
     let url = '';
     for(var key in adds.pubdata) {
-      if (index == 0) {
+      if (index === 0) {
         url = url + encodeURIComponent('pubside_macro[' + key + ']') + '=' + encodeURIComponent(adds.pubdata[key]);
         index++;
       } else {

--- a/modules/clickforceBidAdapter.js
+++ b/modules/clickforceBidAdapter.js
@@ -69,7 +69,7 @@ export const spec = {
     _each(serverResponse.body, function(response) {
       if (response.requestId != null) {
         // native ad size
-        if (response.width == 3) {
+        if (response.width === 3) {
           cfResponses.push({
             requestId: response.requestId,
             cpm: response.cpm,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -230,7 +230,7 @@ export const spec = {
       queryParams.push(`topUrl=${refererInfo.domain}`);
       if (gdprConsent) {
         if (gdprConsent.gdprApplies) {
-          queryParams.push(`gdpr=${gdprConsent.gdprApplies == true ? 1 : 0}`);
+          queryParams.push(`gdpr=${gdprConsent.gdprApplies === true ? 1 : 0}`);
         }
         if (gdprConsent.consentString) {
           queryParams.push(`gdpr_consent=${gdprConsent.consentString}`);
@@ -261,7 +261,7 @@ export const spec = {
       };
 
       window.addEventListener('message', function handler(event) {
-        if (!event.data || event.origin != 'https://gum.criteo.com') {
+        if (!event.data || event.origin !== 'https://gum.criteo.com') {
           return;
         }
 
@@ -532,7 +532,7 @@ function checkNativeSendId(bidRequest) {
 }
 
 function parseSizes(sizes, parser = s => s) {
-  if (sizes == undefined) {
+  if (sizes === undefined) {
     return [];
   }
   if (Array.isArray(sizes[0])) { // is there several sizes ? (ie. [[728,90],[200,300]])

--- a/modules/datablocksBidAdapter.js
+++ b/modules/datablocksBidAdapter.js
@@ -313,7 +313,7 @@ export const spec = {
         id: bidRequest.bidId,
         tagid: bidRequest.params.tagid || bidRequest.adUnitCode,
         placement_id: bidRequest.params.placement_id || 0,
-        secure: window.location.protocol == 'https:',
+        secure: window.location.protocol === 'https:',
         ortb2: deepAccess(bidRequest, `ortb2Imp`) || {},
         floor: {}
       }

--- a/modules/deepintentBidAdapter.js
+++ b/modules/deepintentBidAdapter.js
@@ -272,7 +272,7 @@ function buildDevice() {
   return {
     ua: navigator.userAgent,
     js: 1,
-    dnt: (navigator.doNotTrack == 'yes' || navigator.doNotTrack === '1') ? 1 : 0,
+    dnt: (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1') ? 1 : 0,
     h: screen.height,
     w: screen.width,
     language: navigator.language

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -79,7 +79,7 @@ export const spec = {
           if (typeof hmetas[k] === 'object') {
             var mname = hmetas[k].name || hmetas[k].getAttribute('property');
             var mcont = hmetas[k].content;
-            if (!!mname && mname != 'null' && !!mcont) {
+            if (!!mname && mname !== 'null' && !!mcont) {
               if (wnames.indexOf(mname) >= 0) {
                 if (!mts[mname]) {
                   mts[mname] = [];
@@ -155,8 +155,8 @@ export const spec = {
 
     function verifySize(adItem, validSizes) {
       for (var j = 0, k = validSizes.length; j < k; j++) {
-        if (adItem.width == validSizes[j][0] &&
-            adItem.height == validSizes[j][1]) {
+        if (adItem.width === validSizes[j][0] &&
+            adItem.height === validSizes[j][1]) {
           return true;
         }
       }

--- a/modules/fwsspBidAdapter.js
+++ b/modules/fwsspBidAdapter.js
@@ -179,7 +179,7 @@ export const spec = {
         let videoPlacement = currentBidRequest.mediaTypes.video.placement ? currentBidRequest.mediaTypes.video.placement : null;
         const videoPlcmt = currentBidRequest.mediaTypes.video.plcmt ? currentBidRequest.mediaTypes.video.plcmt : null;
 
-        if (currentBidRequest.params.format == 'inbanner') {
+        if (currentBidRequest.params.format === 'inbanner') {
           videoContext = 'In-Banner';
           videoPlacement = 2;
         }
@@ -450,7 +450,7 @@ export function formatAdHTML(bidrequest, size) {
 }
 
 function getSdkUrl(bidrequest) {
-  const isStg = bidrequest.params.env && bidrequest.params.env.toLowerCase() == 'stg';
+  const isStg = bidrequest.params.env && bidrequest.params.env.toLowerCase() === 'stg';
   const host = isStg ? 'adm.stg.fwmrm.net' : 'mssl.fwmrm.net';
   const sdkVersion = getSDKVersion(bidrequest);
   return `https://${host}/libs/adm/${sdkVersion}/AdManager-prebid.js`
@@ -658,13 +658,13 @@ function getValueFromKeyInImpressionNode(xmlNode, key) {
     let tempValue = '';
     queries.forEach(item => {
       const split = item.split('=');
-      if (split[0] == key) {
+      if (split[0] === key) {
         tempValue = split[1];
       }
-      if (split[0] == 'reqType' && split[1] == 'AdsDisplayStarted') {
+      if (split[0] === 'reqType' && split[1] === 'AdsDisplayStarted') {
         isAdsDisplayStartedPresent = true;
       }
-      if (split[0] == 'rootViewKey') {
+      if (split[0] === 'rootViewKey') {
         isRootViewKeyPresent = true;
       }
     });

--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -155,7 +155,7 @@ function createOpenRtbRequest(validBidRequests, bidderRequest) {
     devicetype: helpers.getDeviceType(),
     ua: navigator.userAgent,
     js: 1,
-    dnt: (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') ? 1 : 0,
+    dnt: (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1') ? 1 : 0,
     language: ((navigator.language || navigator.userLanguage || '').split('-'))[0] || 'en',
   };
   request.site = { page: bidderRequest.refererInfo.page };
@@ -168,7 +168,7 @@ function createOpenRtbRequest(validBidRequests, bidderRequest) {
   }
   deepSetValue(request, 'regs.ext.gdpr', gdprApplies);
 
-  if (GET_CONFIG('coppa') == true) deepSetValue(request, 'regs.coppa', 1);
+  if (GET_CONFIG('coppa') === true) deepSetValue(request, 'regs.coppa', 1);
 
   if (bidderRequest.uspConsent) {
     deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);

--- a/modules/inmobiBidAdapter.js
+++ b/modules/inmobiBidAdapter.js
@@ -316,7 +316,7 @@ export const spec = {
 };
 
 function isReportingAllowed(loggingPercentage) {
-  return loggingPercentage != 0;
+  return loggingPercentage !== 0;
 }
 
 function report(type, data) {


### PR DESCRIPTION
## Summary
- clean up eqeqeq warnings in several bid adapters

## Testing
- `npx eslint modules/advertisingBidAdapter.js modules/betweenBidAdapter.js modules/clickforceBidAdapter.js modules/criteoBidAdapter.js modules/datablocksBidAdapter.js modules/deepintentBidAdapter.js modules/etargetBidAdapter.js modules/fwsspBidAdapter.js modules/impactifyBidAdapter.js modules/inmobiBidAdapter.js`
- `npx gulp test --nolint --file test/spec/modules/advertisingBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/clickforceBidAdapter_spec.js` *(failed)*

------
https://chatgpt.com/codex/tasks/task_b_68756349ffd8832ba736678821d58fd4