### PR TITLE
Tests: use generic cache URL

### DIFF
--- a/test/pages/instream.html
+++ b/test/pages/instream.html
@@ -63,7 +63,7 @@
                     enableTIDs: true,
                     debug: true,
                     cache: {
-                      url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                        url: 'https://prebid.adnxs.com/pbc/v1/cache'
                     }
                 });
         pbjs.requestBids({

--- a/test/pages/instream.html
+++ b/test/pages/instream.html
@@ -63,7 +63,7 @@
                     enableTIDs: true,
                     debug: true,
                     cache: {
-                        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+                        url: 'http://test.cache.url/endpoint'
                     }
                 });
         pbjs.requestBids({

--- a/test/pages/instream.html
+++ b/test/pages/instream.html
@@ -63,7 +63,7 @@
                     enableTIDs: true,
                     debug: true,
                     cache: {
-                      useLocal: true,
+                      url: 'https://prebid.adnxs.com/pbc/v1/cache'
                     }
                 });
         pbjs.requestBids({

--- a/test/pages/instream.html
+++ b/test/pages/instream.html
@@ -63,7 +63,7 @@
                     enableTIDs: true,
                     debug: true,
                     cache: {
-                        url: 'https://test.cache.url/endpoint'
+                      useLocal: true,
                     }
                 });
         pbjs.requestBids({

--- a/test/pages/instream.html
+++ b/test/pages/instream.html
@@ -63,7 +63,7 @@
                     enableTIDs: true,
                     debug: true,
                     cache: {
-                        url: 'http://test.cache.url/endpoint'
+                        url: 'https://test.cache.url/endpoint'
                     }
                 });
         pbjs.requestBids({

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -273,7 +273,7 @@ describe('auctionmanager.js', function () {
       it('No bidder level configuration defined - default for video', function () {
         config.setConfig({
           cache: {
-            url: 'http://test.cache.url/endpoint'
+            url: 'https://test.cache.url/endpoint'
           }
         });
         $$PREBID_GLOBAL$$.bidderSettings = {};
@@ -366,7 +366,7 @@ describe('auctionmanager.js', function () {
       it('Custom configuration for all bidders with video bid', function () {
         config.setConfig({
           cache: {
-            url: 'http://test.cache.url/endpoint'
+            url: 'https://test.cache.url/endpoint'
           }
         });
         const videoBid = utils.deepClone(bid);
@@ -1968,7 +1968,7 @@ describe('auctionmanager.js', function () {
         doneSpy = sinon.spy();
         config.setConfig({
           cache: {
-            url: 'http://test.cache.url/endpoint'
+            url: 'https://test.cache.url/endpoint'
           }
         });
       });

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -233,7 +233,7 @@ describe('auctionmanager.js', function () {
       if (bid.mediaType === 'video') {
         expected[TARGETING_KEYS.UUID] = bid.videoCacheKey;
         expected[TARGETING_KEYS.CACHE_ID] = bid.videoCacheKey;
-        expected[TARGETING_KEYS.CACHE_HOST] = 'prebid.adnxs.com';
+        expected[TARGETING_KEYS.CACHE_HOST] = 'test.cache.url';
       }
       if (!keys) {
         return expected;
@@ -273,7 +273,7 @@ describe('auctionmanager.js', function () {
       it('No bidder level configuration defined - default for video', function () {
         config.setConfig({
           cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'http://test.cache.url/endpoint'
           }
         });
         $$PREBID_GLOBAL$$.bidderSettings = {};
@@ -366,7 +366,7 @@ describe('auctionmanager.js', function () {
       it('Custom configuration for all bidders with video bid', function () {
         config.setConfig({
           cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'http://test.cache.url/endpoint'
           }
         });
         const videoBid = utils.deepClone(bid);
@@ -1968,7 +1968,7 @@ describe('auctionmanager.js', function () {
         doneSpy = sinon.spy();
         config.setConfig({
           cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache'
+            url: 'http://test.cache.url/endpoint'
           }
         });
       });

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -50,7 +50,7 @@ describe('adpod.js', function () {
       clock = sinon.useFakeTimers();
       config.setConfig({
         cache: {
-          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+          url: 'http://test.cache.url/endpoint'
         }
       });
     });

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -50,7 +50,7 @@ describe('adpod.js', function () {
       clock = sinon.useFakeTimers();
       config.setConfig({
         cache: {
-          url: 'http://test.cache.url/endpoint'
+          url: 'https://test.cache.url/endpoint'
         }
       });
     });
@@ -945,7 +945,7 @@ describe('adpod.js', function () {
       bailResult = null;
       config.setConfig({
         cache: {
-          url: 'http://test.cache.url/endpoint'
+          url: 'https://test.cache.url/endpoint'
         },
         adpod: {
           brandCategoryExclusion: true
@@ -974,7 +974,7 @@ describe('adpod.js', function () {
     it('returns true when adpod bid is properly setup', function() {
       config.setConfig({
         cache: {
-          url: 'http://test.cache.url/endpoint'
+          url: 'https://test.cache.url/endpoint'
         },
         adpod: {
           brandCategoryExclusion: false

--- a/test/spec/modules/medianetAnalyticsAdapter_spec.js
+++ b/test/spec/modules/medianetAnalyticsAdapter_spec.js
@@ -453,7 +453,7 @@ describe('Media.net Analytics Adapter', function () {
       // Set config required for vastTrackerHandler
       config.setConfig({
         cache: {
-          url: 'http://test.cache.url/endpoint'
+          url: 'https://test.cache.url/endpoint'
         }
       });
     });

--- a/test/spec/modules/medianetAnalyticsAdapter_spec.js
+++ b/test/spec/modules/medianetAnalyticsAdapter_spec.js
@@ -453,7 +453,7 @@ describe('Media.net Analytics Adapter', function () {
       // Set config required for vastTrackerHandler
       config.setConfig({
         cache: {
-          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+          url: 'http://test.cache.url/endpoint'
         }
       });
     });

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -38,7 +38,7 @@ describe('The video cache', function () {
     beforeEach(function () {
       config.setConfig({
         cache: {
-          url: 'https://prebid.adnxs.com/pbc/v1/cache'
+          url: 'http://test.cache.url/endpoint'
         }
       })
     });
@@ -160,7 +160,7 @@ describe('The video cache', function () {
       store(bids, function () { });
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('https://prebid.adnxs.com/pbc/v1/cache');
+      request.url.should.equal('http://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
       const payload = {
         puts: [{
@@ -181,7 +181,7 @@ describe('The video cache', function () {
     it('should include additional params in request payload should config.cache.vasttrack be true', () => {
       config.setConfig({
         cache: {
-          url: 'https://prebid.adnxs.com/pbc/v1/cache',
+          url: 'http://test.cache.url/endpoint',
           vasttrack: true
         }
       });
@@ -210,7 +210,7 @@ describe('The video cache', function () {
       store(bids, function () { });
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('https://prebid.adnxs.com/pbc/v1/cache');
+      request.url.should.equal('http://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
       const payload = {
         puts: [{
@@ -238,7 +238,7 @@ describe('The video cache', function () {
     it('should include additional params in request payload should config.cache.vasttrack be true - with timestamp', () => {
       config.setConfig({
         cache: {
-          url: 'https://prebid.adnxs.com/pbc/v1/cache',
+          url: 'http://test.cache.url/endpoint',
           vasttrack: true
         }
       });
@@ -281,7 +281,7 @@ describe('The video cache', function () {
 
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('https://prebid.adnxs.com/pbc/v1/cache');
+      request.url.should.equal('http://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
       const payload = {
         puts: [{
@@ -316,7 +316,7 @@ describe('The video cache', function () {
 
         config.setConfig({
           cache: {
-            url: 'https://prebid.adnxs.com/pbc/v1/cache',
+            url: 'http://test.cache.url/endpoint',
             batchSize: 3,
             batchTimeout: 20
           }
@@ -344,7 +344,7 @@ describe('The video cache', function () {
 
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('https://prebid.adnxs.com/pbc/v1/cache');
+      request.url.should.equal('http://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
 
       JSON.parse(request.requestBody).should.deep.equal({
@@ -435,7 +435,7 @@ describe('The getCache function', function () {
   beforeEach(function () {
     config.setConfig({
       cache: {
-        url: 'https://prebid.adnxs.com/pbc/v1/cache'
+        url: 'http://test.cache.url/endpoint'
       }
     })
   });
@@ -447,6 +447,6 @@ describe('The getCache function', function () {
   it('should return the expected URL', function () {
     const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
     const url = getCacheUrl(uuid);
-    url.should.equal(`https://prebid.adnxs.com/pbc/v1/cache?uuid=${uuid}`);
+    url.should.equal(`http://test.cache.url/endpoint?uuid=${uuid}`);
   });
 })

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -38,7 +38,7 @@ describe('The video cache', function () {
     beforeEach(function () {
       config.setConfig({
         cache: {
-          url: 'http://test.cache.url/endpoint'
+          url: 'https://test.cache.url/endpoint'
         }
       })
     });
@@ -160,7 +160,7 @@ describe('The video cache', function () {
       store(bids, function () { });
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('http://test.cache.url/endpoint');
+      request.url.should.equal('https://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
       const payload = {
         puts: [{
@@ -181,7 +181,7 @@ describe('The video cache', function () {
     it('should include additional params in request payload should config.cache.vasttrack be true', () => {
       config.setConfig({
         cache: {
-          url: 'http://test.cache.url/endpoint',
+          url: 'https://test.cache.url/endpoint',
           vasttrack: true
         }
       });
@@ -210,7 +210,7 @@ describe('The video cache', function () {
       store(bids, function () { });
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('http://test.cache.url/endpoint');
+      request.url.should.equal('https://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
       const payload = {
         puts: [{
@@ -238,7 +238,7 @@ describe('The video cache', function () {
     it('should include additional params in request payload should config.cache.vasttrack be true - with timestamp', () => {
       config.setConfig({
         cache: {
-          url: 'http://test.cache.url/endpoint',
+          url: 'https://test.cache.url/endpoint',
           vasttrack: true
         }
       });
@@ -281,7 +281,7 @@ describe('The video cache', function () {
 
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('http://test.cache.url/endpoint');
+      request.url.should.equal('https://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
       const payload = {
         puts: [{
@@ -316,7 +316,7 @@ describe('The video cache', function () {
 
         config.setConfig({
           cache: {
-            url: 'http://test.cache.url/endpoint',
+            url: 'https://test.cache.url/endpoint',
             batchSize: 3,
             batchTimeout: 20
           }
@@ -344,7 +344,7 @@ describe('The video cache', function () {
 
       const request = server.requests[0];
       request.method.should.equal('POST');
-      request.url.should.equal('http://test.cache.url/endpoint');
+      request.url.should.equal('https://test.cache.url/endpoint');
       request.requestHeaders['Content-Type'].should.equal('text/plain');
 
       JSON.parse(request.requestBody).should.deep.equal({
@@ -435,7 +435,7 @@ describe('The getCache function', function () {
   beforeEach(function () {
     config.setConfig({
       cache: {
-        url: 'http://test.cache.url/endpoint'
+        url: 'https://test.cache.url/endpoint'
       }
     })
   });
@@ -447,6 +447,6 @@ describe('The getCache function', function () {
   it('should return the expected URL', function () {
     const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
     const url = getCacheUrl(uuid);
-    url.should.equal(`http://test.cache.url/endpoint?uuid=${uuid}`);
+    url.should.equal(`https://test.cache.url/endpoint?uuid=${uuid}`);
   });
 })


### PR DESCRIPTION
## Summary
- replace Prebid Cache address in tests with a placeholder
- revert unintended updates to longform fixtures

## Testing
- `npx eslint --cache --cache-strategy content test/spec/auctionmanager_spec.js test/spec/modules/adpod_spec.js test/spec/modules/medianetAnalyticsAdapter_spec.js test/spec/videoCache_spec.js`
- `npx gulp test --file test/spec/videoCache_spec.js --nolint`
- `npx gulp test --file test/spec/auctionmanager_spec.js --nolint`
- `npx gulp test --file test/spec/modules/adpod_spec.js --nolint`
- `npx gulp test --file test/spec/modules/medianetAnalyticsAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_68824144fafc832ba71c76624d379386