### PR TITLE
Bid Adapters: revert eqeqeq changes

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -174,7 +174,8 @@ export const spec = {
       }
 
       const matchedBid = ((serverResponse.body) || []).find(function (bidResponse) {
-        return bidRequest.params.adslotId === bidResponse.id;
+        // eslint-disable-next-line eqeqeq
+        return bidRequest.params.adslotId == bidResponse.id;
       });
 
       if (matchedBid) {
@@ -195,7 +196,7 @@ export const spec = {
           creativeId: '' + matchedBid.id,
           dealId: (matchedBid['c.dealid']) ? matchedBid['c.dealid'] : matchedBid.pid,
           currency: CURRENCY_CODE,
-          netRevenue: matchedBid.netRevenue !== undefined ? matchedBid.netRevenue : false,
+          netRevenue: matchedBid.netRevenue,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}${iabContent}"></script>`,

--- a/modules/zmaticooBidAdapter.js
+++ b/modules/zmaticooBidAdapter.js
@@ -149,7 +149,8 @@ export const spec = {
       payload.test = params.test;
     }
     if (bidderRequest.gdprConsent) {
-      payload.regs.ext = Object.assign(payload.regs.ext, {gdpr: bidderRequest.gdprConsent.gdprApplies === true ? 1 : 0});
+      // eslint-disable-next-line eqeqeq
+      payload.regs.ext = Object.assign(payload.regs.ext, {gdpr: bidderRequest.gdprConsent.gdprApplies == true ? 1 : 0});
     }
     if (bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies) {
       payload.user.ext = Object.assign(payload.user.ext, {consent: bidderRequest.gdprConsent.consentString});


### PR DESCRIPTION
## Summary
- revert eqeqeq related changes for yieldlab and zmatico adapters
- allow non-strict equality through lint rule comment

## Testing
- `npx eslint modules/yieldlabBidAdapter.js modules/zmaticooBidAdapter.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/yieldlabBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/zmaticooBidAdapter_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_68765cd860ec832baab1f737a326f46a