### PR TITLE
PulsePoint & Adxcg Adapters: share imp util

### DIFF
--- a/libraries/impUtils.js
+++ b/libraries/impUtils.js
@@ -1,0 +1,33 @@
+import { isArray } from '../src/utils.js';
+
+export function slotUnknownParams(slot, knownParams) {
+  const ext = {};
+  const knownParamsMap = {};
+  knownParams.forEach(value => { knownParamsMap[value] = 1; });
+  Object.keys(slot.params).forEach(key => {
+    if (!knownParamsMap[key]) {
+      ext[key] = slot.params[key];
+    }
+  });
+  return Object.keys(ext).length > 0 ? { prebid: ext } : null;
+}
+
+export function applyCommonImpParams(imp, bidRequest, knownParams) {
+  const unknownParams = slotUnknownParams(bidRequest, knownParams);
+  if (imp.ext || unknownParams) {
+    imp.ext = Object.assign({}, imp.ext, unknownParams);
+  }
+  if (bidRequest.params.battr) {
+    ['banner', 'video', 'audio', 'native'].forEach(k => {
+      if (imp[k]) {
+        imp[k].battr = bidRequest.params.battr;
+      }
+    });
+  }
+  if (bidRequest.params.deals && isArray(bidRequest.params.deals)) {
+    imp.pmp = {
+      private_auction: 0,
+      deals: bidRequest.params.deals
+    };
+  }
+}

--- a/modules/adxcgBidAdapter.js
+++ b/modules/adxcgBidAdapter.js
@@ -3,7 +3,6 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import {
-  isArray,
   replaceAuctionPrice,
   triggerPixel,
   logMessage,
@@ -11,6 +10,7 @@ import {
   getBidIdParameter
 } from '../src/utils.js';
 import { config } from '../src/config.js';
+import { applyCommonImpParams } from '../libraries/impUtils.js';
 
 const BIDDER_CODE = 'adxcg';
 const SECURE_BID_URL = 'https://pbc.adxcg.net/rtb/ortb/pbc?adExchangeId=1';
@@ -101,26 +101,7 @@ const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
     // tagid
     imp.tagid = bidRequest.params.adzoneid.toString();
-    // unknown params
-    const unknownParams = slotUnknownParams(bidRequest);
-    if (imp.ext || unknownParams) {
-      imp.ext = Object.assign({}, imp.ext, unknownParams);
-    }
-    // battr
-    if (bidRequest.params.battr) {
-      ['banner', 'video', 'audio', 'native'].forEach(k => {
-        if (imp[k]) {
-          imp[k].battr = bidRequest.params.battr;
-        }
-      });
-    }
-    // deals
-    if (bidRequest.params.deals && isArray(bidRequest.params.deals)) {
-      imp.pmp = {
-        private_auction: 0,
-        deals: bidRequest.params.deals
-      };
-    }
+    applyCommonImpParams(imp, bidRequest, KNOWN_PARAMS);
 
     imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
 
@@ -147,20 +128,5 @@ const converter = ortbConverter({
     return bidResponse;
   },
 });
-
-/**
- * Unknown params are captured and sent on ext
- */
-function slotUnknownParams(slot) {
-  const ext = {};
-  const knownParamsMap = {};
-  KNOWN_PARAMS.forEach(value => knownParamsMap[value] = 1);
-  Object.keys(slot.params).forEach(key => {
-    if (!knownParamsMap[key]) {
-      ext[key] = slot.params[key];
-    }
-  });
-  return Object.keys(ext).length > 0 ? { prebid: ext } : null;
-}
 
 registerBidder(spec);

--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -1,6 +1,6 @@
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import {isArray} from '../src/utils.js';
-import {registerBidder} from '../src/adapters/bidderFactory.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { applyCommonImpParams } from '../libraries/impUtils.js';
 
 const DEFAULT_CURRENCY = 'USD';
 const KNOWN_PARAMS = ['cp', 'ct', 'cf', 'battr', 'deals'];
@@ -71,26 +71,7 @@ const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
     // tagid
     imp.tagid = bidRequest.params.ct.toString();
-    // unknown params
-    const unknownParams = slotUnknownParams(bidRequest);
-    if (imp.ext || unknownParams) {
-      imp.ext = Object.assign({}, imp.ext, unknownParams);
-    }
-    // battr
-    if (bidRequest.params.battr) {
-      ['banner', 'video', 'audio', 'native'].forEach(k => {
-        if (imp[k]) {
-          imp[k].battr = bidRequest.params.battr;
-        }
-      });
-    }
-    // deals
-    if (bidRequest.params.deals && isArray(bidRequest.params.deals)) {
-      imp.pmp = {
-        private_auction: 0,
-        deals: bidRequest.params.deals
-      };
-    }
+    applyCommonImpParams(imp, bidRequest, KNOWN_PARAMS);
     return imp;
   },
 
@@ -115,20 +96,4 @@ const converter = ortbConverter({
     return bidResponse;
   },
 });
-
-/**
- * Unknown params are captured and sent on ext
- */
-function slotUnknownParams(slot) {
-  const ext = {};
-  const knownParamsMap = {};
-  KNOWN_PARAMS.forEach(value => knownParamsMap[value] = 1);
-  Object.keys(slot.params).forEach(key => {
-    if (!knownParamsMap[key]) {
-      ext[key] = slot.params[key];
-    }
-  });
-  return Object.keys(ext).length > 0 ? { prebid: ext } : null;
-}
-
 registerBidder(spec);

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -195,7 +195,7 @@ export const spec = {
           creativeId: '' + matchedBid.id,
           dealId: (matchedBid['c.dealid']) ? matchedBid['c.dealid'] : matchedBid.pid,
           currency: CURRENCY_CODE,
-          netRevenue: matchedBid.netRevenue !== undefined ? matchedBid.netRevenue : false,
+          netRevenue: matchedBid.netRevenue,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}${iabContent}"></script>`,

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -195,7 +195,7 @@ export const spec = {
           creativeId: '' + matchedBid.id,
           dealId: (matchedBid['c.dealid']) ? matchedBid['c.dealid'] : matchedBid.pid,
           currency: CURRENCY_CODE,
-          netRevenue: matchedBid.netRevenue,
+          netRevenue: matchedBid.netRevenue !== undefined ? matchedBid.netRevenue : false,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}${iabContent}"></script>`,


### PR DESCRIPTION
## Summary
- add `applyCommonImpParams` helper for shared impression logic
- remove duplicated code in PulsePoint and Adxcg adapters
- update tests

## Testing
- `npx eslint --cache --cache-strategy content modules/adxcgBidAdapter.js modules/pulsepointBidAdapter.js libraries/impUtils.js`
- `npx gulp test --nolint --file test/spec/modules/adxcgBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/pulsepointBidAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_687692f9c6d0832baf829987945dda64