### PR TITLE
Yieldlab Adapter: handle missing netRevenue

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -195,7 +195,7 @@ export const spec = {
           creativeId: '' + matchedBid.id,
           dealId: (matchedBid['c.dealid']) ? matchedBid['c.dealid'] : matchedBid.pid,
           currency: CURRENCY_CODE,
-          netRevenue: matchedBid.netRevenue,
+          netRevenue: matchedBid.netRevenue !== undefined ? matchedBid.netRevenue : false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}${iabContent}"></script>`,


### PR DESCRIPTION
## Summary
- ensure yieldlab adapter sets netRevenue to false when not provided

## Testing
- `npx eslint --cache --cache-strategy content modules/yieldlabBidAdapter.js test/spec/modules/yieldlabBidAdapter_spec.js modules/zmaticooBidAdapter.js test/spec/modules/zmaticooBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/yieldlabBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/zmaticooBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68763fd9dedc832bbfa076f702ddf9cb