### PR TITLE
Multiple Adapters: fix eqeqeq lint errors

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -235,12 +235,12 @@ export const spec = {
             dealId: sovrnBid.dealid || null,
             currency: 'USD',
             netRevenue: true,
-            mediaType: sovrnBid.mtype == 2 ? VIDEO : BANNER,
+            mediaType: sovrnBid.mtype === 2 ? VIDEO : BANNER,
             ttl: sovrnBid.ext?.ttl || 90,
             meta: { advertiserDomains: sovrnBid && sovrnBid.adomain ? sovrnBid.adomain : [] }
           }
 
-          if (sovrnBid.mtype == 2) {
+          if (sovrnBid.mtype === 2) {
             bid.vastXml = decodeURIComponent(sovrnBid.adm)
           } else {
             bid.ad = sovrnBid.nurl ? decodeURIComponent(`${sovrnBid.adm}<img src="${sovrnBid.nurl}">`) : decodeURIComponent(sovrnBid.adm)

--- a/modules/sparteoBidAdapter.js
+++ b/modules/sparteoBidAdapter.js
@@ -49,7 +49,7 @@ const converter = ortbConverter({
 
     const response = buildBidResponse(bid, context);
 
-    if (context.mediaType == 'video') {
+      if (context.mediaType === 'video') {
       response.nurl = bid.nurl;
       response.vastUrl = deepAccess(bid, 'ext.prebid.cache.vastXml.url') ?? null;
     }
@@ -96,7 +96,7 @@ export const spec = {
     if (bannerParams) {
       const sizes = bannerParams.sizes;
 
-      if (!sizes || parseSizesInput(sizes).length == 0) {
+        if (!sizes || parseSizesInput(sizes).length === 0) {
         logError('mediaTypes.banner.sizes must be set for banner placement at the right format.');
         return false;
       }
@@ -107,7 +107,7 @@ export const spec = {
      */
 
     if (videoParams) {
-      if (parseSizesInput(videoParams.playerSize).length == 0) {
+        if (parseSizesInput(videoParams.playerSize).length === 0) {
         logError('mediaTypes.video.playerSize must be set for video placement at the right format.');
         return false;
       }

--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -119,8 +119,8 @@ function hasParamsNotBlankString(params, key) {
   return (
     key in params &&
     typeof params[key] !== 'undefined' &&
-    params[key] != null &&
-    params[key] != ''
+    params[key] !== null &&
+    params[key] !== ''
   );
 }
 
@@ -151,7 +151,7 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
       ? encodeURIComponentIncludeSingleQuotation(geparameter[GEPARAMS_KEY.GENIEE_CT0])
       : '',
     referer: refererInfo?.ref || encodeURIComponentIncludeSingleQuotation(geparameter[GEPARAMS_KEY.REFERRER]) || '',
-    topframe: window.parent == window.self ? 1 : 0,
+      topframe: window.parent === window.self ? 1 : 0,
     cur: bid.params.hasOwnProperty('currency') ? bid.params.currency : DEFAULT_CURRENCY,
     requestid: bid.bidId,
     ua: navigator.userAgent,

--- a/modules/stackadaptBidAdapter.js
+++ b/modules/stackadaptBidAdapter.js
@@ -97,7 +97,7 @@ export const spec = {
 
     if (mediaTypesBanner) {
       const sizes = mediaTypesBanner.sizes;
-      if (!sizes || parseSizesInput(sizes).length == 0) {
+        if (!sizes || parseSizesInput(sizes).length === 0) {
         logWarn('StackAdapt bidder adapter - banner bid requires bid.mediaTypes.banner.sizes of valid format');
         return false;
       }

--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -77,7 +77,7 @@ export const spec = {
       }
 
       payload.uids = serializeUids(bidRequest);
-      if (payload.uids == '') {
+        if (payload.uids === '') {
         delete payload.uids;
       }
 
@@ -105,7 +105,7 @@ export const spec = {
           .filter(key => Object.keys(VIDEO_ORTB_PARAMS).includes(key) && params[VIDEO_ORTB_PARAMS[key]] === undefined)
           .forEach(key => payload.pfilter[VIDEO_ORTB_PARAMS[key]] = videoParams[key]);
       }
-      if (Object.keys(payload.pfilter).length == 0) { delete payload.pfilter }
+        if (Object.keys(payload.pfilter).length === 0) { delete payload.pfilter }
 
       if (bidderRequest && bidderRequest.gdprConsent) {
         payload.gdpr_consent = bidderRequest.gdprConsent.consentString;
@@ -154,7 +154,7 @@ function stvObjectToQueryString(obj, prefix) {
       const v = obj[p];
       str.push((v !== null && typeof v === 'object')
         ? stvObjectToQueryString(v, k)
-        : (k == 'schain' || k == 'uids' ? k + '=' + v : encodeURIComponent(k) + '=' + encodeURIComponent(v)));
+          : (k === 'schain' || k === 'uids' ? k + '=' + v : encodeURIComponent(k) + '=' + encodeURIComponent(v)));
     }
   }
   return str.join('&');

--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -278,7 +278,7 @@ function fillTaboolaReqData(bidderRequest, bidRequest, data) {
   const site = getSiteProperties(bidRequest.params, refererInfo, bidderRequest.ortb2);
   deepSetValue(data, 'device', bidderRequest?.ortb2?.device);
   const extractedUserId = userData.getUserId(gdprConsent, uspConsent);
-  if (data.user == undefined) {
+    if (data.user === undefined) {
     data.user = {
       buyeruid: 0,
       ext: {}
@@ -287,7 +287,7 @@ function fillTaboolaReqData(bidderRequest, bidRequest, data) {
   if (extractedUserId && extractedUserId !== 0) {
     deepSetValue(data, 'user.buyeruid', extractedUserId);
   }
-  if (data.regs?.ext == undefined) {
+    if (data.regs?.ext === undefined) {
     data.regs = {
       ext: {}
     }
@@ -320,7 +320,7 @@ function fillTaboolaReqData(bidderRequest, bidRequest, data) {
 
   data.id = bidderRequest.bidderRequestId;
   data.site = site;
-  data.tmax = (bidderRequest.timeout == undefined) ? undefined : parseInt(bidderRequest.timeout);
+    data.tmax = (bidderRequest.timeout == null) ? undefined : parseInt(bidderRequest.timeout);
   data.bcat = ortb2.bcat || bidRequest.params.bcat || [];
   data.badv = ortb2.badv || bidRequest.params.badv || [];
   data.wlang = ortb2.wlang || bidRequest.params.wlang || [];

--- a/modules/tapnativeBidAdapter.js
+++ b/modules/tapnativeBidAdapter.js
@@ -29,9 +29,9 @@ export const spec = {
   interpretResponse: function(serverResponse, serverRequest) {
     let bidderResponse = {};
     const mType = JSON.parse(serverRequest.data)[0].MediaType;
-    if (mType == BANNER) {
+      if (mType === BANNER) {
       bidderResponse = getBannerResponse(serverResponse, BANNER);
-    } else if (mType == NATIVE) {
+      } else if (mType === NATIVE) {
       bidderResponse = getNativeResponse(serverResponse, serverRequest, NATIVE);
     }
     return bidderResponse;

--- a/modules/targetVideoBidAdapter.js
+++ b/modules/targetVideoBidAdapter.js
@@ -169,7 +169,7 @@ export const spec = {
     if (serverResponse.tags) {
       serverResponse.tags.forEach(serverBid => {
         const rtbBid = getRtbBid(serverBid);
-        if (rtbBid && rtbBid.cpm !== 0 && rtbBid.ad_type == VIDEO) {
+          if (rtbBid && rtbBid.cpm !== 0 && rtbBid.ad_type === VIDEO) {
           bids.push(bannerBid(serverBid, rtbBid, bidderRequest, MARGIN));
         }
       });
@@ -181,7 +181,7 @@ export const spec = {
           const requestId = bidRequest.bidId;
           const params = bidRequest.params;
           const vBid = videoBid(bid, requestId, currency, params, TIME_TO_LIVE);
-          if (bids.length == 0 || bids[0].cpm < vBid.cpm) {
+            if (bids.length === 0 || bids[0].cpm < vBid.cpm) {
             bids[0] = vBid;
           }
         });

--- a/modules/tealBidAdapter.js
+++ b/modules/tealBidAdapter.js
@@ -134,7 +134,7 @@ export const spec = {
   onBidderError: function({ error, bidderRequest }) {
     if (error.responseText && error.status) {
       const id = error.responseText.match(/found for id: (.*)/);
-      if (Array.isArray(id) && id.length > 1 && error.status == 400) {
+        if (Array.isArray(id) && id.length > 1 && error.status === 400) {
         logError(`Placement: ${id[1]} not found on ${BIDDER_CODE} server. Please contact your account manager or email prebid@teal.works`, error);
         return;
       }

--- a/modules/temedyaBidAdapter.js
+++ b/modules/temedyaBidAdapter.js
@@ -72,7 +72,7 @@ export const spec = {
     try {
       const bidResponse = serverResponse.body;
       const bidResponses = [];
-      if (bidResponse && bidRequest.options.mediaType == NATIVE) {
+        if (bidResponse && bidRequest.options.mediaType === NATIVE) {
         bidResponse.ads.forEach(function(ad) {
           bidResponses.push({
             requestId: bidRequest.options.requestId,
@@ -106,7 +106,7 @@ export const spec = {
             },
           });
         });
-      } else if (bidResponse && bidRequest.options.mediaType == 'display') {
+        } else if (bidResponse && bidRequest.options.mediaType === 'display') {
         bidResponse.ads.forEach(function(ad) {
           const w = ad.assets.width || 300;
           const h = ad.assets.height || 250;

--- a/modules/theAdxBidAdapter.js
+++ b/modules/theAdxBidAdapter.js
@@ -278,7 +278,7 @@ export const spec = {
           mediaType: mediaType,
           native: native,
         };
-        if (mediaType == VIDEO && videoXml) {
+          if (mediaType === VIDEO && videoXml) {
           response.vastUrl = videoXml;
           response.videoCacheKey = bid.ext.rid;
         }
@@ -504,8 +504,8 @@ const generateImpBody = (bidRequest, bidderRequest) => {
   return result;
 }
 const getRegionEndPoint = (bidRequest) => {
-  if (bidRequest && bidRequest.params && bidRequest.params.region) {
-    if (bidRequest.params.region.toLowerCase() == 'tr') {
+    if (bidRequest && bidRequest.params && bidRequest.params.region) {
+      if (bidRequest.params.region.toLowerCase() === 'tr') {
       return ENDPOINT_TR_URL;
     }
   }

--- a/modules/trionBidAdapter.js
+++ b/modules/trionBidAdapter.js
@@ -97,7 +97,7 @@ function getSyncUrl(gdprConsent, usPrivacy) {
 function getPublisherUrl() {
   var url = '';
   try {
-    if (window.top == window) {
+  if (window.top === window) {
       url = window.location.href;
     } else {
       try {
@@ -121,7 +121,7 @@ function buildTrionUrlParams(bid, bidderRequest) {
   var isHidden = (document.hidden) ? '1' : '0';
   var visibilityState = encodeURIComponent(document.visibilityState);
 
-  var intT = window.TR_INT_T && window.TR_INT_T != -1 ? window.TR_INT_T : null;
+  var intT = window.TR_INT_T && window.TR_INT_T !== -1 ? window.TR_INT_T : null;
   if (!intT) {
     intT = getStorageData(BASE_KEY + 'int_t');
   }

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -368,7 +368,7 @@ function _buildResponseObject(bidderRequest, bid) {
   const creativeId = bid.crid || '';
   const breq = bidderRequest.bids[bid.imp_id];
 
-  if (bid.cpm != 0 && bid.ad) {
+  if (bid.cpm !== 0 && bid.ad) {
     bidResponse = {
       requestId: breq.bidId,
       cpm: bid.cpm,
@@ -398,7 +398,7 @@ function _buildResponseObject(bidderRequest, bid) {
       bidResponse.meta.advertiserDomains = bid.adomain;
     }
 
-    if (bid.tl_source && bid.tl_source == 'hdx') {
+  if (bid.tl_source && bid.tl_source === 'hdx') {
       if (_isVideoBidRequest(breq) && bid.media_type === 'video') {
         bidResponse.meta.mediaType = 'video'
       } else {
@@ -406,7 +406,7 @@ function _buildResponseObject(bidderRequest, bid) {
       }
     }
 
-    if (bid.tl_source && bid.tl_source == 'tlx') {
+  if (bid.tl_source && bid.tl_source === 'tlx') {
       bidResponse.meta.mediaType = 'native';
     }
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -112,7 +112,7 @@ function getUser(bidderRequest, firstPartyData) {
   if (eids && eids.length) {
     utils.deepSetValue(user, 'ext.eids', eids);
 
-    const tdid = eids.find(eid => eid.source == 'adserver.org')?.uids?.[0]?.id;
+      const tdid = eids.find(eid => eid.source === 'adserver.org')?.uids?.[0]?.id;
     if (tdid) {
       user.buyeruid = tdid
     }


### PR DESCRIPTION
## Summary
- fix `eqeqeq` lint warnings across several bid adapters
- maintain behavior by using strict comparisons

## Testing
- `npx eslint --cache --cache-strategy content modules/sovrnBidAdapter.js modules/sparteoBidAdapter.js modules/ssp_genieeBidAdapter.js modules/stackadaptBidAdapter.js modules/stvBidAdapter.js modules/taboolaBidAdapter.js modules/tapnativeBidAdapter.js modules/targetVideoBidAdapter.js modules/tealBidAdapter.js modules/temedyaBidAdapter.js modules/theAdxBidAdapter.js modules/trionBidAdapter.js modules/tripleliftBidAdapter.js modules/ttdBidAdapter.js`
- `npx gulp test --nolint --file test/spec/modules/sovrnBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/sparteoBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/ssp_genieeBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/stackadaptBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/stvBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/taboolaBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/tapnativeBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/targetVideoBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/tealBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/temedyaBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/theAdxBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/trionBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/tripleliftBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/ttdBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68756a2dcc5c832b8bbaac1dbb78ef0c