### PR TITLE
Adapters: fix eqeqeq lint issues

### DIFF
--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -128,7 +128,7 @@ export const spec = {
         bidResponse.vastXml = response.vastXML;
         try {
           if (bidResponse.vastXml != null) {
-            if (JSON.parse(bidRequest.data).videoData.format == 'outstream' || JSON.parse(bidRequest.data).videoData.format == 'banner') {
+            if (JSON.parse(bidRequest.data).videoData.format === 'outstream' || JSON.parse(bidRequest.data).videoData.format === 'banner') {
               bidResponse.renderer = Renderer.install({
                 id: bidRequest.bidId,
                 adunitcode: bidRequest.tagId,
@@ -180,12 +180,12 @@ export const spec = {
       consentGPP += '&gpp_sid=' + encodeURIComponent(gppConsent?.applicableSections?.join(','));
     }
 
-    if (syncOptions.iframeEnabled && raiSync.raiIframe != 'exclude') {
+    if (syncOptions.iframeEnabled && raiSync.raiIframe !== 'exclude') {
       syncUrl = 'https://sync.richaudience.com/dcf3528a0b8aa83634892d50e91c306e/?ord=' + rand
-      if (consent != '') {
+      if (consent !== '') {
         syncUrl += `&${consent}`
       }
-      if (consentGPP != '') {
+      if (consentGPP !== '') {
         syncUrl += `&${consentGPP}`
       }
       syncs.push({
@@ -194,12 +194,12 @@ export const spec = {
       });
     }
 
-    if (syncOptions.pixelEnabled && REFERER != null && syncs.length == 0 && raiSync.raiImage != 'exclude') {
+    if (syncOptions.pixelEnabled && REFERER != null && syncs.length === 0 && raiSync.raiImage !== 'exclude') {
       syncUrl = `https://sync.richaudience.com/bf7c142f4339da0278e83698a02b0854/?referrer=${REFERER}`;
-      if (consent != '') {
+      if (consent !== '') {
         syncUrl += `&${consent}`
       }
-      if (consentGPP != '') {
+      if (consentGPP !== '') {
         syncUrl += `&${consentGPP}`
       }
       syncs.push({
@@ -237,13 +237,13 @@ function raiGetDemandType(bid) {
   let raiFormat = 'display';
   if (typeof bid.sizes !== 'undefined') {
     bid.sizes.forEach(function (sz) {
-      if ((sz[0] == '1800' && sz[1] == '1000') || (sz[0] == '1' && sz[1] == '1')) {
+      if ((sz[0] === '1800' && sz[1] === '1000') || (sz[0] === '1' && sz[1] === '1')) {
         raiFormat = 'skin'
       }
     })
   }
-  if (bid.mediaTypes != undefined) {
-    if (bid.mediaTypes.video != undefined) {
+  if (bid.mediaTypes !== undefined) {
+    if (bid.mediaTypes.video !== undefined) {
       raiFormat = 'video';
     }
   }
@@ -252,7 +252,7 @@ function raiGetDemandType(bid) {
 
 function raiGetVideoInfo(bid) {
   let videoData;
-  if (raiGetDemandType(bid) == 'video') {
+  if (raiGetDemandType(bid) === 'video') {
     videoData = {
       format: bid.mediaTypes.video.context,
       playerSize: bid.mediaTypes.video.playerSize,
@@ -304,10 +304,10 @@ function raiGetSyncInclude(config) {
     if (config.getConfig('userSync').filterSettings != null && typeof config.getConfig('userSync').filterSettings !== 'undefined') {
       raConfig = config.getConfig('userSync').filterSettings
       if (raConfig.iframe != null && typeof raConfig.iframe !== 'undefined') {
-        raiSync.raiIframe = raConfig.iframe.bidders == 'richaudience' || raConfig.iframe.bidders == '*' ? raConfig.iframe.filter : 'exclude';
+        raiSync.raiIframe = raConfig.iframe.bidders === 'richaudience' || raConfig.iframe.bidders === '*' ? raConfig.iframe.filter : 'exclude';
       }
       if (raConfig.image != null && typeof raConfig.image !== 'undefined') {
-        raiSync.raiImage = raConfig.image.bidders == 'richaudience' || raConfig.image.bidders == '*' ? raConfig.image.filter : 'exclude';
+        raiSync.raiImage = raConfig.image.bidders === 'richaudience' || raConfig.image.bidders === '*' ? raConfig.image.filter : 'exclude';
       }
     }
     return raiSync;

--- a/modules/seedingAllianceBidAdapter.js
+++ b/modules/seedingAllianceBidAdapter.js
@@ -213,7 +213,7 @@ function parseNative(bid, nativeParams) {
 
   nativeParamKeys.forEach(nativeParam => {
     assets.forEach(asset => {
-      if (asset.id == id) {
+      if (asset.id === id) {
         switch (nativeParam) {
           case 'title':
             result.title = asset.title.text;

--- a/modules/smartxBidAdapter.js
+++ b/modules/smartxBidAdapter.js
@@ -288,7 +288,7 @@ export const spec = {
         _each(bids.bid, function (smartxBid) {
           let currentBidRequest = {};
           for (const i in bidderRequest.bidRequest.bids) {
-            if (smartxBid.impid == bidderRequest.bidRequest.bids[i].bidId) {
+            if (smartxBid.impid === bidderRequest.bidRequest.bids[i].bidId) {
               currentBidRequest = bidderRequest.bidRequest.bids[i];
             }
           }
@@ -296,7 +296,7 @@ export const spec = {
            * Make sure currency and price are the right ones
            */
           _each(currentBidRequest.params.pre_market_bids, function (pmb) {
-            if (pmb.deal_id == smartxBid.id) {
+            if (pmb.deal_id === smartxBid.id) {
               smartxBid.price = pmb.price;
               serverResponseBody.cur = pmb.currency;
             }
@@ -389,19 +389,19 @@ function createOutstreamConfig(bid) {
     },
   };
 
-  if (confStartOpen == 'true') {
+  if (confStartOpen === 'true') {
     playerConfig.startOpen = true;
-  } else if (confStartOpen == 'false') {
+  } else if (confStartOpen === 'false') {
     playerConfig.startOpen = false;
   }
 
-  if (confEndingScreen == 'true') {
+  if (confEndingScreen === 'true') {
     playerConfig.endingScreen = true;
-  } else if (confEndingScreen == 'false') {
+  } else if (confEndingScreen === 'false') {
     playerConfig.endingScreen = false;
   }
 
-  if (confTitle || (typeof bid.renderer.config.outstream_options.title === 'string' && bid.renderer.config.outstream_options.title == '')) {
+  if (confTitle || (typeof bid.renderer.config.outstream_options.title === 'string' && bid.renderer.config.outstream_options.title === '')) {
     playerConfig.layoutSettings.advertisingLabel = confTitle;
   }
 

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -359,7 +359,7 @@ function buildOneRequest(validBidRequests, bidderRequest) {
     video.mimes = videoMediaType.mimes;
 
     const videoExt = {};
-    if ((typeof videoMediaType.rewarded !== 'undefined') && videoMediaType.rewarded == 1) {
+    if ((typeof videoMediaType.rewarded !== 'undefined') && videoMediaType.rewarded === 1) {
       videoExt.rewarded = videoMediaType.rewarded;
     }
     video.ext = videoExt;
@@ -507,12 +507,12 @@ function getLanguage() {
 
 function getOs() {
   const ua = navigator.userAgent;
-  if (ua.match(/Android/)) { return 'Android'; } else if (ua.match(/(iPhone|iPod|iPad)/)) { return 'iOS'; } else if (ua.indexOf('Mac OS X') != -1) { return 'macOS'; } else if (ua.indexOf('Windows') != -1) { return 'Windows'; } else if (ua.indexOf('Linux') != -1) { return 'Linux'; } else { return 'Unknown'; }
+  if (ua.match(/Android/)) { return 'Android'; } else if (ua.match(/(iPhone|iPod|iPad)/)) { return 'iOS'; } else if (ua.indexOf('Mac OS X') !== -1) { return 'macOS'; } else if (ua.indexOf('Windows') !== -1) { return 'Windows'; } else if (ua.indexOf('Linux') !== -1) { return 'Linux'; } else { return 'Unknown'; }
 }
 
 function getVendor() {
   const ua = navigator.userAgent;
-  if (ua.indexOf('Chrome') != -1) { return 'Google'; } else if (ua.indexOf('Firefox') != -1) { return 'Mozilla'; } else if (ua.indexOf('Safari') != -1) { return 'Apple'; } else if (ua.indexOf('Edge') != -1) { return 'Microsoft'; } else if (ua.indexOf('MSIE') != -1 || ua.indexOf('Trident') != -1) { return 'Microsoft'; } else { return ''; }
+  if (ua.indexOf('Chrome') !== -1) { return 'Google'; } else if (ua.indexOf('Firefox') !== -1) { return 'Mozilla'; } else if (ua.indexOf('Safari') !== -1) { return 'Apple'; } else if (ua.indexOf('Edge') !== -1) { return 'Microsoft'; } else if (ua.indexOf('MSIE') !== -1 || ua.indexOf('Trident') !== -1) { return 'Microsoft'; } else { return ''; }
 }
 
 export function _getHostInfo(validBidRequests) {

--- a/modules/ucfunnelBidAdapter.js
+++ b/modules/ucfunnelBidAdapter.js
@@ -164,18 +164,18 @@ registerBidder(spec);
 
 function getCookieSyncParameter(gdprApplies, apiVersion, consentString, uspConsent) {
   let param = '?';
-  if (gdprApplies == '1') {
+  if (gdprApplies === '1') {
     param = param + 'gdpr=1&';
   }
-  if (apiVersion == 1) {
+  if (apiVersion === 1) {
     param = param + 'euconsent=' + consentString + '&';
-  } else if (apiVersion == 2) {
+  } else if (apiVersion === 2) {
     param = param + 'euconsent-v2=' + consentString + '&';
   }
   if (uspConsent) {
     param = param + 'usprivacy=' + uspConsent;
   }
-  return (param == '?') ? '' : param;
+  return (param === '?') ? '' : param;
 }
 
 function parseSizes(bid) {
@@ -260,7 +260,7 @@ function getFormat(size) {
 function getRequestData(bid, bidderRequest) {
   const size = parseSizes(bid);
   const language = navigator.language;
-  const dnt = (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') ? 1 : 0;
+  const dnt = (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1') ? 1 : 0;
   const userIdTdid = (bid.userId && bid.userId.tdid) ? bid.userId.tdid : '';
   const schain = bid?.ortb2?.source?.ext?.schain;
   const supplyChain = getSupplyChain(schain);
@@ -291,7 +291,7 @@ function getRequestData(bid, bidderRequest) {
 
   if (storage.cookiesAreEnabled()) {
     let ucfUid = '';
-    if (storage.getCookie(COOKIE_NAME) != undefined) {
+    if (storage.getCookie(COOKIE_NAME) !== undefined) {
       ucfUid = storage.getCookie(COOKIE_NAME);
       bidData.ucfUid = ucfUid;
     } else {
@@ -301,7 +301,7 @@ function getRequestData(bid, bidderRequest) {
     }
   }
 
-  if (size != undefined && size.length > 0 && size[0].length == 2) {
+  if (size !== undefined && size.length > 0 && size[0].length === 2) {
     bidData.w = size[0][0];
     bidData.h = size[0][1];
   }


### PR DESCRIPTION
## Summary
- address eqeqeq lint complaints in RichAudience, Seeding Alliance, SmartX, Tappx and UCFunnel adapters

## Testing
- `npx eslint modules/richaudienceBidAdapter.js modules/seedingAllianceBidAdapter.js modules/smartxBidAdapter.js modules/tappxBidAdapter.js modules/ucfunnelBidAdapter.js`
- `npx gulp test --file test/spec/modules/richaudienceBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/seedingAllianceAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/smartxBidAdapter_spec.js --nolint` *(fails: document.getElementById(...) is not a function)*
- `npx gulp test --file test/spec/modules/tappxBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/ucfunnelBidAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6875630da86c832b94b06dc9e1ae8604