### PR TITLE
Maintenance: preserve equality behavior

### DIFF
--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -913,7 +913,7 @@ magniteAdapter.track = ({ eventType, args }) => {
         if (adUnit.bids[bid.bidId].source === 'server') adUnit.pbsRequest = 1;
         // set acct site zone id on adunit
         if ((!adUnit.siteId || !adUnit.zoneId) && rubiconAliases.indexOf(bid.bidder) !== -1) {
-          if (deepAccess(bid, 'params.accountId') === accountId) {
+          if (Number(deepAccess(bid, 'params.accountId')) === accountId) {
             adUnit.accountId = parseInt(accountId);
             adUnit.siteId = parseInt(deepAccess(bid, 'params.siteId'));
             adUnit.zoneId = parseInt(deepAccess(bid, 'params.zoneId'));

--- a/modules/mediafuseBidAdapter.js
+++ b/modules/mediafuseBidAdapter.js
@@ -623,7 +623,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
     let jsTrackers = nativeAd.javascript_trackers;
 
-    if (jsTrackers === undefined) {
+    if (jsTrackers === undefined || jsTrackers === null) {
       jsTrackers = jsTrackerDisarmed;
     } else if (isStr(jsTrackers)) {
       jsTrackers = [jsTrackers, jsTrackerDisarmed];


### PR DESCRIPTION
## Summary
- ensure null check with strict equality
- preserve numeric equality checks when passing lint

## Testing
- `npx eslint --cache --cache-strategy content modules/magniteAnalyticsAdapter.js modules/mediafuseBidAdapter.js`
- `npx gulp test --nolint --file test/spec/modules/magniteAnalyticsAdapter_spec.js --file test/spec/modules/mediafuseBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_6875767a6eec832ba37bbccb304aa364