### PR TITLE
Mediaimpact: share adapter helpers

### DIFF
--- a/libraries/mediaImpactUtils/index.js
+++ b/libraries/mediaImpactUtils/index.js
@@ -59,3 +59,119 @@ export function postRequest(endpoint, data) {
 export function buildEndpointUrl(protocol, hostname, pathname, searchParams) {
   return buildUrl({ protocol, hostname, pathname, search: searchParams });
 }
+
+export function createBuildRequests(protocol, domain, path) {
+  return function(validBidRequests, bidderRequest) {
+    const referer = bidderRequest?.refererInfo?.page || window.location.href;
+    const { bidRequests, beaconParams } = buildBidRequestsAndParams(validBidRequests, referer);
+    const url = buildEndpointUrl(protocol, domain, path, beaconParams);
+    return {
+      method: 'POST',
+      url,
+      data: JSON.stringify(bidRequests)
+    };
+  };
+}
+
+export function interpretMIResponse(serverResponse, bidRequest, spec) {
+  const validBids = JSON.parse(bidRequest.data);
+  if (typeof serverResponse.body === 'undefined') {
+    return [];
+  }
+
+  return validBids
+    .map(bid => ({ bid, ad: serverResponse.body[bid.adUnitCode] }))
+    .filter(item => item.ad)
+    .map(item => spec.adResponse(item.bid, item.ad));
+}
+
+export function createOnBidWon(protocol, domain, postFn = postRequest) {
+  return function(data) {
+    data.winNotification.forEach(function(unitWon) {
+      const bidWonUrl = buildEndpointUrl(protocol, domain, unitWon.path);
+      if (unitWon.method === 'POST') {
+        postFn(bidWonUrl, JSON.stringify(unitWon.data));
+      }
+    });
+    return true;
+  };
+}
+
+export function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent) {
+  const syncs = [];
+
+  if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
+    return syncs;
+  }
+
+  const appendGdprParams = function(url, gdprParams) {
+    if (gdprParams === null) {
+      return url;
+    }
+
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') + gdprParams;
+  };
+
+  let gdprParams = null;
+  if (gdprConsent) {
+    if (typeof gdprConsent.gdprApplies === 'boolean') {
+      gdprParams = `gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
+    } else {
+      gdprParams = `gdpr_consent=${gdprConsent.consentString}`;
+    }
+  }
+
+  serverResponses.forEach(resp => {
+    if (resp.body) {
+      Object.keys(resp.body).map(key => {
+        const respObject = resp.body[key];
+        if (
+          respObject['syncs'] !== undefined &&
+          Array.isArray(respObject.syncs) &&
+          respObject.syncs.length > 0
+        ) {
+          if (syncOptions.iframeEnabled) {
+            respObject.syncs
+              .filter(function(syncIframeObject) {
+                if (
+                  syncIframeObject['type'] !== undefined &&
+                  syncIframeObject['link'] !== undefined &&
+                  syncIframeObject.type === 'iframe'
+                ) {
+                  return true;
+                }
+                return false;
+              })
+              .forEach(function(syncIframeObject) {
+                syncs.push({
+                  type: 'iframe',
+                  url: appendGdprParams(syncIframeObject.link, gdprParams)
+                });
+              });
+          }
+          if (syncOptions.pixelEnabled) {
+            respObject.syncs
+              .filter(function(syncImageObject) {
+                if (
+                  syncImageObject['type'] !== undefined &&
+                  syncImageObject['link'] !== undefined &&
+                  syncImageObject.type === 'image'
+                ) {
+                  return true;
+                }
+                return false;
+              })
+              .forEach(function(syncImageObject) {
+                syncs.push({
+                  type: 'image',
+                  url: appendGdprParams(syncImageObject.link, gdprParams)
+                });
+              });
+          }
+        }
+      });
+    }
+  });
+
+  return syncs;
+}

--- a/modules/adpartnerBidAdapter.js
+++ b/modules/adpartnerBidAdapter.js
@@ -1,5 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { buildBidRequestsAndParams, postRequest, buildEndpointUrl } from '../libraries/mediaImpactUtils/index.js';
+import { createBuildRequests, interpretMIResponse, createOnBidWon, getUserSyncs, postRequest } from '../libraries/mediaImpactUtils/index.js';
 
 const BIDDER_CODE = 'adpartner';
 export const ENDPOINT_PROTOCOL = 'https';
@@ -13,37 +13,10 @@ export const spec = {
     return !!parseInt(bidRequest.params.unitId) || !!parseInt(bidRequest.params.partnerId);
   },
 
-  buildRequests: function (validBidRequests, bidderRequest) {
-    const referer = bidderRequest?.refererInfo?.page || window.location.href;
-
-    // Use the common function to build bidRequests and beaconParams
-    const { bidRequests, beaconParams } = buildBidRequestsAndParams(validBidRequests, referer);
-
-    const adPartnerRequestUrl = buildEndpointUrl(
-      ENDPOINT_PROTOCOL,
-      ENDPOINT_DOMAIN,
-      ENDPOINT_PATH,
-      beaconParams
-    );
-
-    return {
-      method: 'POST',
-      url: adPartnerRequestUrl,
-      data: JSON.stringify(bidRequests),
-    };
-  },
+  buildRequests: createBuildRequests(ENDPOINT_PROTOCOL, ENDPOINT_DOMAIN, ENDPOINT_PATH),
 
   interpretResponse: function (serverResponse, bidRequest) {
-    const validBids = JSON.parse(bidRequest.data);
-
-    if (typeof serverResponse.body === 'undefined') {
-      return [];
-    }
-
-    return validBids
-      .map(bid => ({ bid: bid, ad: serverResponse.body[bid.adUnitCode] }))
-      .filter(item => item.ad)
-      .map(item => spec.adResponse(item.bid, item.ad));
+    return interpretMIResponse(serverResponse, bidRequest, spec);
   },
 
   adResponse: function (bid, ad) {
@@ -65,85 +38,10 @@ export const spec = {
   },
 
   onBidWon: function (data) {
-    data.winNotification.forEach(function (unitWon) {
-      const adPartnerBidWonUrl = buildEndpointUrl(
-        ENDPOINT_PROTOCOL,
-        ENDPOINT_DOMAIN,
-        unitWon.path
-      );
-
-      if (unitWon.method === 'POST') {
-        postRequest(adPartnerBidWonUrl, JSON.stringify(unitWon.data));
-      }
-    });
-
-    return true;
+    return createOnBidWon(ENDPOINT_PROTOCOL, ENDPOINT_DOMAIN, postRequest)(data);
   },
 
-  getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
-    const syncs = [];
-
-    if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
-      return syncs;
-    }
-
-    const appendGdprParams = function (url, gdprParams) {
-      if (gdprParams === null) {
-        return url;
-      }
-
-      return url + (url.indexOf('?') >= 0 ? '&' : '?') + gdprParams;
-    };
-
-    let gdprParams = null;
-    if (gdprConsent) {
-      if (typeof gdprConsent.gdprApplies === 'boolean') {
-        gdprParams = `gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
-      } else {
-        gdprParams = `gdpr_consent=${gdprConsent.consentString}`;
-      }
-    }
-
-    serverResponses.forEach(resp => {
-      if (resp.body) {
-        Object.keys(resp.body).map(function(key, index) {
-          const respObject = resp.body[key];
-          if (respObject['syncs'] !== undefined &&
-            Array.isArray(respObject.syncs) &&
-            respObject.syncs.length > 0) {
-            if (syncOptions.iframeEnabled) {
-              respObject.syncs.filter(function (syncIframeObject) {
-                if (syncIframeObject['type'] !== undefined &&
-                  syncIframeObject['link'] !== undefined &&
-                  syncIframeObject.type === 'iframe') { return true; }
-                return false;
-              }).forEach(function (syncIframeObject) {
-                syncs.push({
-                  type: 'iframe',
-                  url: appendGdprParams(syncIframeObject.link, gdprParams)
-                });
-              });
-            }
-            if (syncOptions.pixelEnabled) {
-              respObject.syncs.filter(function (syncImageObject) {
-                if (syncImageObject['type'] !== undefined &&
-                  syncImageObject['link'] !== undefined &&
-                  syncImageObject.type === 'image') { return true; }
-                return false;
-              }).forEach(function (syncImageObject) {
-                syncs.push({
-                  type: 'image',
-                  url: appendGdprParams(syncImageObject.link, gdprParams)
-                });
-              });
-            }
-          }
-        });
-      }
-    });
-
-    return syncs;
-  },
+  getUserSyncs: getUserSyncs,
 };
 
 registerBidder(spec);

