### PR TITLE
Kubient & Moneytizer Adapters: remove gvlid

### DIFF
--- a/modules/kubientBidAdapter.js
+++ b/modules/kubientBidAdapter.js
@@ -9,7 +9,6 @@ const VERSION = '1.1';
 const VENDOR_ID = 794;
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: VENDOR_ID,
   supportedMediaTypes: [ BANNER, VIDEO ],
   isBidRequestValid: function (bid) {
     return !!(

--- a/modules/themoneytizerBidAdapter.js
+++ b/modules/themoneytizerBidAdapter.js
@@ -3,14 +3,12 @@ import { BANNER } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'themoneytizer';
-const GVLID = 1265;
 const ENDPOINT_URL = 'https://ads.biddertmz.com/m/';
 
 export const spec = {
   aliases: [BIDDER_CODE],
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER],
-  gvlid: GVLID,
 
   isBidRequestValid: function (bid) {
     if (!(bid && bid.params.pid)) {

--- a/test/spec/modules/themoneytizerBidAdapter_spec.js
+++ b/test/spec/modules/themoneytizerBidAdapter_spec.js
@@ -102,12 +102,6 @@ describe('The Moneytizer Bidder Adapter', function () {
     });
   });
 
-  describe('gvlid', function () {
-    it('should expose gvlid', function () {
-      expect(spec.gvlid).to.equal(1265)
-    });
-  });
-
   describe('isBidRequestValid', function () {
     it('should return true for a bid with all required fields', function () {
       const validBid = spec.isBidRequestValid(VALID_BID_BANNER);


### PR DESCRIPTION
## Summary
- remove `gvlid` field from Kubient adapter
- remove `gvlid` and constant from TheMoneytizer adapter
- drop gvlid test for TheMoneytizer

## Testing
- `npx eslint --cache --cache-strategy content modules/themoneytizerBidAdapter.js modules/kubientBidAdapter.js test/spec/modules/themoneytizerBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/themoneytizerBidAdapter_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_68763f4eca7c832bb63397950b32ab22