### PR TITLE
Core: log errors before throwing

### DIFF
--- a/creative/renderers/display/renderer.js
+++ b/creative/renderers/display/renderer.js
@@ -2,10 +2,9 @@ import {ERROR_NO_AD} from './constants.js';
 
 export function render({ad, adUrl, width, height, instl}, {mkFrame}, win) {
   if (!ad && !adUrl) {
-    throw {
-      reason: ERROR_NO_AD,
-      message: 'Missing ad markup or URL'
-    };
+    const err = new Error('Missing ad markup or URL');
+    err.reason = ERROR_NO_AD;
+    throw err;
   } else {
     if (height == null) {
       const body = win.document?.body;

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -86,10 +86,14 @@ export const extractConsent = ({ gdpr }) => {
   }
   const { gdprApplies, consentString } = gdpr
   if (!(gdprApplies == '0' || gdprApplies == '1')) {
-    throw 'TCF Consent: gdprApplies has wrong format'
+    const msg = 'TCF Consent: gdprApplies has wrong format'
+    logError(msg)
+    throw new Error(msg)
   }
   if (consentString && typeof consentString != 'string') {
-    throw 'TCF Consent: consentString must be string if defined'
+    const msg = 'TCF Consent: consentString must be string if defined'
+    logError(msg)
+    throw new Error(msg)
   }
   const result = {
     'gdpr_applies': gdprApplies,

--- a/modules/getintentBidAdapter.js
+++ b/modules/getintentBidAdapter.js
@@ -1,4 +1,4 @@
-import {getBidIdParameter, isFn, isInteger} from '../src/utils.js';
+import {getBidIdParameter, isFn, isInteger, logError} from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 /**
@@ -211,7 +211,9 @@ function produceSize (sizes) {
     if (Array.isArray(s) && s.length === 2 && isInteger(s[0]) && isInteger(s[1])) {
       return s.join('x');
     } else {
-      throw "Malformed parameter 'sizes'";
+      const msg = "Malformed parameter 'sizes'";
+      logError(msg);
+      throw new Error(msg);
     }
   }
   if (Array.isArray(sizes) && Array.isArray(sizes[0])) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -116,12 +116,16 @@ function parsePlaylistItem(response) {
   try {
     const data = JSON.parse(response);
     if (!data) {
-      throw ('Empty response');
+      const msg = 'Empty response';
+      logError(msg);
+      throw new Error(msg);
     }
 
     const playlist = data.playlist;
     if (!playlist || !playlist.length) {
-      throw ('Empty playlist');
+      const msg = 'Empty playlist';
+      logError(msg);
+      throw new Error(msg);
     }
 
     item = playlist[0];

--- a/modules/nodalsAiRtdProvider.js
+++ b/modules/nodalsAiRtdProvider.js
@@ -392,7 +392,9 @@ class NodalsAiRtdProvider {
     try {
       data = JSON.parse(response);
     } catch (error) {
-      throw `Error parsing response: ${error}`;
+      const msg = `Error parsing response: ${error}`;
+      logError(msg);
+      throw new Error(msg);
     }
     this.#writeToStorage(this.#overrides?.storageKey || this.STORAGE_KEY, data);
     this.#loadAdLibraries(data.deps || []);

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -355,7 +355,9 @@ class WeboramaRtdProvider {
 
       requiredFields.forEach((field) => {
         if (!(field in weboSectionConf)) {
-          throw `missing required field '${field}'`;
+          const msg = `missing required field '${field}'`;
+          logger.logError(msg);
+          throw new Error(msg);
         }
       });
 
@@ -363,7 +365,9 @@ class WeboramaRtdProvider {
         isPlainObject(extra?.userConsent?.gdpr) &&
         !this.#checkTCFv2(extra.userConsent.gdpr)
       ) {
-        throw 'gdpr consent not ok';
+        const msg = 'gdpr consent not ok';
+        logger.logError(msg);
+        throw new Error(msg);
       }
     } catch (e) {
       logger.logError(
@@ -474,11 +478,15 @@ class WeboramaRtdProvider {
     this.#coerceSendToBidders(submoduleParams);
 
     if (!isFn(submoduleParams.onData)) {
-      throw 'onData parameter should be a callback';
+      const msg = 'onData parameter should be a callback';
+      logger.logError(msg);
+      throw new Error(msg);
     }
 
     if (!isValidProfile(submoduleParams.defaultProfile)) {
-      throw 'defaultProfile is not valid';
+      const msg = 'defaultProfile is not valid';
+      logger.logError(msg);
+      throw new Error(msg);
     }
   }
 
@@ -497,7 +505,9 @@ class WeboramaRtdProvider {
         submoduleParams.setPrebidTargeting
       );
     } catch (e) {
-      throw `invalid setPrebidTargeting: ${e}`;
+      const msg = `invalid setPrebidTargeting: ${e}`;
+      logger.logError(msg);
+      throw new Error(msg);
     }
   }
 
@@ -533,7 +543,9 @@ class WeboramaRtdProvider {
         try {
           return validatorCallback(adUnitCode);
         } catch (e) {
-          throw `invalid sendToBidders[${bidder}]: ${e}`;
+          const msg = `invalid sendToBidders[${bidder}]: ${e}`;
+          logger.logError(msg);
+          throw new Error(msg);
         }
       };
 
@@ -546,7 +558,9 @@ class WeboramaRtdProvider {
         (bid) => bid.bidder
       );
     } catch (e) {
-      throw `invalid sendToBidders: ${e}`;
+      const msg = `invalid sendToBidders: ${e}`;
+      logger.logError(msg);
+      throw new Error(msg);
     }
   }
 
@@ -680,7 +694,9 @@ class WeboramaRtdProvider {
         const data = JSON.parse(response);
         onSuccess(data);
       } else {
-        throw `unexpected http status response ${req.status} with response ${response}`;
+        const msg = `unexpected http status response ${req.status} with response ${response}`;
+        logger.logError(msg);
+        throw new Error(msg);
       }
 
       onDone();
@@ -997,7 +1013,9 @@ class WeboramaRtdProvider {
       };
     }
 
-    throw `unexpected format: ${typeof value} (expects function, boolean, string or array)`;
+    const msg = `unexpected format: ${typeof value} (expects function, boolean, string or array)`;
+    logger.logError(msg);
+    throw new Error(msg);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -547,13 +547,13 @@ export function newConfig() {
 
     function check(obj) {
       if (!isPlainObject(obj)) {
-        throw 'setBidderConfig bidder options must be an object';
+        throw new Error('setBidderConfig bidder options must be an object');
       }
       if (!(Array.isArray(obj.bidders) && obj.bidders.length)) {
-        throw 'setBidderConfig bidder options must contain a bidders list with at least 1 bidder';
+        throw new Error('setBidderConfig bidder options must contain a bidders list with at least 1 bidder');
       }
       if (!isPlainObject(obj.config)) {
-        throw 'setBidderConfig bidder options must contain a config object';
+        throw new Error('setBidderConfig bidder options must contain a config object');
       }
     }
   }

--- a/test/spec/libraries/greedy/greedyPromise_spec.js
+++ b/test/spec/libraries/greedy/greedyPromise_spec.js
@@ -25,7 +25,7 @@ describe('GreedyPromise', () => {
 
     Object.entries({
 
-      'resolver that throws': (P) => new P(() => { throw 'error' }),
+      'resolver that throws': (P) => new P(() => { throw new Error('error') }),
       'resolver that resolves multiple times': (P) => new P((resolve) => { resolve('first'); resolve('second'); }),
       'resolver that rejects multiple times': (P) => new P((resolve, reject) => { reject('first'); reject('second') }),
       'resolver that resolves and rejects': (P) => new P((resolve, reject) => { reject('first'); resolve('second') }),
@@ -75,7 +75,7 @@ describe('GreedyPromise', () => {
           .catch((err) => `${err} ${fval}`)
       },
 
-      '.finally that throws': (P) => makePromise(P, 'value').finally(() => { throw 'error' }),
+      '.finally that throws': (P) => makePromise(P, 'value').finally(() => { throw new Error('error') }),
       'chained .finally that rejects': (P) => makePromise(P, 'value').finally(() => P.reject('error')),
       'scalar Promise.resolve': (P) => P.resolve('scalar'),
       'null Promise.resolve': (P) => P.resolve(null),


### PR DESCRIPTION
## Summary
- log errors using `logError` before throwing `Error` objects
- adjust indentation automatically

## Testing
- `npx eslint --cache --cache-strategy content modules/1plusXRtdProvider.js modules/getintentBidAdapter.js modules/jwplayerRtdProvider.js modules/nodalsAiRtdProvider.js modules/weboramaRtdProvider.js creative/renderers/display/renderer.js src/config.ts test/spec/libraries/greedy/greedyPromise_spec.js`
- `npx gulp test --file test/spec/libraries/greedy/greedyPromise_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68769d0b5278832bbd4746d3604682cf