--- a/modules/mediaimpactBidAdapter.js
+++ b/modules/mediaimpactBidAdapter.js
@@ -1,5 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { buildBidRequestsAndParams, postRequest, buildEndpointUrl } from '../libraries/mediaImpactUtils/index.js';
+import { createBuildRequests, interpretMIResponse, createOnBidWon, getUserSyncs, postRequest } from '../libraries/mediaImpactUtils/index.js';
 
 const BIDDER_CODE = 'mediaimpact';
 export const ENDPOINT_PROTOCOL = 'https';
@@ -13,37 +13,10 @@ export const spec = {
     return !!parseInt(bidRequest.params.unitId) || !!parseInt(bidRequest.params.partnerId);
   },
 
-  buildRequests: function (validBidRequests, bidderRequest) {
-    const referer = bidderRequest?.refererInfo?.page || window.location.href;
-
-    // Use the common function to build bidRequests and beaconParams
-    const { bidRequests, beaconParams } = buildBidRequestsAndParams(validBidRequests, referer);
-
-    const adRequestUrl = buildEndpointUrl(
-      ENDPOINT_PROTOCOL,
-      ENDPOINT_DOMAIN,
-      ENDPOINT_PATH,
-      beaconParams
-    );
-
-    return {
-      method: 'POST',
-      url: adRequestUrl,
-      data: JSON.stringify(bidRequests),
-    };
-  },
+  buildRequests: createBuildRequests(ENDPOINT_PROTOCOL, ENDPOINT_DOMAIN, ENDPOINT_PATH),
 
   interpretResponse: function (serverResponse, bidRequest) {
-    const validBids = JSON.parse(bidRequest.data);
-
-    if (typeof serverResponse.body === 'undefined') {
-      return [];
-    }
-
-    return validBids
-      .map(bid => ({ bid: bid, ad: serverResponse.body[bid.adUnitCode] }))
-      .filter(item => item.ad)
-      .map(item => spec.adResponse(item.bid, item.ad));
+    return interpretMIResponse(serverResponse, bidRequest, spec);
   },
 
   adResponse: function (bid, ad) {
@@ -63,85 +36,10 @@ export const spec = {
   },
 
   onBidWon: function (data) {
-    data.winNotification.forEach(function (unitWon) {
-      const adBidWonUrl = buildEndpointUrl(
-        ENDPOINT_PROTOCOL,
-        ENDPOINT_DOMAIN,
-        unitWon.path
-      );
-
-      if (unitWon.method === 'POST') {
-        postRequest(adBidWonUrl, JSON.stringify(unitWon.data));
-      }
-    });
-
-    return true;
+    return createOnBidWon(ENDPOINT_PROTOCOL, ENDPOINT_DOMAIN, postRequest)(data);
   },
 
-  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
-    const syncs = [];
-
-    if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
-      return syncs;
-    }
-
-    const appendGdprParams = function (url, gdprParams) {
-      if (gdprParams === null) {
-        return url;
-      }
-
-      return url + (url.indexOf('?') >= 0 ? '&' : '?') + gdprParams;
-    };
-
-    let gdprParams = null;
-    if (gdprConsent) {
-      if (typeof gdprConsent.gdprApplies === 'boolean') {
-        gdprParams = `gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
-      } else {
-        gdprParams = `gdpr_consent=${gdprConsent.consentString}`;
-      }
-    }
-
-    serverResponses.forEach(resp => {
-      if (resp.body) {
-        Object.keys(resp.body).map(function(key, index) {
-          const respObject = resp.body[key];
-          if (respObject['syncs'] !== undefined &&
-            Array.isArray(respObject.syncs) &&
-            respObject.syncs.length > 0) {
-            if (syncOptions.iframeEnabled) {
-              respObject.syncs.filter(function (syncIframeObject) {
-                if (syncIframeObject['type'] !== undefined &&
-                  syncIframeObject['link'] !== undefined &&
-                  syncIframeObject.type === 'iframe') { return true; }
-                return false;
-              }).forEach(function (syncIframeObject) {
-                syncs.push({
-                  type: 'iframe',
-                  url: appendGdprParams(syncIframeObject.link, gdprParams)
-                });
-              });
-            }
-            if (syncOptions.pixelEnabled) {
-              respObject.syncs.filter(function (syncImageObject) {
-                if (syncImageObject['type'] !== undefined &&
-                  syncImageObject['link'] !== undefined &&
-                  syncImageObject.type === 'image') { return true; }
-                return false;
-              }).forEach(function (syncImageObject) {
-                syncs.push({
-                  type: 'image',
-                  url: appendGdprParams(syncImageObject.link, gdprParams)
-                });
-              });
-            }
-          }
-        });
-      }
-    });
-
-    return syncs;
-  },
+  getUserSyncs: getUserSyncs,
 };
 
 registerBidder(spec);


### PR DESCRIPTION
## Summary
- add helper functions to `mediaImpactUtils`
- use common helpers in `adpartner` and `mediaimpact` adapters
- remove duplicated logic

## Testing
- `npx eslint libraries/mediaImpactUtils/index.js modules/adpartnerBidAdapter.js modules/mediaimpactBidAdapter.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/adpartnerBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/mediaimpactBidAdapter_spec.js`

------
https://chatgpt.com/codex/tasks/task_b_687eb9645068832bbf2671d547962518