### PR TITLE
Gamoshi Adapter: fix missing returns

### DIFF
--- a/libraries/mediaImpactUtils/index.js
+++ b/libraries/mediaImpactUtils/index.js
@@ -123,7 +123,7 @@ export function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConse
 
   serverResponses.forEach(resp => {
     if (resp.body) {
-      Object.keys(resp.body).map(key => {
+      Object.keys(resp.body).forEach(key => {
         const respObject = resp.body[key];
         if (
           respObject['syncs'] !== undefined &&

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -155,7 +155,7 @@ export const spec = {
         let type = bidRequest.mediaTypes['banner'] ? BANNER : VIDEO;
         if (!supplyPartnerId && type != null) {
           logError('Gamoshi: supplyPartnerId is required');
-          return;
+          return null;
         }
         bidRequest.mediaTypes.mediaType = type;
         const bidderCode = bidderRequest.bidderCode || 'gamoshi';
@@ -168,7 +168,7 @@ export const spec = {
         });
         if (!ortbRequest || !ortbRequest.imp || ortbRequest.imp.length === 0) {
           logWarn('Gamoshi: Failed to build valid ORTB request');
-          return;
+          return null;
         }
         return {
           method: 'POST',
@@ -178,6 +178,7 @@ export const spec = {
         };
       } catch (error) {
         logError('Gamoshi: Error building request:', error);
+        return null;
       }
     }).filter(Boolean);
   },


### PR DESCRIPTION
## Summary
- fix array-callback-return lint issue in mediaImpactUtils
- ensure gamoshi adapter map callback always returns a value

## Testing
- `npx eslint libraries/mediaImpactUtils/index.js modules/gamoshiBidAdapter.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/modules/gamoshiBidAdapter_spec.js --nolint`


------
https://chatgpt.com/codex/tasks/task_b_6888e00b7214832bb58f8795612bfae3