### PR TITLE
Bid adapters: fix eqeqeq lint errors

### DIFF
--- a/modules/distroscaleBidAdapter.js
+++ b/modules/distroscaleBidAdapter.js
@@ -72,7 +72,7 @@ function _createImpressionObject(bid) {
       addSize(bid.mediaTypes[BANNER].sizes[i]);
     }
   }
-  if (sizesCount == 0) {
+  if (sizesCount === 0) {
     logWarn(LOG_WARN_PREFIX + 'Error: missing sizes: ' + bid.params.adUnit + '. Ignoring the banner impression in the adunit.');
   } else {
     // Use the first preferred size
@@ -140,7 +140,7 @@ export const spec = {
         if (win.vx.cs_loaded) {
           dsloaded = 1;
         }
-        if (win != win.parent) {
+        if (win !== win.parent) {
           win = win.parent;
         } else {
           break;
@@ -163,7 +163,7 @@ export const spec = {
         h: screen.height,
         w: screen.width,
         language: (navigator.language && navigator.language.replace(/-.*/, '')) || 'en',
-        dnt: (navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1' || navigator.doNotTrack == 'yes') ? 1 : 0
+        dnt: (navigator.doNotTrack === '1' || navigator.msDoNotTrack === '1' || navigator.doNotTrack === 'yes') ? 1 : 0
       },
       imp: [],
       user: {},
@@ -180,7 +180,7 @@ export const spec = {
       }
     });
 
-    if (payload.imp.length == 0) {
+    if (payload.imp.length === 0) {
       return;
     }
 

--- a/modules/docereeAdManagerBidAdapter.js
+++ b/modules/docereeAdManagerBidAdapter.js
@@ -17,7 +17,7 @@ export const spec = {
   },
   isGdprConsentPresent: (bid) => {
     const { gdpr, gdprconsent } = bid.params;
-    if (gdpr == '1') {
+    if (gdpr === '1') {
       return !!gdprconsent;
     }
     return true;

--- a/modules/docereeBidAdapter.js
+++ b/modules/docereeBidAdapter.js
@@ -20,7 +20,7 @@ export const spec = {
   },
   isGdprConsentPresent: (bid) => {
     const { gdpr, gdprConsent } = bid.params;
-    if (gdpr == '1') {
+    if (gdpr === '1') {
       return !!gdprConsent
     }
     return true

--- a/modules/dochaseBidAdapter.js
+++ b/modules/dochaseBidAdapter.js
@@ -29,9 +29,9 @@ export const spec = {
   interpretResponse: (bidRes, bidReq) => {
     let Response = {};
     const media = JSON.parse(bidReq.data)[0].MediaType;
-    if (media == BANNER) {
+    if (media === BANNER) {
       Response = getBannerResponse(bidRes, BANNER);
-    } else if (media == NATIVE) {
+    } else if (media === NATIVE) {
       Response = getNativeResponse(bidRes, bidReq, NATIVE);
     }
     return Response;

--- a/modules/dvgroupBidAdapter.js
+++ b/modules/dvgroupBidAdapter.js
@@ -62,7 +62,7 @@ export const spec = {
       bid.meta = bid.meta || {};
       bid.ttl = bid.ttl || TIME_TO_LIVE;
       bid.meta.advertiserDomains = bid.meta.advertiserDomains || [];
-      if (bid.meta.advertiserDomains.length == 0) {
+      if (bid.meta.advertiserDomains.length === 0) {
         bid.meta.advertiserDomains.push('dvgroup.com');
       }
     });

--- a/modules/dxkultureBidAdapter.js
+++ b/modules/dxkultureBidAdapter.js
@@ -181,9 +181,9 @@ export const spec = {
         });
 
         if (syncOptions.iframeEnabled) {
-          syncs = syncs.filter(s => s.type == 'iframe');
+          syncs = syncs.filter(s => s.type === 'iframe');
         } else if (syncOptions.pixelEnabled) {
-          syncs = syncs.filter(s => s.type == 'image');
+          syncs = syncs.filter(s => s.type === 'image');
         }
       }
     });

--- a/modules/ehealthcaresolutionsBidAdapter.js
+++ b/modules/ehealthcaresolutionsBidAdapter.js
@@ -29,9 +29,9 @@ export const spec = {
   interpretResponse: (bResponse, bRequest) => {
     let Response = {};
     const mediaType = JSON.parse(bRequest.data)[0].MediaType;
-    if (mediaType == BANNER) {
+    if (mediaType === BANNER) {
       Response = getBannerResponse(bResponse, BANNER);
-    } else if (mediaType == NATIVE) {
+    } else if (mediaType === NATIVE) {
       Response = getNativeResponse(bResponse, bRequest, NATIVE);
     }
     return Response;

--- a/modules/engageyaBidAdapter.js
+++ b/modules/engageyaBidAdapter.js
@@ -12,7 +12,7 @@ const SUPPORTED_SIZES = [
 ];
 
 function getPageUrl(bidRequest, bidderRequest) {
-  if (bidRequest.params.pageUrl && bidRequest.params.pageUrl != '[PAGE_URL]') {
+  if (bidRequest.params.pageUrl && bidRequest.params.pageUrl !== '[PAGE_URL]') {
     return bidRequest.params.pageUrl;
   }
   if (bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.page) {
@@ -160,7 +160,7 @@ export const spec = {
       return [];
     }
     var response = serverResponse.body;
-    var isNative = response.pbtypeId == 1;
+    var isNative = response.pbtypeId === 1;
     return response.recs.map(rec => {
       const bid = {
         requestId: response.ireqId,


### PR DESCRIPTION
## Summary
- fix linting issues in several modules to use strict comparison

## Testing
- `npx eslint modules/distroscaleBidAdapter.js modules/docereeAdManagerBidAdapter.js modules/docereeBidAdapter.js modules/dochaseBidAdapter.js modules/dvgroupBidAdapter.js modules/dxkultureBidAdapter.js modules/ehealthcaresolutionsBidAdapter.js modules/engageyaBidAdapter.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/distroscaleBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/docereeAdManagerBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/docereeBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/dochaseBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/dvgroupBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/dxkultureBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/ehealthcaresolutionsBidAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/engageyaBidAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_68756971f208832ba2f56ce23123e84d