### PR TITLE
Core: improve getBidRequest performance

### DIFF
--- a/src/auctionIndex.js
+++ b/src/auctionIndex.js
@@ -60,10 +60,17 @@ export function AuctionIndex(getAuctions) {
     },
     getBidRequest({requestId}) {
       if (requestId != null) {
-        return getAuctions()
-          .flatMap(a => a.getBidRequests())
-          .flatMap(ber => ber.bids)
-          .find(br => br && br.bidId === requestId);
+        for (const auction of getAuctions()) {
+          const bidRequests = auction.getBidRequests();
+          for (const bidderRequest of bidRequests) {
+            const bids = Array.isArray(bidderRequest.bids) ? bidderRequest.bids : [];
+            for (const bid of bids) {
+              if (bid && bid.bidId === requestId) {
+                return bid;
+              }
+            }
+          }
+        }
       }
     },
     getOrtb2(bid) {


### PR DESCRIPTION
## Summary
- reduce array allocations in `getBidRequest`

## Testing
- `npx eslint src/auctionIndex.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/unit/core/auctionIndex_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_68667525b9dc832b9e2be4046c346256