### PR TITLE
Modules: use clear native timers

### DIFF
--- a/test/spec/modules/instreamTracking_spec.js
+++ b/test/spec/modules/instreamTracking_spec.js
@@ -148,7 +148,7 @@ function getMockInput(mediaType) {
 describe('Instream Tracking', function () {
   beforeEach(function () {
     sandbox = sinon.createSandbox();
-    clock = sandbox.useFakeTimers();
+    clock = sandbox.useFakeTimers({shouldClearNativeTimers: true});
   });
 
   afterEach(function () {

--- a/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubwiseAnalyticsAdapter_spec.js
@@ -35,7 +35,7 @@ describe('PubWise Prebid Analytics', function () {
 
   beforeEach(function() {
     sandbox = sinon.createSandbox();
-    clock = sandbox.useFakeTimers();
+    clock = sandbox.useFakeTimers({shouldClearNativeTimers: true});
     sandbox.stub(events, 'getEvents').returns([]);
 
     requests = server.requests;


### PR DESCRIPTION
## Summary
- update module tests to use `shouldClearNativeTimers`

## Testing
- `npx eslint --cache --cache-strategy content test/spec/modules/pubwiseAnalyticsAdapter_spec.js test/spec/modules/instreamTracking_spec.js`
- `npx gulp test --file test/spec/modules/pubwiseAnalyticsAdapter_spec.js --nolint`
- `npx gulp test --file test/spec/modules/instreamTracking_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6887d59a1e44832b8c44916409454e7c