### PR TITLE
Pubmatic adapters: fix eqeqeq linting

### DIFF
--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -207,7 +207,7 @@ function getDevicePlatform() {
   var deviceType = 3;
   try {
     var ua = navigator.userAgent;
-    if (ua && isStr(ua) && ua.trim() != '') {
+    if (ua && isStr(ua) && ua.trim() !== '') {
       ua = ua.toLowerCase().trim();
       var isMobileRegExp = new RegExp('(mobi|tablet|ios).*');
       if (ua.match(isMobileRegExp)) {
@@ -331,7 +331,7 @@ function getFloorsCommonField (floorData) {
 }
 
 function getFloorType(floorResponseData) {
-  return floorResponseData ? (floorResponseData.enforcements.enforceJS == false ? 0 : 1) : undefined;
+  return floorResponseData ? (floorResponseData.enforcements.enforceJS === false ? 0 : 1) : undefined;
 }
 
 function gatherPartnerBidsForAdUnitForLogger(adUnit, adUnitId, highestBid, e) {
@@ -371,7 +371,7 @@ function gatherPartnerBidsForAdUnitForLogger(adUnit, adUnitId, highestBid, e) {
         'l2': 0,
         'adv': bid.bidResponse ? getAdDomain(bid.bidResponse) || undefined : undefined,
         'ss': isS2SBidder(bid.bidder),
-        't': (bid.status == ERROR && bid.error.code == TIMEOUT_ERROR) ? 1 : 0,
+        't': (bid.status === ERROR && bid.error.code === TIMEOUT_ERROR) ? 1 : 0,
         'wb': (highestBid && highestBid.adId === bid.adId ? 1 : 0),
         'mi': bid.bidResponse ? (bid.bidResponse.mi || undefined) : undefined,
         'af': bid.bidResponse ? (bid.bidResponse.mediaType || undefined) : undefined,
@@ -404,7 +404,7 @@ function getAdUnitAdFormats(adUnit) {
 }
 
 function getAdUnit(adUnits, adUnitId) {
-  return adUnits.filter(adUnit => (adUnit.divID && adUnit.divID == adUnitId) || (adUnit.code == adUnitId))[0];
+  return adUnits.filter(adUnit => (adUnit.divID && adUnit.divID === adUnitId) || (adUnit.code === adUnitId))[0];
 }
 
 function getTgId() {
@@ -513,7 +513,7 @@ function executeBidsLoggerCall(e, highestCpmBids) {
       'mt': getAdUnitAdFormats(origAdUnit),
       'sz': getSizesForAdUnit(adUnit, adUnitId),
       'ps': gatherPartnerBidsForAdUnitForLogger(adUnit, adUnitId, highestCpmBids.filter(bid => bid.adUnitCode === adUnitId), e),
-      'fskp': floorData && floorFetchStatus ? (floorData.floorRequestData ? (floorData.floorRequestData.skipped == false ? 0 : 1) : undefined) : undefined,
+      'fskp': floorData && floorFetchStatus ? (floorData.floorRequestData ? (floorData.floorRequestData.skipped === false ? 0 : 1) : undefined) : undefined,
       'sid': generateUUID()
     };
     slotsArray.push(slotObject);
@@ -558,7 +558,7 @@ function executeBidWonLoggerCall(auctionId, adUnitId) {
   const wiid = cache.auctions[auctionId]?.wiid || auctionId;
   const referrer = config.getConfig('pageUrl') || cache.auctions[auctionId]?.referer || '';
   const adv = winningBid.bidResponse ? getAdDomain(winningBid.bidResponse) || undefined : undefined;
-  const fskp = floorData ? (floorData.floorRequestData ? (floorData.floorRequestData.skipped == false ? 0 : 1) : undefined) : undefined;
+  const fskp = floorData ? (floorData.floorRequestData ? (floorData.floorRequestData.skipped === false ? 0 : 1) : undefined) : undefined;
   const pg = window.parseFloat(Number(winningBid?.bidResponse?.adserverTargeting?.hb_pb || winningBid?.bidResponse?.adserverTargeting?.pwtpb)) || undefined;
   let pixelURL = END_POINT_WIN_BID_LOGGER;
 
@@ -593,7 +593,7 @@ function executeBidWonLoggerCall(auctionId, adUnitId) {
   adv && (pixelURL += '&adv=' + enc(adv));
   pixelURL += '&orig=' + enc(getDomainFromUrl(referrer));
   pixelURL += '&ss=' + enc(isS2SBidder(winningBid.bidder));
-  (fskp != undefined) && (pixelURL += '&fskp=' + enc(fskp));
+  (fskp !== undefined) && (pixelURL += '&fskp=' + enc(fskp));
   if (floorData) {
     const floorRootValues = getFloorsCommonField(floorData.floorRequestData);
     if (floorRootValues) {

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -314,9 +314,9 @@ const setFloorInImp = (imp, bid) => {
 const updateBannerImp = (bannerObj, adSlot) => {
   const slot = adSlot.split(':');
   let splits = slot[0]?.split('@');
-  splits = splits?.length == 2 ? splits[1].split('x') : splits.length == 3 ? splits[2].split('x') : [];
+  splits = splits?.length === 2 ? splits[1].split('x') : splits.length === 3 ? splits[2].split('x') : [];
   const primarySize = bannerObj.format[0];
-  if (splits.length !== 2 || (parseInt(splits[0]) == 0 && parseInt(splits[1]) == 0)) {
+  if (splits.length !== 2 || (parseInt(splits[0]) === 0 && parseInt(splits[1]) === 0)) {
     bannerObj.w = primarySize.w;
     bannerObj.h = primarySize.h;
   } else {
@@ -461,7 +461,7 @@ const updateResponseWithCustomFields = (res, bid, ctx) => {
   res.pm_dspid = bid.ext?.dspid ? bid.ext.dspid : null;
   res.pm_seat = seatbid.seat;
   if (!res.creativeId) res.creativeId = bid.id;
-  if (res.ttl == DEFAULT_TTL) res.ttl = MEDIATYPE_TTL[res.mediaType];
+  if (res.ttl === DEFAULT_TTL) res.ttl = MEDIATYPE_TTL[res.mediaType];
   if (bid.dealid) {
     res.dealChannel = bid.ext?.deal_channel ? dealChannel[bid.ext.deal_channel] || null : 'PMP';
   }
@@ -531,7 +531,7 @@ const addExtenstionParams = (req) => {
  */
 const assignDealTier = (bid, context, maxduration) => {
   if (!bid?.ext?.prebiddealpriority || !FEATURES.VIDEO) return;
-  if (context != ADPOD) return;
+  if (context !== ADPOD) return;
 
   const duration = bid?.ext?.video?.duration || maxduration;
   // if (!duration) return;

--- a/modules/pwbidBidAdapter.js
+++ b/modules/pwbidBidAdapter.js
@@ -218,7 +218,7 @@ export const spec = {
     });
 
     // no payload imps, no rason to continue
-    if (payload.imp.length == 0) {
+    if (payload.imp.length === 0) {
       return;
     }
 
@@ -380,7 +380,7 @@ export const spec = {
 
 function _checkMediaType(bid, newBid) {
   // Check Various ADM Aspects to Determine Media Type
-  if (bid.ext && bid.ext['bidtype'] != undefined) {
+  if (bid.ext && bid.ext['bidtype'] !== undefined) {
     // this is the most explicity check
     newBid.mediaType = MEDIATYPE[bid.ext.bidtype];
   } else {
@@ -513,7 +513,7 @@ function _createOrtbTemplate(conf) {
     device: {
       ua: navigator.userAgent,
       js: 1,
-      dnt: (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') ? 1 : 0,
+      dnt: (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1') ? 1 : 0,
       h: screen.height,
       w: screen.width,
       language: navigator.language,
@@ -672,7 +672,7 @@ function _addFloorFromFloorModule(impObj, bid) {
         const floorInfo = bid.getFloor({ currency: impObj.bidFloorCur, mediaType: mediaType, size: '*' });
         if (isPlainObject(floorInfo) && floorInfo.currency === impObj.bidFloorCur && !isNaN(parseInt(floorInfo.floor))) {
           const mediaTypeFloor = parseFloat(floorInfo.floor);
-          bidFloor = (bidFloor == -1 ? mediaTypeFloor : Math.min(mediaTypeFloor, bidFloor))
+          bidFloor = (bidFloor === -1 ? mediaTypeFloor : Math.min(mediaTypeFloor, bidFloor))
         }
       }
     });
@@ -803,13 +803,13 @@ function _createNativeRequest(params) {
   NATIVE_MINIMUM_REQUIRED_IMAGE_ASSETS.forEach(ele => {
     var lengthOfExistingAssets = nativeRequestObject.assets.length;
     for (var i = 0; i < lengthOfExistingAssets; i++) {
-      if (ele.id == nativeRequestObject.assets[i].id) {
+      if (ele.id === nativeRequestObject.assets[i].id) {
         presentrequiredAssetCount++;
         break;
       }
     }
   });
-  if (requiredAssetCount == presentrequiredAssetCount) {
+  if (requiredAssetCount === presentrequiredAssetCount) {
     isInvalidNativeRequest = false;
   } else {
     isInvalidNativeRequest = true;
@@ -937,7 +937,7 @@ function _isNonEmptyArray(test) {
  * @returns
  */
 function _getEndpointURL(bid) {
-  if (!isEmptyStr(bid?.params?.endpoint_url) && bid?.params?.endpoint_url != UNDEFINED) {
+  if (!isEmptyStr(bid?.params?.endpoint_url) && bid?.params?.endpoint_url !== UNDEFINED) {
     return bid.params.endpoint_url;
   }
 


### PR DESCRIPTION
## Summary
- clean up eqeqeq errors in Pubmatic adapters

## Testing
- `npx eslint --cache --cache-strategy content modules/pubmaticAnalyticsAdapter.js modules/pubmaticBidAdapter.js modules/pwbidBidAdapter.js`
- `npx gulp test --file test/spec/modules/pubmaticAnalyticsAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/pubmaticBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/pwbidBidAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_687569f66610832b8e3e86044a13465e