### PR TITLE
Core: handle operaads decode types

### DIFF
--- a/modules/operaadsIdSystem.js
+++ b/modules/operaadsIdSystem.js
@@ -72,7 +72,7 @@ export const operaIdSubmodule = {
    * @returns {{'operaId': string}}
    */
   decode: (id) =>
-    id !== null && id.length > 0
+    typeof id === 'string' && id.length > 0
       ? { [ID_KEY]: id }
       : undefined,
 


### PR DESCRIPTION
## Summary
- ensure `decode` checks for string ids in `operaadsIdSystem`

## Testing
- `npx eslint --cache --cache-strategy content modules/operaadsIdSystem.js`
- `npx gulp test --file test/spec/modules/operaadsIdSystem_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_68758450beb4832ba1b6aaba744d18de