### PR TITLE
Unicorn Adapter: fix advertiserDomains check

### DIFF
--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -139,7 +139,7 @@ const interpretResponse = (serverResponse, request) => {
           currency: res.cur
         }
 
-        if (b.adomain !== undefined || b.adomain !== null) {
+        if (b.adomain) {
           bid.meta = { advertiserDomains: b.adomain };
         }
 


### PR DESCRIPTION
## Summary
- fix advertiserDomains check in unicorn adapter

## Testing
- `npx eslint modules/unicornBidAdapter.js test/spec/modules/unicornBidAdapter_spec.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/unicornBidAdapter_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_68763ff5d8dc832b950cd915ccc16da5