### PR TITLE
Adapters: fix eqeqeq linting

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -100,7 +100,7 @@ function buildRequests(validBidRequests, bidderRequest) {
   });
 
   // Add site.cat if it exists
-  if (firstBidRequest.ortb2?.site?.cat != null) {
+  if (firstBidRequest.ortb2?.site?.cat !== null && firstBidRequest.ortb2?.site?.cat !== undefined) {
     krakenParams.site = { cat: firstBidRequest.ortb2.site.cat };
   }
 
@@ -114,27 +114,27 @@ function buildRequests(validBidRequests, bidderRequest) {
   krakenParams.user.data = deepAccess(firstBidRequest, REQUEST_KEYS.USER_DATA) || [];
 
   const reqCount = getRequestCount()
-  if (reqCount != null) {
+  if (reqCount !== null && reqCount !== undefined) {
     krakenParams.requestCount = reqCount;
   }
 
   // Add currency if not USD
-  if (currency != null && currency != CURRENCY.US_DOLLAR) {
+  if ((currency !== null && currency !== undefined) && currency !== CURRENCY.US_DOLLAR) {
     krakenParams.cur = currency;
   }
 
-  if (metadata.rawCRB != null) {
+  if (metadata.rawCRB !== null && metadata.rawCRB !== undefined) {
     krakenParams.rawCRB = metadata.rawCRB
   }
 
-  if (metadata.rawCRBLocalStorage != null) {
+  if (metadata.rawCRBLocalStorage !== null && metadata.rawCRBLocalStorage !== undefined) {
     krakenParams.rawCRBLocalStorage = metadata.rawCRBLocalStorage
   }
 
   // Pull Social Canvas segments and embed URL
   const socialCanvas = deepAccess(firstBidRequest, REQUEST_KEYS.SOCIAL_CANVAS);
 
-  if (socialCanvas != null) {
+  if (socialCanvas !== null && socialCanvas !== undefined) {
     krakenParams.socan = socialCanvas;
   }
 
@@ -166,9 +166,9 @@ function buildRequests(validBidRequests, bidderRequest) {
     krakenParams.device.sua = pick(uaClientHints, suaValidAttributes);
   }
 
-  const validPageId = getLocalStorageSafely(CERBERUS.PAGE_VIEW_ID) != null
-  const validPageTimestamp = getLocalStorageSafely(CERBERUS.PAGE_VIEW_TIMESTAMP) != null
-  const validPageUrl = getLocalStorageSafely(CERBERUS.PAGE_VIEW_URL) != null
+  const validPageId = getLocalStorageSafely(CERBERUS.PAGE_VIEW_ID) !== null && getLocalStorageSafely(CERBERUS.PAGE_VIEW_ID) !== undefined
+  const validPageTimestamp = getLocalStorageSafely(CERBERUS.PAGE_VIEW_TIMESTAMP) !== null && getLocalStorageSafely(CERBERUS.PAGE_VIEW_TIMESTAMP) !== undefined
+  const validPageUrl = getLocalStorageSafely(CERBERUS.PAGE_VIEW_URL) !== null && getLocalStorageSafely(CERBERUS.PAGE_VIEW_URL) !== undefined
 
   const page = {}
   if (validPageId) {
@@ -229,7 +229,7 @@ function interpretResponse(response, bidRequest) {
       meta: meta
     };
 
-    if (meta.mediaType == VIDEO) {
+    if (meta.mediaType === VIDEO) {
       if (adUnit.admUrl) {
         bidResponse.vastUrl = adUnit.admUrl;
       } else {
@@ -271,7 +271,7 @@ function getUserSyncs(syncOptions, _, gdprConsent, usPrivacy, gppConsent) {
   var gppApplicableSections = (gppConsent && gppConsent.applicableSections && Array.isArray(gppConsent.applicableSections)) ? gppConsent.applicableSections.join(',') : '';
 
   // don't sync if opted out via usPrivacy
-  if (typeof usPrivacy === 'string' && usPrivacy.length == 4 && usPrivacy[0] == 1 && usPrivacy[2] == 'Y') {
+  if (typeof usPrivacy === 'string' && usPrivacy.length === 4 && usPrivacy[0] === '1' && usPrivacy[2] === 'Y') {
     return syncs;
   }
   if (syncOptions.iframeEnabled && seed && clientId) {
@@ -290,7 +290,7 @@ function getUserSyncs(syncOptions, _, gdprConsent, usPrivacy, gppConsent) {
 }
 
 function onTimeout(timeoutData) {
-  if (timeoutData == null) {
+  if (timeoutData === null || timeoutData === undefined) {
     return;
   }
 
@@ -390,22 +390,22 @@ function getUserIds(tdidAdapter, usp, gdpr, eids, gpp) {
   }
 
   // Kargo ID
-  if (crb.lexId != null) {
+  if (crb.lexId !== null && crb.lexId !== undefined) {
     userIds.kargoID = crb.lexId;
   }
 
   // Client ID
-  if (crb.clientId != null) {
+  if (crb.clientId !== null && crb.clientId !== undefined) {
     userIds.clientID = crb.clientId;
   }
 
   // Opt Out
-  if (crb.optOut != null) {
+  if (crb.optOut !== null && crb.optOut !== undefined) {
     userIds.optOut = crb.optOut;
   }
 
   // User ID Sub-Modules (userIdAsEids)
-  if (eids != null) {
+  if (eids !== null && eids !== undefined) {
     userIds.sharedIDEids = eids;
   }
 

--- a/modules/kubientBidAdapter.js
+++ b/modules/kubientBidAdapter.js
@@ -30,7 +30,7 @@ export const spec = {
       };
 
       if (typeof bid.getFloor === 'function') {
-        const mediaType = (Object.keys(bid.mediaTypes).length == 1) ? Object.keys(bid.mediaTypes)[0] : '*';
+        const mediaType = (Object.keys(bid.mediaTypes).length === 1) ? Object.keys(bid.mediaTypes)[0] : '*';
         const sizes = bid.sizes || '*';
         const floorInfo = bid.getFloor({currency: 'USD', mediaType: mediaType, size: sizes});
         if (isPlainObject(floorInfo) && floorInfo.currency === 'USD') {

--- a/modules/madvertiseBidAdapter.js
+++ b/modules/madvertiseBidAdapter.js
@@ -45,7 +45,7 @@ export const spec = {
       var src = '?rt=bid_request&v=1.0';
 
       for (var i = 0; i < bidRequest.sizes.length; i++) {
-        if (Array.isArray(bidRequest.sizes[i]) && bidRequest.sizes[i].length == 2) {
+        if (Array.isArray(bidRequest.sizes[i]) && bidRequest.sizes[i].length === 2) {
           src = src + '&sizes[' + i + ']=' + bidRequest.sizes[i][0] + 'x' + bidRequest.sizes[i][1];
         }
       }
@@ -76,7 +76,7 @@ export const spec = {
   interpretResponse: function (responseObj, bidRequest) {
     responseObj = responseObj.body;
     // check overall response
-    if (responseObj == null || typeof responseObj !== 'object' || !responseObj.hasOwnProperty('ad')) {
+    if (responseObj === null || responseObj === undefined || typeof responseObj !== 'object' || !responseObj.hasOwnProperty('ad')) {
       return [];
     }
 

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -66,11 +66,11 @@ export const spec = {
         if (Array.isArray(adunitValue.sizes)) {
           adunitValue.sizes.forEach(value => {
             const tmpFloor = adunitValue.getFloor({currency: 'USD', mediaType: '*', size: value});
-            if (tmpFloor != {}) { code.floor[value.join('x')] = tmpFloor; }
+            if (tmpFloor !== {}) { code.floor[value.join('x')] = tmpFloor; }
           });
         }
         const tmpFloor = adunitValue.getFloor({currency: 'USD', mediaType: '*', size: '*'});
-        if (tmpFloor != {}) { code.floor['*'] = tmpFloor; }
+        if (tmpFloor !== {}) { code.floor['*'] = tmpFloor; }
       }
       if (adunitValue.ortb2Imp) { code.ortb2Imp = adunitValue.ortb2Imp }
       codes.push(code);
@@ -163,7 +163,7 @@ export const spec = {
    * @return {UserSync[]} The user syncs which should be dropped.
    */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
-    if (typeof serverResponses === 'object' && serverResponses != null && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
+    if (typeof serverResponses === 'object' && serverResponses !== null && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
         serverResponses[0].body.hasOwnProperty('cookies') && typeof serverResponses[0].body.cookies === 'object') {
       return serverResponses[0].body.cookies;
     } else {
@@ -177,7 +177,7 @@ export const spec = {
    */
   onBidWon: function(bid) {
     // fires a pixel to confirm a winning bid
-    if (bid.hasOwnProperty('mediaType') && bid.mediaType == 'video') {
+    if (bid.hasOwnProperty('mediaType') && bid.mediaType === 'video') {
       return;
     }
     const params = { pbjs: '$prebid.version$', referer: encodeURIComponent(getRefererInfo().page || getRefererInfo().topmostLocation) };

--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -123,7 +123,7 @@ export const spec = {
     if (
       typeof capping?.expiry === 'number' &&
       new Date().getTime() < capping?.expiry &&
-      (!capping?.referer || capping?.referer == referer)
+      (!capping?.referer || capping?.referer === referer)
     ) {
       logInfo('Missena - Capped');
       return [];

--- a/modules/nobidBidAdapter.js
+++ b/modules/nobidBidAdapter.js
@@ -289,7 +289,7 @@ function nobidBuildRequests(bids, bidderRequest) {
 function nobidInterpretResponse(response, bidRequest) {
   var findBid = function(divid, bids) {
     for (var i = 0; i < bids.length; i++) {
-      if (bids[i].adUnitCode == divid) {
+      if (bids[i].adUnitCode === divid) {
         return bids[i];
       }
     }
@@ -402,9 +402,9 @@ export const spec = {
       var env = (typeof getParameterByName === 'function') && (getParameterByName('nobid-env'));
       env = window.location.href.indexOf('nobid-env=dev') > 0 ? 'dev' : env;
       if (!env) ret = 'https://ads.servenobid.com/';
-      else if (env == 'beta') ret = 'https://beta.servenobid.com/';
-      else if (env == 'dev') ret = '//localhost:8282/';
-      else if (env == 'qa') ret = 'https://qa-ads.nobid.com/';
+      else if (env === 'beta') ret = 'https://beta.servenobid.com/';
+      else if (env === 'dev') ret = '//localhost:8282/';
+      else if (env === 'qa') ret = 'https://qa-ads.nobid.com/';
       return ret;
     }
     var buildEndpoint = function() {

--- a/modules/novatiqIdSystem.js
+++ b/modules/novatiqIdSystem.js
@@ -82,7 +82,7 @@ export const novatiqIdSubmodule = {
     const novatiqId = syncUrl.novatiqId;
 
     // for testing
-    const sharedStatus = (sharedId != undefined && sharedId != false) ? 'Found' : 'Not Found';
+    const sharedStatus = (sharedId !== null && sharedId !== undefined && sharedId !== false) ? 'Found' : 'Not Found';
 
     if (useCallbacks) {
       const res = this.sendAsyncSyncRequest(novatiqId, url); ;
@@ -165,7 +165,7 @@ export const novatiqIdSubmodule = {
     }
 
     // append on the shared ID if we have one
-    if (sharedId != null) {
+    if (sharedId !== null && sharedId !== undefined) {
       url = url + '&sharedId=' + sharedId;
     }
 
@@ -184,16 +184,16 @@ export const novatiqIdSubmodule = {
     }
 
     if (typeof configParams.urlParams !== 'undefined') {
-      if (configParams.urlParams.novatiqId != undefined) {
+      if (configParams.urlParams.novatiqId !== undefined) {
         urlParams.novatiqId = configParams.urlParams.novatiqId;
       }
-      if (configParams.urlParams.useStandardUuid != undefined) {
+      if (configParams.urlParams.useStandardUuid !== undefined) {
         urlParams.useStandardUuid = configParams.urlParams.useStandardUuid;
       }
-      if (configParams.urlParams.useSspId != undefined) {
+      if (configParams.urlParams.useSspId !== undefined) {
         urlParams.useSspId = configParams.urlParams.useSspId;
       }
-      if (configParams.urlParams.useSspHost != undefined) {
+      if (configParams.urlParams.useSspHost !== undefined) {
         urlParams.useSspHost = configParams.urlParams.useSspHost;
       }
     }
@@ -212,7 +212,7 @@ export const novatiqIdSubmodule = {
   getCookieOrStorageID(configParams) {
     let cookieOrStorageID = '_pubcid';
 
-    if (typeof configParams.sharedIdName !== 'undefined' && configParams.sharedIdName != null && configParams.sharedIdName != '') {
+    if (typeof configParams.sharedIdName !== 'undefined' && configParams.sharedIdName !== null && configParams.sharedIdName !== '') {
       cookieOrStorageID = configParams.sharedIdName;
       logInfo('NOVATIQ sharedID name redefined: ' + cookieOrStorageID);
     }
@@ -234,7 +234,7 @@ export const novatiqIdSubmodule = {
       }
 
       // if nothing check the local cookies
-      if (sharedId == null) {
+      if (sharedId === null || sharedId === undefined) {
         sharedId = storage.getCookie(cookieOrStorageID);
         logInfo('NOVATIQ sharedID retrieved from cookies:' + sharedId);
       }
@@ -246,7 +246,7 @@ export const novatiqIdSubmodule = {
   },
 
   getSrcId(configParams, urlParams) {
-    if (urlParams.useSspId == false) {
+    if (urlParams.useSspId === false) {
       logInfo('NOVATIQ Configured to NOT use sspid');
       return '';
     }

--- a/modules/openPairIdSystem.js
+++ b/modules/openPairIdSystem.js
@@ -110,7 +110,7 @@ export const openPairIdSubmodule = {
       }
     }
 
-    if (ids.length == 0) {
+    if (ids.length === 0) {
       logInfo('Open Pair ID: no ids found')
       return undefined;
     }


### PR DESCRIPTION
## Summary
- enforce strict equality in several adapters and ID systems
- keep behavior consistent for user privacy and shared ID handling

## Testing
- `npx eslint --cache --cache-strategy content modules/kargoBidAdapter.js modules/kubientBidAdapter.js modules/madvertiseBidAdapter.js modules/mediasquareBidAdapter.js modules/missenaBidAdapter.js modules/nobidBidAdapter.js modules/novatiqIdSystem.js modules/openPairIdSystem.js`
- `npx gulp test --nolint --file test/spec/modules/kargoBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/kubientBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/madvertiseBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/mediasquareBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/missenaBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/nobidBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/novatiqIdSystem_spec.js`
- `npx gulp test --nolint --file test/spec/modules/openPairIdSystem_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68756367205c832b90194a7fe1c37a4c