### PR TITLE
Core: clear native timers for tests

### DIFF
--- a/test/spec/modules/33acrossAnalyticsAdapter_spec.js
+++ b/test/spec/modules/33acrossAnalyticsAdapter_spec.js
@@ -17,6 +17,7 @@ describe('33acrossAnalyticsAdapter:', function () {
     sandbox = sinon.createSandbox({
       useFakeTimers: {
         now: new Date(2023, 3, 3, 0, 1, 33, 425),
+        shouldClearNativeTimers: true
       },
     });
 

--- a/test/spec/modules/geolocationRtdProvider_spec.js
+++ b/test/spec/modules/geolocationRtdProvider_spec.js
@@ -49,7 +49,10 @@ describe('Geolocation RTD Provider', function () {
       onDone = sinon.stub();
       permState = 'prompt';
       rtdConfig = {params: {}};
-      clock = sandbox.useFakeTimers(11000);
+      clock = sandbox.useFakeTimers({
+        now: 11000,
+        shouldClearNativeTimers: true
+      });
       sandbox.stub(navigator.geolocation, 'getCurrentPosition').value((cb) => {
         cb({coords: {latitude: 1, longitude: 2}, timestamp: 1000});
       });

--- a/test/spec/modules/instreamTracking_spec.js
+++ b/test/spec/modules/instreamTracking_spec.js
@@ -148,7 +148,7 @@ function getMockInput(mediaType) {
 describe('Instream Tracking', function () {
   beforeEach(function () {
     sandbox = sinon.createSandbox();
-    clock = sandbox.useFakeTimers();
+    clock = sandbox.useFakeTimers({shouldClearNativeTimers: true});
   });
 
   afterEach(function () {

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -35,7 +35,7 @@ describe('PubWise Prebid Analytics', function () {
 
   beforeEach(function() {
     sandbox = sinon.createSandbox();
-    clock = sandbox.useFakeTimers();
+    clock = sandbox.useFakeTimers({shouldClearNativeTimers: true});
     sandbox.stub(events, 'getEvents').returns([]);
 
     requests = server.requests;


### PR DESCRIPTION
## Summary
- remove fake timer warnings in `33acrossAnalyticsAdapter_spec.js` and `geolocationRtdProvider_spec.js`

## Testing
- `npx gulp lint --files "test/spec/modules/33acrossAnalyticsAdapter_spec.js,test/spec/modules/geolocationRtdProvider_spec.js"`
- `npx gulp test --file test/spec/modules/33acrossAnalyticsAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/geolocationRtdProvider_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6887d5deb664832ba75ef1d8c7ad3d09