### PR TITLE
Core: type secureSignalProviders

### DIFF
--- a/modules/userId/index.ts
+++ b/modules/userId/index.ts
@@ -2,6 +2,7 @@
  * This module adds User ID support to prebid.js
  * @module modules/userId
  */
+/// <reference types="google-publisher-tag" />
 
 import {config} from '../../src/config.js';
 import * as events from '../../src/events.js';
@@ -702,7 +703,7 @@ function registerSignalSources() {
   if (!isGptPubadsDefined()) {
     return;
   }
-  const providers = window.googletag.secureSignalProviders = window.googletag.secureSignalProviders || [];
+  const providers: googletag.secureSignals.SecureSignalProvider[] | googletag.secureSignals.SecureSignalProvidersArray = window.googletag.secureSignalProviders = window.googletag.secureSignalProviders || [];
   const existingIds = new Set((providers as any[]).map((p: any) => p.id));
   const encryptedSignalSources = config.getConfig('userSync.encryptedSignalSources');
   if (encryptedSignalSources) {


### PR DESCRIPTION
## Summary
- import GPT types for user ID module
- type `googletag.secureSignalProviders` using GPT types

## Testing
- `npx eslint modules/userId/index.ts test/spec/modules/userId_spec.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/userId_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_68757853b534832b804c959ccf07a270