### PR TITLE
Bid Adapters: fix eqeqeq lint errors

### DIFF
--- a/modules/relaidoBidAdapter.js
+++ b/modules/relaidoBidAdapter.js
@@ -138,7 +138,7 @@ function buildRequests(validBidRequests, bidderRequest) {
 function interpretResponse(serverResponse, bidRequest) {
   const bidResponses = [];
   const body = serverResponse.body;
-  if (!body || body.status != 'ok') {
+  if (!body || body.status !== 'ok') {
     return [];
   }
 
@@ -330,10 +330,10 @@ function getValidSizes(sizes) {
   const result = [];
   if (sizes && isArray(sizes) && sizes.length > 0) {
     for (let i = 0; i < sizes.length; i++) {
-      if (isArray(sizes[i]) && sizes[i].length == 2) {
+      if (isArray(sizes[i]) && sizes[i].length === 2) {
         const width = sizes[i][0];
         const height = sizes[i][1];
-        if (width == 1 && height == 1) {
+        if (width === 1 && height === 1) {
           return [[1, 1]];
         }
         if ((width >= 300 && height >= 250)) {
@@ -342,7 +342,7 @@ function getValidSizes(sizes) {
       } else if (isNumber(sizes[i])) {
         const width = sizes[0];
         const height = sizes[1];
-        if (width == 1 && height == 1) {
+        if (width === 1 && height === 1) {
           return [[1, 1]];
         }
         if ((width >= 300 && height >= 250)) {

--- a/modules/revcontentBidAdapter.js
+++ b/modules/revcontentBidAdapter.js
@@ -187,15 +187,15 @@ function getTemplate(size, customTemplate) {
     return customTemplate;
   }
 
-  if (size.width == 300 && size.height == 250) {
+  if (size.width === 300 && size.height === 250) {
     return '<a href="{clickUrl}" rel="nofollow sponsored"  target="_blank" style="border: 1px solid #eee;    width: 298px;    height: 248px;    display: block;"><div style="background-image:url({image});width: 300px;height: 165px;background-repeat: none;background-size: cover;border-bottom:5px solid;border-color:#3f92f7"><div style="position: absolute;top: 160px;left:12px"><h1 style="max-height:45px;overflow:hidden;color: #000;font-family: Georgia;font-weight:normal;font-size: 19px; position: relative; width: 290px;margin-bottom:3px">{title}</h1> <div style="border:1px solid #3f92f7;background-color:#3f92f7;color:#fff;text-align:center;width:94%;height:17px;line-height: 20px;font-size:15px;padding:2px">SEE MORE</div></div></div></a>';
   }
 
-  if (size.width == 728 && size.height == 90) {
+  if (size.width === 728 && size.height === 90) {
     return '<a href="{clickUrl}" rel="nofollow sponsored"  target="_blank" style="    border: 1px solid #eee;    width: 726px;    height: 86px;    display: block;"><div style="border-right:5px solid #3f92f7;background-image:url({image});width: 130px;height: 88px;background-repeat: no-repeat;background-size: cover;"><div style="position: absolute;left:125px;"><h1 style="color: #000;width:80%;font-family: Georgia;font-weight:normal;font-size: 24px; position: relative; width: 100%%;margin-bottom:-5px;margin-left:20px;">{title}</h1> <div style="text-align:center;line-height: 39px;margin-top:-45px;height:40px;border-radius:50%;display:inline-block;border:1px solid #3f92f7;background-color:#3f92f7;width:7%;float:right;color:#fff;margin-right:20px;">&#x3e;</div></div></div></a>';
   }
 
-  if (size.width == 300 && size.height == 600) {
+  if (size.width === 300 && size.height === 600) {
     return '<a href="{clickUrl}" rel="nofollow sponsored"  target="_blank" style="    border: 1px solid #eee;    width: 296px;    height: 597px;    display: block;"><div style="border-bottom:5px solid #3f92f7;background-image:url({image});width: 298px;height: 230px;background-repeat: no-repeat;background-size: cover;"><div style="position: absolute;top:220px;"><h1 style="color: #000;font-family: Georgia;font-weight:normal;font-size: 45px; position: relative; width: 97%;margin-left:3px;height:270px;max-height:270px;overflow:hidden;">{title}</h1> <div style="text-align:center;line-height: 39px;height:40px;border-radius:50%;display:inline-block;border:1px solid #3f92f7;background-color:#3f92f7;width:15%;font-size:25px;color:#fff;margin-left:38%;margin-top:-15px">&#x3e;</div></div></div></a>';
   }
 

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -32,7 +32,7 @@ function RhythmOneBidAdapter() {
       // clever trick to get the protocol
       var el = document.createElement('a');
       el.href = bidderRequest.refererInfo.stack[0];
-      isSecure = (el.protocol == 'https:') ? 1 : 0;
+    isSecure = (el.protocol === 'https:') ? 1 : 0;
     }
     for (var i = 0; i < BRs.length; i++) {
       slotsToBids[BRs[i].adUnitCode] = BRs[i];

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -207,7 +207,7 @@ export const converter = ortbConverter({
   imp(buildImp, bidRequest, context) {
     // skip banner-only requests
     const bidRequestType = bidType(bidRequest);
-    if (bidRequestType.includes(BANNER) && bidRequestType.length == 1) return;
+      if (bidRequestType.includes(BANNER) && bidRequestType.length === 1) return;
 
     const imp = buildImp(bidRequest, context);
     imp.id = bidRequest.adUnitCode;
@@ -1314,7 +1314,7 @@ export function resetUserSync() {
  * @param {*} imp
  */
 function setBidFloors(bidRequest, imp) {
-  if (imp.bidfloorcur != 'USD') {
+  if (imp.bidfloorcur !== 'USD') {
     delete imp.bidfloor;
     delete imp.bidfloorcur;
   }

--- a/modules/silverpushBidAdapter.js
+++ b/modules/silverpushBidAdapter.js
@@ -45,7 +45,7 @@ export const spec = {
     ajax(endpoint, null, undefined, {method: 'GET'});
   },
   getOS: function(ua) {
-    if (ua.indexOf('Windows') != -1) { return 'Windows'; } else if (ua.match(/(iPhone|iPod|iPad)/)) { return 'iOS'; } else if (ua.indexOf('Mac OS X') != -1) { return 'macOS'; } else if (ua.match(/Android/)) { return 'Android'; } else if (ua.indexOf('Linux') != -1) { return 'Linux'; } else { return 'Unknown'; }
+    if (ua.indexOf('Windows') !== -1) { return 'Windows'; } else if (ua.match(/(iPhone|iPod|iPad)/)) { return 'iOS'; } else if (ua.indexOf('Mac OS X') !== -1) { return 'macOS'; } else if (ua.match(/Android/)) { return 'Android'; } else if (ua.indexOf('Linux') !== -1) { return 'Linux'; } else { return 'Unknown'; }
   }
 };
 
@@ -142,7 +142,7 @@ function isBidRequestValid(bidRequest) {
 
 function isPublisherIdValid(bidRequest) {
   const pubId = utils.deepAccess(bidRequest, 'params.publisherId');
-  return (pubId != null && utils.isStr(pubId) && pubId != '');
+  return (pubId !== null && utils.isStr(pubId) && pubId !== '');
 }
 
 function isValidBannerRequest(bidRequest) {
@@ -222,7 +222,7 @@ function createRequest(bidRequests, bidderRequest, mediaType) {
 }
 
 function buildVideoVastResponse(bidResponse) {
-  if (bidResponse.mediaType == VIDEO && bidResponse.vastXml) {
+  if (bidResponse.mediaType === VIDEO && bidResponse.vastXml) {
     bidResponse.vastUrl = bidResponse.vastXml;
   }
 

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -145,9 +145,9 @@ export const spec = {
     if (videoParams?.startDelay) {
       return videoParams.startDelay;
     } else if (videoMediaType?.startdelay) {
-      if (videoMediaType.startdelay > 0 || videoMediaType.startdelay == -1) {
+        if (videoMediaType.startdelay > 0 || videoMediaType.startdelay === -1) {
         return 2;
-      } else if (videoMediaType.startdelay == -2) {
+        } else if (videoMediaType.startdelay === -2) {
         return 3;
       }
     }

--- a/modules/smartyadsAnalyticsAdapter.js
+++ b/modules/smartyadsAnalyticsAdapter.js
@@ -89,7 +89,7 @@ const bidHandler = (eventType, bid) => {
   for (const bidObj of bids) {
     let bidToSend;
 
-    if (bidObj.bidderCode != BIDDER_CODE) {
+    if (bidObj.bidderCode !== BIDDER_CODE) {
       if (eventType === BID_WON) {
         bidToSend = {
           cpm: bidObj.cpm,

--- a/modules/smartyadsBidAdapter.js
+++ b/modules/smartyadsBidAdapter.js
@@ -16,7 +16,7 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   isBidRequestValid: (bid) => {
-    return Boolean(bid.bidId && bid.params && !isNaN(bid.params.sourceid) && !isNaN(bid.params.accountid) && bid.params.host == 'prebid');
+  return Boolean(bid.bidId && bid.params && !isNaN(bid.params.sourceid) && !isNaN(bid.params.accountid) && bid.params.host === 'prebid');
   },
 
   buildRequests: (validBidRequests = [], bidderRequest) => {

--- a/modules/snigelBidAdapter.js
+++ b/modules/snigelBidAdapter.js
@@ -130,9 +130,9 @@ function getTestFlag() {
 
 function getLanguage() {
   return navigator && navigator.language
-    ? navigator.language.indexOf('-') != -1
-      ? navigator.language.split('-')[0]
-      : navigator.language
+    ? navigator.language.indexOf('-') !== -1
+        ? navigator.language.split('-')[0]
+        : navigator.language
     : undefined;
 }
 


### PR DESCRIPTION
## Summary
- fix eqeqeq linting issues across several adapters

## Testing
- `npx eslint modules/relaidoBidAdapter.js modules/revcontentBidAdapter.js modules/rhythmoneBidAdapter.js modules/rubiconBidAdapter.js modules/silverpushBidAdapter.js modules/smartadserverBidAdapter.js modules/smartyadsAnalyticsAdapter.js modules/smartyadsBidAdapter.js modules/snigelBidAdapter.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/revcontentBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/rhythmoneBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/rubiconBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/silverpushBidAdapter_spec.js` *(fails: Cannot read properties of undefined)*
- `npx gulp test --nolint --file test/spec/modules/relaidoBidAdapter_spec.js` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_b_68756a194b00832b9583e0ba666012b1