### PR TITLE
Core: fix price bucket capping logic

### DIFF
--- a/src/cpmBucketManager.ts
+++ b/src/cpmBucketManager.ts
@@ -79,17 +79,17 @@ function getCpmStringValue(cpm, config, granularityMultiplier) {
     'max': 0,
   });
 
+  if (cpm > cap.max * granularityMultiplier) {
+    let precision = cap.precision;
+    if (typeof precision === 'undefined') {
+      precision = _defaultPrecision;
+    }
+    return (cap.max * granularityMultiplier).toFixed(precision);
+  }
+
   let bucketFloor = 0;
   const bucket = config.buckets.find(bucket => {
-    if (cpm > cap.max * granularityMultiplier) {
-      // cpm exceeds cap, just return the cap.
-      let precision = bucket.precision;
-      if (typeof precision === 'undefined') {
-        precision = _defaultPrecision;
-      }
-      cpmStr = (bucket.max * granularityMultiplier).toFixed(precision);
-      return true;
-    } else if (cpm <= bucket.max * granularityMultiplier && cpm >= bucketFloor * granularityMultiplier) {
+    if (cpm <= bucket.max * granularityMultiplier && cpm >= bucketFloor * granularityMultiplier) {
       bucket.min = bucketFloor;
       return true;
     } else {


### PR DESCRIPTION
## Summary
- correct price bucket capping in `getCpmStringValue`

## Testing
- `npx eslint src/cpmBucketManager.ts --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/cpmBucketManager_spec.js`
- `npx gulp test --nolint --file test/spec/auctionmanager_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_687e7b088848832b84aa93f5c99ffcc4