### PR TITLE
Docs: update prebid cache URL

### DIFF
--- a/modules/asoBidAdapter.md
+++ b/modules/asoBidAdapter.md
@@ -72,7 +72,7 @@ The Adserver.Online Bid Adapter expects Prebid Cache (for video) to be enabled.
 ```
 pbjs.setConfig({
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/modules/exadsBidAdapter.md
+++ b/modules/exadsBidAdapter.md
@@ -30,7 +30,7 @@ Use `setConfig` to instruct Prebid.js to initilize the exadsBidAdapter, as speci
 ```js
 pbjs.setConfig({
     debug: false,
-    //cache: { url: "https://prebid.adnxs.com/pbc/v1/cache" },
+    //cache: { url: "https://prebid.example.com/pbc/v1/cache" },
     consentManagement: {
         gdpr: {
             cmpApi: 'static',

--- a/modules/ixBidAdapter.md
+++ b/modules/ixBidAdapter.md
@@ -339,7 +339,7 @@ Note that the IX adapter expects a client-side Prebid Cache to be enabled for in
 pbjs.setConfig({
     usePrebidCache: true,
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/modules/limelightDigitalBidAdapter.md
+++ b/modules/limelightDigitalBidAdapter.md
@@ -64,7 +64,7 @@ The Limelight Digital Exchange Bidder Adapter expects Prebid Cache(for video) to
 pbjs.setConfig({
     usePrebidCache: true,
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/modules/lkqdBidAdapter.md
+++ b/modules/lkqdBidAdapter.md
@@ -43,7 +43,7 @@ The LKQD Bidder Adapter expects Prebid Cache to be enabled so that we can store 
 pbjs.setConfig({
     usePrebidCache: true,
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```

--- a/modules/operaadsBidAdapter.md
+++ b/modules/operaadsBidAdapter.md
@@ -106,7 +106,7 @@ var adUnits = [{
 ```javascript
 pbjs.setConfig({
   cache: {
-    url: 'https://prebid.adnxs.com/pbc/v1/cache'
+    url: 'https://prebid.example.com/pbc/v1/cache'
   }
 });
 ```

--- a/modules/pstudioBidAdapter.md
+++ b/modules/pstudioBidAdapter.md
@@ -141,7 +141,7 @@ For video ads, Prebid cache must be enabled, as the demand partner does not supp
 ```js
 pbjs.setConfig({
   cache: {
-    url: 'https://prebid.adnxs.com/pbc/v1/cache',
+    url: 'https://prebid.example.com/pbc/v1/cache',
   },
 });
 ```

--- a/modules/pubmaticBidAdapter.md
+++ b/modules/pubmaticBidAdapter.md
@@ -203,7 +203,7 @@ For Video ads, prebid cache needs to be enabled for PubMatic adapter.
 pbjs.setConfig({
     debug: true,
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 

--- a/modules/vdoaiBidAdapter.md
+++ b/modules/vdoaiBidAdapter.md
@@ -64,7 +64,7 @@ The VDO.AI Bidder Adapter expects Prebid Cache(for video) to be enabled so that 
 pbjs.setConfig({
     usePrebidCache: true,
     cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'https://prebid.example.com/pbc/v1/cache'
     }
 });
 ```


### PR DESCRIPTION
## Summary
- switch prebid cache URLs in module docs to `prebid.example.com`

## Testing
- `npx eslint --cache --cache-strategy content`
- `npx gulp lint`


------
https://chatgpt.com/codex/tasks/task_b_68823a1b6714832ba49d97d903882835