### PR TITLE
Tests: fix eqeqeq linting

### DIFF
--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -661,7 +661,7 @@ describe('weboramaRtdProvider', function() {
             'other': false,
           },
           'callback': (bid) => {
-            return bid.bidder == 'appnexus'
+            return bid.bidder === 'appnexus'
           },
         };
 
@@ -755,7 +755,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
+              if (v === 'appnexus') {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   site: {
                     ext: {
@@ -787,7 +787,7 @@ describe('weboramaRtdProvider', function() {
             'appnexus': ['adunit1']
           },
           'callback': (bid, adUnitCode) => {
-            return bid.bidder == 'appnexus' && adUnitCode == 'adunit1';
+            return bid.bidder === 'appnexus' && adUnitCode === 'adunit1';
           },
         };
 
@@ -1044,7 +1044,7 @@ describe('weboramaRtdProvider', function() {
         const testcases = {
           'array with one unit': ['adunit1'],
           'callback': (adUnitCode) => {
-            return adUnitCode == 'adunit1';
+            return adUnitCode === 'adunit1';
           },
         };
 
@@ -1452,13 +1452,13 @@ describe('weboramaRtdProvider', function() {
               token: 'foo',
               targetURL: 'https://prebid.org',
               setPrebidTargeting: (adUnitCode, data, meta) => {
-                if (adUnitCode == 'adunit1') {
+                if (adUnitCode === 'adunit1') {
                   data['webo_foo'] = ['bar'];
                 }
                 return true;
               },
               sendToBidders: (bid, adUnitCode, data, meta) => {
-                if (bid.bidder == 'appnexus' && adUnitCode == 'adunit1') {
+                if (bid.bidder === 'appnexus' && adUnitCode === 'adunit1') {
                   data['webo_bar'] = ['baz'];
                 }
                 return true;
@@ -1546,7 +1546,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
+          if (v === 'appnexus') {
             expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
               site: {
                 ext: {
@@ -1692,7 +1692,7 @@ describe('weboramaRtdProvider', function() {
             'other': false,
           },
           'callback': (bid) => {
-            return bid.bidder == 'appnexus'
+            return bid.bidder === 'appnexus'
           },
         };
 
@@ -1786,7 +1786,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
+              if (v === 'appnexus') {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   user: {
                     ext: {
@@ -1818,7 +1818,7 @@ describe('weboramaRtdProvider', function() {
             'appnexus': ['adunit1']
           },
           'callback': (bid, adUnitCode) => {
-            return bid.bidder == 'appnexus' && adUnitCode == 'adunit1';
+            return bid.bidder === 'appnexus' && adUnitCode === 'adunit1';
           },
         };
 
@@ -1911,7 +1911,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
+              if (v === 'appnexus') {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   user: {
                     ext: {
@@ -2091,7 +2091,7 @@ describe('weboramaRtdProvider', function() {
         const testcases = {
           'array with one unit': ['adunit1'],
           'callback': (adUnitCode) => {
-            return adUnitCode == 'adunit1';
+              return adUnitCode === 'adunit1';
           },
         };
 
@@ -2639,13 +2639,13 @@ describe('weboramaRtdProvider', function() {
               accoundId: 12345,
               targetURL: 'https://prebid.org',
               setPrebidTargeting: (adUnitCode, data, meta) => {
-                if (adUnitCode == 'adunit1') {
+                if (adUnitCode === 'adunit1') {
                   data['webo_foo'] = ['bar'];
                 }
                 return true;
               },
               sendToBidders: (bid, adUnitCode, data, meta) => {
-                if (bid.bidder == 'appnexus' && adUnitCode == 'adunit1') {
+                if (bid.bidder === 'appnexus' && adUnitCode === 'adunit1') {
                   data['webo_bar'] = ['baz'];
                 }
                 return true;
@@ -2735,7 +2735,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
+          if (v === 'appnexus') {
             expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
               user: {
                 ext: {
@@ -2874,7 +2874,7 @@ describe('weboramaRtdProvider', function() {
             'other': false,
           },
           'callback': (bid) => {
-            return bid.bidder == 'appnexus'
+            return bid.bidder === 'appnexus'
           },
         };
 
@@ -2967,7 +2967,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
+              if (v === 'appnexus') {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   site: {
                     ext: {
@@ -3000,7 +3000,7 @@ describe('weboramaRtdProvider', function() {
             'appnexus': ['adunit1']
           },
           'callback': (bid, adUnitCode) => {
-            return bid.bidder == 'appnexus' && adUnitCode == 'adunit1';
+            return bid.bidder === 'appnexus' && adUnitCode === 'adunit1';
           },
         };
 
@@ -3096,7 +3096,7 @@ describe('weboramaRtdProvider', function() {
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
+              if (v === 'appnexus') {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   site: {
                     ext: {
@@ -3272,7 +3272,7 @@ describe('weboramaRtdProvider', function() {
         const testcases = {
           'array with one unit': ['adunit1'],
           'callback': (adUnitCode) => {
-            return adUnitCode == 'adunit1';
+            return adUnitCode === 'adunit1';
           },
         };
 
@@ -3828,13 +3828,13 @@ describe('weboramaRtdProvider', function() {
             sfbxLiteDataConf: {
               targetURL: 'https://prebid.org',
               setPrebidTargeting: (adUnitCode, data, meta) => {
-                if (adUnitCode == 'adunit1') {
+                if (adUnitCode === 'adunit1') {
                   data['lito_foo'] = ['bar'];
                 }
                 return true;
               },
               sendToBidders: (bid, adUnitCode, data, meta) => {
-                if (bid.bidder == 'appnexus' && adUnitCode == 'adunit1') {
+                if (bid.bidder === 'appnexus' && adUnitCode === 'adunit1') {
                   data['lito_bar'] = ['baz'];
                 }
                 return true;
@@ -3924,7 +3924,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
+          if (v === 'appnexus') {
             expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
               site: {
                 ext: {

--- a/test/spec/modules/yahooAdsBidAdapter_spec.js
+++ b/test/spec/modules/yahooAdsBidAdapter_spec.js
@@ -270,9 +270,9 @@ describe('Yahoo Advertising Bid Adapter:', () => {
       let iframeCount = 0;
       let imageCount = 0;
       pixelObjects.forEach(pixelObject => {
-        if (pixelObject.type == 'iframe') {
+        if (pixelObject.type === 'iframe') {
           iframeCount++;
-        } else if (pixelObject.type == 'image') {
+        } else if (pixelObject.type === 'image') {
           imageCount++;
         }
       });

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -519,7 +519,7 @@ describe('targeting tests', function () {
         });
 
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
-        const limitedBids = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') != -1)
+        const limitedBids = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') !== -1)
 
         expect(limitedBids.length).to.equal(1);
       });
@@ -532,7 +532,7 @@ describe('targeting tests', function () {
         });
 
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
-        const limitedBids = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') != -1)
+        const limitedBids = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') !== -1)
 
         expect(limitedBids.length).to.equal(2);
       });
@@ -545,7 +545,7 @@ describe('targeting tests', function () {
         });
 
         const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
-        const limitedBids = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') != -1)
+        const limitedBids = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') !== -1)
 
         expect(limitedBids.length).to.equal(2);
       });
@@ -1003,7 +1003,7 @@ describe('targeting tests', function () {
       // we should only get the targeting data for the one requested adunit
       expect(Object.keys(targeting).length).to.equal(1);
 
-      const sendAllBidCpm = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') != -1)
+      const sendAllBidCpm = Object.keys(targeting['/123456/header-bid-tag-0']).filter(key => key.indexOf(TARGETING_KEYS.PRICE_BUCKET + '_') !== -1)
       // we shouldn't get more than 1 key for hb_pb_${bidder}
       expect(sendAllBidCpm.length).to.equal(1);
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2967,7 +2967,7 @@ describe('Unit: Prebid Module', function () {
           });
           return (req.bids.length > 0) ? req : undefined;
         }).filter((item) => {
-          return item != undefined;
+          return item !== undefined;
         });
       };
       auction1.getBidsReceived = function() {
@@ -2983,7 +2983,7 @@ describe('Unit: Prebid Module', function () {
           });
           return (req.bids.length > 0) ? req : undefined;
         }).filter((item) => {
-          return item != undefined;
+          return item !== undefined;
         });
       };
       auction2.getBidsReceived = function() {


### PR DESCRIPTION
## Summary
- use strict equality comparisons in various unit tests

## Testing
- `npx eslint --cache --cache-strategy content test/spec/modules/weboramaRtdProvider_spec.js test/spec/modules/yahooAdsBidAdapter_spec.js test/spec/unit/core/targeting_spec.js test/spec/unit/pbjs_api_spec.js`
- `npx gulp test --file test/spec/modules/weboramaRtdProvider_spec.js --nolint`
- `npx gulp test --file test/spec/modules/yahooAdsBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/unit/core/targeting_spec.js --nolint`
- `npx gulp test --file test/spec/unit/pbjs_api_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_68756a485de8832b9694fdf22d66a675