### PR TITLE
Core: move array callback lint exception

### DIFF
--- a/src/cpmBucketManager.ts
+++ b/src/cpmBucketManager.ts
@@ -1,3 +1,4 @@
+/* eslint-disable array-callback-return */
 import { isEmpty, logWarn } from './utils.js';
 import { config } from './config.js';
 
@@ -79,22 +80,20 @@ function getCpmStringValue(cpm, config, granularityMultiplier) {
     'max': 0,
   });
 
-  if (cpm > cap.max * granularityMultiplier) {
-    let precision = cap.precision;
-    if (typeof precision === 'undefined') {
-      precision = _defaultPrecision;
-    }
-    return (cap.max * granularityMultiplier).toFixed(precision);
-  }
-
   let bucketFloor = 0;
   const bucket = config.buckets.find(bucket => {
-    if (cpm <= bucket.max * granularityMultiplier && cpm >= bucketFloor * granularityMultiplier) {
+    if (cpm > cap.max * granularityMultiplier) {
+      // cpm exceeds cap, just return the cap.
+      let precision = bucket.precision;
+      if (typeof precision === 'undefined') {
+        precision = _defaultPrecision;
+      }
+      cpmStr = (bucket.max * granularityMultiplier).toFixed(precision);
+    } else if (cpm <= bucket.max * granularityMultiplier && cpm >= bucketFloor * granularityMultiplier) {
       bucket.min = bucketFloor;
-      return true;
+      return bucket;
     } else {
       bucketFloor = bucket.max;
-      return false;
     }
   });
   if (bucket) {


### PR DESCRIPTION
## Summary
- remove global lint override for `cpmBucketManager.ts`
- add file level disable comment for `array-callback-return`
- restore original spacing and bucket logic

## Testing
- `npx gulp lint`
- `npx gulp test --file test/spec/cpmBucketManager_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_687ea33db614832b997c606c8fa5ff69