### PR TITLE
Core: prevent multiple message listeners

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -29,10 +29,16 @@ if (FEATURES.NATIVE) {
   });
 }
 
+let messageListenerAdded = false;
+function onMessage(ev) {
+  receiveMessage(ev);
+}
+
 export function listenMessagesFromCreative() {
-  window.addEventListener('message', function (ev) {
-    receiveMessage(ev);
-  }, false);
+  if (!messageListenerAdded) {
+    window.addEventListener('message', onMessage, false);
+    messageListenerAdded = true;
+  }
 }
 
 export function getReplier(ev) {

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -1,4 +1,4 @@
-import {getReplier, receiveMessage, resizeRemoteCreative} from 'src/secureCreatives.js';
+import {getReplier, receiveMessage, resizeRemoteCreative, listenMessagesFromCreative} from 'src/secureCreatives.js';
 import * as utils from 'src/utils.js';
 import {getAdUnits, getBidRequests, getBidResponses} from 'test/fixtures/fixtures.js';
 import {auctionManager} from 'src/auctionManager.js';
@@ -589,5 +589,14 @@ describe('secureCreatives', () => {
       });
       sinon.assert.notCalled(document.getElementById);
     })
+  })
+
+  describe('listenMessagesFromCreative', () => {
+    it('should only add one listener when called multiple times', () => {
+      const stub = sandbox.stub(window, 'addEventListener');
+      listenMessagesFromCreative();
+      listenMessagesFromCreative();
+      sinon.assert.calledOnce(stub);
+    });
   })
 });


### PR DESCRIPTION
## Summary
- avoid repeated message listeners in secure creative handling
- test listener registration

## Testing
- `npx eslint --cache --cache-strategy content src/secureCreatives.js test/spec/unit/secureCreatives_spec.js`
- `npx gulp test --nolint --file test/spec/unit/secureCreatives_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_687ebe2d8d94832baa779c504b2a5bf4