### PR TITLE
Multiple Adapters: fix eqeqeq linting

### DIFF
--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -57,7 +57,7 @@ MACRO['targetelt'] = function(b, c) {
   return c.toselector(b);
 };
 MACRO['creatype'] = function(b, c) {
-  return b.mediaType == 'video' ? ADLOOX_MEDIATYPE.VIDEO : ADLOOX_MEDIATYPE.DISPLAY;
+  return b.mediaType === 'video' ? ADLOOX_MEDIATYPE.VIDEO : ADLOOX_MEDIATYPE.DISPLAY;
 };
 MACRO['pageurl'] = function(b, c) {
   const refererInfo = getRefererInfo();
@@ -224,7 +224,7 @@ analyticsAdapter.url = function(url, args, bid) {
 
 const preloaded = {};
 analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = function(auctionDetails) {
-  if (!(auctionDetails.auctionStatus == AUCTION_COMPLETED && auctionDetails.bidsReceived.length > 0)) return;
+  if (!(auctionDetails.auctionStatus === AUCTION_COMPLETED && auctionDetails.bidsReceived.length > 0)) return;
 
   const uri = parseUrl(analyticsAdapter.url(`${analyticsAdapter.context.js}#`));
   const href = `${uri.protocol}://${uri.host}${uri.pathname}`;

--- a/modules/adtrueBidAdapter.js
+++ b/modules/adtrueBidAdapter.js
@@ -95,7 +95,7 @@ function _generateGUID() {
   var guid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
     var r = (d + Math.random() * 16) % 16 | 0;
     d = Math.floor(d / 16);
-    return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
   })
   return guid;
 }
@@ -168,7 +168,7 @@ function _createOrtbTemplate(conf) {
       ua: navigator.userAgent,
       os: platform,
       js: 1,
-      dnt: (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') ? 1 : 0,
+      dnt: (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1') ? 1 : 0,
       h: screen.height,
       w: screen.width,
       language: _getLanguage(),
@@ -483,7 +483,7 @@ export const spec = {
         payload.imp.push(impObj);
       }
     });
-    if (payload.imp.length == 0) {
+    if (payload.imp.length === 0) {
       return;
     }
     publisherId = conf.pubId.trim();

--- a/modules/adxpremiumAnalyticsAdapter.js
+++ b/modules/adxpremiumAnalyticsAdapter.js
@@ -179,7 +179,7 @@ function bidTimeout(args) {
   args.forEach(bid => {
     const pulledRequestId = bidMapper[bid.bidId];
     const eventIndex = bidRequestsMapper[pulledRequestId];
-    if (eventIndex !== undefined && completeObject.events[eventIndex] && usedRequestIds.indexOf(pulledRequestId) == -1) {
+    if (eventIndex !== undefined && completeObject.events[eventIndex] && usedRequestIds.indexOf(pulledRequestId) === -1) {
       // mark as timeouted
       const tempEventIndex = timeoutObject.events.push(completeObject.events[eventIndex]) - 1;
       timeoutObject.events[tempEventIndex]['type'] = 'TIMEOUT';
@@ -211,7 +211,7 @@ function deviceType() {
 
 function clearSlot(elementId) {
   if (elementIds.includes(elementId)) { elementIds.splice(elementIds.indexOf(elementId), 1); logInfo('AdxPremium Analytics - Done with: ' + elementId); }
-  if (elementIds.length == 0 && !requestSent && !timeoutBased) {
+  if (elementIds.length === 0 && !requestSent && !timeoutBased) {
     requestSent = true;
     sendEvent(completeObject);
     logInfo('AdxPremium Analytics - Everything ready');

--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -64,12 +64,12 @@ export const spec = {
       }
 
       var targetKey = 0;
-      if (bySlotTargetKey[bidReq.adUnitCode] != undefined) {
+      if (bySlotTargetKey[bidReq.adUnitCode] !== undefined) {
         targetKey = bySlotTargetKey[bidReq.adUnitCode];
       } else {
         var biggestSize = _getBiggestSize(bidReq.sizes);
         if (biggestSize) {
-          if (bySlotSizesCount[biggestSize] != undefined) {
+          if (bySlotSizesCount[biggestSize] !== undefined) {
             bySlotSizesCount[biggestSize]++
             targetKey = bySlotSizesCount[biggestSize];
           } else {
@@ -260,19 +260,19 @@ function _getBiggestSize(sizes) {
 
 function _getDoNotTrack() {
   try {
-    if (window.top.doNotTrack && window.top.doNotTrack == '1') {
+    if (window.top.doNotTrack && window.top.doNotTrack === '1') {
       return 1;
     }
   } catch (e) { }
 
   try {
-    if (navigator.doNotTrack && (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1')) {
+    if (navigator.doNotTrack && (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1')) {
       return 1;
     }
   } catch (e) { }
 
   try {
-    if (navigator.msDoNotTrack && navigator.msDoNotTrack == '1') {
+    if (navigator.msDoNotTrack && navigator.msDoNotTrack === '1') {
       return 1;
     }
   } catch (e) { }

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -369,9 +369,9 @@ export const spec = {
         if (!eid || !eid.uids || eid.uids.length < 1) { return; }
         eid.uids.forEach(uid => {
           const tmp = {'source': eid.source, 'id': uid.id};
-          if (eid.source == 'adserver.org') {
+          if (eid.source === 'adserver.org') {
             tmp.rti_partner = 'TDID';
-          } else if (eid.source == 'uidapi.com') {
+          } else if (eid.source === 'uidapi.com') {
             tmp.rti_partner = 'UID2';
           }
           eids.push(tmp);
@@ -395,7 +395,7 @@ export const spec = {
       if (isArray(pubDsaObj.transparency) && pubDsaObj.transparency.every((v) => isPlainObject(v))) {
         const tpData = [];
         pubDsaObj.transparency.forEach((tpObj) => {
-          if (isStr(tpObj.domain) && tpObj.domain != '' && isArray(tpObj.dsaparams) && tpObj.dsaparams.every((v) => isNumber(v))) {
+          if (isStr(tpObj.domain) && tpObj.domain !== '' && isArray(tpObj.dsaparams) && tpObj.dsaparams.every((v) => isNumber(v))) {
             tpData.push(tpObj);
           }
         });
@@ -675,7 +675,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     }
 
     let jsTrackers = nativeAd.javascript_trackers;
-    if (jsTrackers == undefined) {
+    if (jsTrackers === undefined) {
       jsTrackers = viewScript;
     } else if (isStr(jsTrackers)) {
       jsTrackers = [jsTrackers, viewScript];

--- a/modules/bmtmBidAdapter.js
+++ b/modules/bmtmBidAdapter.js
@@ -17,7 +17,7 @@ export const spec = {
     if (bid.bidId && bid.bidder && bid.params && bid.params.placement_id) {
       return true;
     }
-    if (bid.params.placement_id == 0 && bid.params.test === 1) {
+    if (bid.params.placement_id === 0 && bid.params.test === 1) {
       return true;
     }
     return false;
@@ -180,14 +180,14 @@ function buildDevice() {
     h: window.top.screen.height,
     js: 1,
     language: navigator.language,
-    dnt: navigator.doNotTrack === 'yes' || navigator.doNotTrack == '1' ||
-      navigator.msDoNotTrack == '1' ? 1 : 0,
+    dnt: navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' ||
+      navigator.msDoNotTrack === '1' ? 1 : 0,
   }
 }
 
 function buildRegs(bidderRequest) {
   const regs = {
-    coppa: config.getConfig('coppa') == true ? 1 : 0,
+    coppa: config.getConfig('coppa') === true ? 1 : 0,
   };
 
   if (bidderRequest && bidderRequest.gdprConsent) {

--- a/modules/bucksenseBidAdapter.js
+++ b/modules/bucksenseBidAdapter.js
@@ -98,7 +98,7 @@ export const spec = {
       var sAd = oResponse.ad || '';
       var sAdomains = oResponse.adomains || [];
 
-      if (request && sRequestID.length == 0) {
+      if (request && sRequestID.length === 0) {
         logInfo(WHO + ' interpretResponse() - use RequestID from Placments');
         sRequestID = request.data.bid_id || '';
       }

--- a/modules/chtnwBidAdapter.js
+++ b/modules/chtnwBidAdapter.js
@@ -29,7 +29,7 @@ export const spec = {
   },
   buildRequests: function(validBidRequests = [], bidderRequest = {}) {
     validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
-    const chtnwId = (storage.getCookie(COOKIE_NAME) != undefined) ? storage.getCookie(COOKIE_NAME) : generateUUID();
+    const chtnwId = (storage.getCookie(COOKIE_NAME) !== undefined) ? storage.getCookie(COOKIE_NAME) : generateUUID();
     if (storage.cookiesAreEnabled()) {
       storage.setCookie(COOKIE_NAME, chtnwId);
     }

--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -40,7 +40,7 @@ export const spec = {
       url: bidderRequest.refererInfo?.page,
       referrer: bidderRequest.refererInfo?.ref,
       screensize: getScreenSize(),
-      dnt: (navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1') ? 1 : 0,
+      dnt: (navigator.doNotTrack === 'yes' || navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1') ? 1 : 0,
       language: navigator.language,
       ua: navigator.userAgent,
       pversion: '$prebid.version$',
@@ -195,7 +195,7 @@ export const spec = {
     const pixelType = syncOptions.iframeEnabled ? 'iframe' : 'image';
     let syncEndpoint;
 
-    if (pixelType == 'iframe') {
+    if (pixelType === 'iframe') {
       syncEndpoint = 'https://sync.connectad.io/iFrameSyncer?';
     } else {
       syncEndpoint = 'https://sync.connectad.io/ImageSyncer?';

--- a/modules/cpmstarBidAdapter.js
+++ b/modules/cpmstarBidAdapter.js
@@ -28,15 +28,15 @@ export const spec = {
   pageID: Math.floor(Math.random() * 10e6),
 
   getMediaType: function (bidRequest) {
-    if (bidRequest == null) return BANNER;
+    if (bidRequest === null) return BANNER;
     return !utils.deepAccess(bidRequest, 'mediaTypes.video') ? BANNER : VIDEO;
   },
 
   getPlayerSize: function (bidRequest) {
     var playerSize = utils.deepAccess(bidRequest, 'mediaTypes.video.playerSize');
-    if (playerSize == null) return [640, 440];
-    if (playerSize[0] != null) playerSize = playerSize[0];
-    if (playerSize == null || playerSize[0] == null || playerSize[1] == null) return [640, 440];
+    if (playerSize === null) return [640, 440];
+    if (playerSize[0] !== null) playerSize = playerSize[0];
+    if (playerSize === null || playerSize[0] === null || playerSize[1] === null) return [640, 440];
     return playerSize;
   },
 
@@ -51,13 +51,13 @@ export const spec = {
       var bidRequest = validBidRequests[i];
       const referer = bidderRequest.refererInfo.page ? bidderRequest.refererInfo.page : bidderRequest.refererInfo.domain;
       const e = utils.getBidIdParameter('endpoint', bidRequest.params);
-      const ENDPOINT = e == 'dev' ? ENDPOINT_DEV : e == 'staging' ? ENDPOINT_STAGING : ENDPOINT_PRODUCTION;
+      const ENDPOINT = e === 'dev' ? ENDPOINT_DEV : e === 'staging' ? ENDPOINT_STAGING : ENDPOINT_PRODUCTION;
       const url = new URL(ENDPOINT);
       const body = {};
       const mediaType = spec.getMediaType(bidRequest);
       const playerSize = spec.getPlayerSize(bidRequest);
       url.searchParams.set('media', mediaType);
-      if (mediaType == VIDEO) {
+      if (mediaType === VIDEO) {
         url.searchParams.set('fv', 0);
         if (playerSize) {
           url.searchParams.set('w', playerSize?.[0]);
@@ -109,9 +109,9 @@ export const spec = {
       if (adUnitCode) {
         body.adUnitCode = adUnitCode;
       }
-      if (mediaType == VIDEO) {
+      if (mediaType === VIDEO) {
         body.video = utils.deepAccess(bidRequest, 'mediaTypes.video');
-      } else if (mediaType == BANNER) {
+      } else if (mediaType === BANNER) {
         body.banner = utils.deepAccess(bidRequest, 'mediaTypes.banner');
       }
 
@@ -171,11 +171,11 @@ export const spec = {
         bidResponse.dealId = rawBid.dealId;
       }
 
-      if (mediaType == BANNER && rawBid.code) {
+      if (mediaType === BANNER && rawBid.code) {
         bidResponse.ad = rawBid.code + (rawBid.px_cr ? "\n<img width=0 height=0 src='" + rawBid.px_cr + "' />" : '');
-      } else if (mediaType == VIDEO && rawBid.creativemacros && rawBid.creativemacros.HTML5VID_VASTSTRING) {
+      } else if (mediaType === VIDEO && rawBid.creativemacros && rawBid.creativemacros.HTML5VID_VASTSTRING) {
         var playerSize = spec.getPlayerSize(bidRequest);
-        if (playerSize != null) {
+        if (playerSize !== null) {
           bidResponse.width = playerSize[0];
           bidResponse.height = playerSize[1];
         }
@@ -193,12 +193,12 @@ export const spec = {
 
   getUserSyncs: function (syncOptions, serverResponses) {
     const syncs = [];
-    if (serverResponses.length == 0 || !serverResponses[0].body) return syncs;
+    if (serverResponses.length === 0 || !serverResponses[0].body) return syncs;
     var usersyncs = serverResponses[0].body[0].syncs;
     if (!usersyncs || usersyncs.length < 0) return syncs;
     for (var i = 0; i < usersyncs.length; i++) {
       var us = usersyncs[i];
-      if ((us.type === 'image' && syncOptions.pixelEnabled) || (us.type == 'iframe' && syncOptions.iframeEnabled)) {
+      if ((us.type === 'image' && syncOptions.pixelEnabled) || (us.type === 'iframe' && syncOptions.iframeEnabled)) {
         syncs.push(us);
       }
     }

--- a/modules/dailyhuntBidAdapter.js
+++ b/modules/dailyhuntBidAdapter.js
@@ -307,7 +307,7 @@ const getQueryVariable = (variable) => {
   const vars = query.split('&');
   for (var i = 0; i < vars.length; i++) {
     const pair = vars[i].split('=');
-    if (decodeURIComponent(pair[0]) == variable) {
+    if (decodeURIComponent(pair[0]) === variable) {
       return decodeURIComponent(pair[1]);
     }
   }

--- a/modules/dataControllerModule/index.js
+++ b/modules/dataControllerModule/index.js
@@ -36,7 +36,7 @@ function containsConfiguredEIDS(eidSourcesMap, bidderCode) {
     return true;
   }
   const bidderEIDs = eidSourcesMap.get(bidderCode);
-  if (bidderEIDs == undefined) {
+  if (bidderEIDs === undefined) {
     return false;
   }
   let containsEIDs = false;
@@ -57,7 +57,7 @@ function containsConfiguredSDA(segementMap, bidderCode) {
 
 function hasValue(bidderSegement) {
   let containsSDA = false;
-  if (bidderSegement == undefined) {
+  if (bidderSegement === undefined) {
     return false;
   }
   _dataControllerConfig.filterEIDwhenSDA.some(segment => {

--- a/modules/datawrkzBidAdapter.js
+++ b/modules/datawrkzBidAdapter.js
@@ -39,7 +39,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function(bid) {
-    return !!(bid.params && bid.params.site_id && (deepAccess(bid, 'mediaTypes.video.context') != 'adpod'));
+    return !!(bid.params && bid.params.site_id && (deepAccess(bid, 'mediaTypes.video.context') !== 'adpod'));
   },
 
   /**
@@ -55,7 +55,7 @@ export const spec = {
     if (validBidRequests.length > 0) {
       validBidRequests.forEach(bidRequest => {
         if (!bidRequest.mediaTypes) return;
-        if (bidRequest.mediaTypes.banner && ((bidRequest.mediaTypes.banner.sizes && bidRequest.mediaTypes.banner.sizes.length != 0) ||
+        if (bidRequest.mediaTypes.banner && ((bidRequest.mediaTypes.banner.sizes && bidRequest.mediaTypes.banner.sizes.length !== 0) ||
           (bidRequest.sizes))) {
           requests.push(buildBannerRequest(bidRequest, bidderRequest));
         } else if (bidRequest.mediaTypes.native) {
@@ -85,11 +85,11 @@ export const spec = {
       return [];
     }
 
-    if (getMediaTypeOfResponse(bidRequest) == BANNER) {
+    if (getMediaTypeOfResponse(bidRequest) === BANNER) {
       bidResponses = buildBannerResponse(bidRequest, bidResponse);
-    } else if (getMediaTypeOfResponse(bidRequest) == NATIVE) {
+    } else if (getMediaTypeOfResponse(bidRequest) === NATIVE) {
       bidResponses = buildNativeResponse(bidRequest, bidResponse);
-    } else if (getMediaTypeOfResponse(bidRequest) == VIDEO) {
+    } else if (getMediaTypeOfResponse(bidRequest) === VIDEO) {
       bidResponses = buildVideoResponse(bidRequest, bidResponse);
     }
     return bidResponses;
@@ -233,7 +233,7 @@ function buildVideoRequest(bidRequest, bidderRequest) {
   };
 
   const context = deepAccess(bidRequest, 'mediaTypes.video.context');
-  if (context == 'outstream' && !bidRequest.renderer) video.mimes = OUTSTREAM_MIMES;
+  if (context === 'outstream' && !bidRequest.renderer) video.mimes = OUTSTREAM_MIMES;
 
   var imp = [];
   var deals = [];
@@ -241,7 +241,7 @@ function buildVideoRequest(bidRequest, bidderRequest) {
     deals = bidRequest.params.deals;
   }
 
-  if (context != 'adpod') {
+  if (context !== 'adpod') {
     imp.push({
       id: bidRequest.bidId,
       video: video,
@@ -282,9 +282,9 @@ function getVideoAdUnitSize(bidRequest) {
 
 /* Get mediatype of the adunit from request */
 function getMediaTypeOfResponse(bidRequest) {
-  if (bidRequest.requestedMediaType == BANNER) return BANNER;
-  else if (bidRequest.requestedMediaType == NATIVE) return NATIVE;
-  else if (bidRequest.requestedMediaType == VIDEO) return VIDEO;
+  if (bidRequest.requestedMediaType === BANNER) return BANNER;
+  else if (bidRequest.requestedMediaType === NATIVE) return NATIVE;
+  else if (bidRequest.requestedMediaType === VIDEO) return VIDEO;
   else return '';
 }
 
@@ -341,8 +341,8 @@ function generateNativeImgObj(obj, type, id) {
   const bidSizes = obj.sizes;
 
   var typeId;
-  if (type == 'icon') typeId = 1;
-  else if (type == 'image') typeId = 3;
+  if (type === 'icon') typeId = 1;
+  else if (type === 'image') typeId = 3;
 
   if (isArray(bidSizes)) {
     if (bidSizes.length === 2 && typeof bidSizes[0] === 'number' && typeof bidSizes[1] === 'number') {
@@ -396,7 +396,7 @@ function generateNativeDataObj(obj, type, id) {
   const data = {
     type: typeId
   };
-  if (typeId == 2 && obj.len) {
+  if (typeId === 2 && obj.len) {
     data.len = parseInt(obj.len);
   }
   return {
@@ -558,8 +558,8 @@ function setTargeting(query) {
 /* Get image type with respect to the id */
 function getAssetImageType(id, assets) {
   for (var i = 0; i < assets.length; i++) {
-    if (assets[i].id == id) {
-      if (assets[i].img.type == 1) { return 'icon'; } else if (assets[i].img.type == 3) { return 'image'; }
+    if (assets[i].id === id) {
+      if (assets[i].img.type === 1) { return 'icon'; } else if (assets[i].img.type === 3) { return 'image'; }
     }
   }
   return '';
@@ -568,8 +568,8 @@ function getAssetImageType(id, assets) {
 /* Get type of data asset with respect to the id */
 function getAssetDataType(id, assets) {
   for (var i = 0; i < assets.length; i++) {
-    if (assets[i].id == id) {
-      if (assets[i].data.type == 1) { return 'sponsored'; } else if (assets[i].data.type == 2) { return 'desc'; } else if (assets[i].data.type == 12) { return 'cta'; }
+    if (assets[i].id === id) {
+      if (assets[i].data.type === 1) { return 'sponsored'; } else if (assets[i].data.type === 2) { return 'desc'; } else if (assets[i].data.type === 12) { return 'cta'; }
     }
   }
   return '';

--- a/modules/dchain.ts
+++ b/modules/dchain.ts
@@ -108,7 +108,7 @@ function isValidDchain(bid) {
   let mode: string = MODE.STRICT;
   const dchainConfig = config.getConfig('dchain');
 
-  if (dchainConfig && isStr(dchainConfig.validation) && MODES.indexOf(dchainConfig.validation) != -1) {
+  if (dchainConfig && isStr(dchainConfig.validation) && MODES.indexOf(dchainConfig.validation) !== -1) {
     mode = dchainConfig.validation;
   }
 


### PR DESCRIPTION
## Summary
- address `eqeqeq` lint violations across multiple adapter modules
- ESLint passes for updated files
- unit tests fail due to environment issues

## Testing
- `npx eslint modules/adlooxAnalyticsAdapter.js modules/adtrueBidAdapter.js modules/adxpremiumAnalyticsAdapter.js modules/apacdexBidAdapter.js modules/appnexusBidAdapter.js modules/bmtmBidAdapter.js modules/bucksenseBidAdapter.js modules/chtnwBidAdapter.js modules/connectadBidAdapter.js modules/cpmstarBidAdapter.js modules/dailyhuntBidAdapter.js modules/dataControllerModule/index.js modules/datawrkzBidAdapter.js modules/dchain.ts --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/adlooxAnalyticsAdapter_spec.js --nolint` *(fails: Karma tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_68756960a028832b93c2e9c26fe83cd4