### PR TITLE
Core: extend webdriver session timeouts

### DIFF
--- a/test/helpers/testing-utils.js
+++ b/test/helpers/testing-utils.js
@@ -1,5 +1,5 @@
 const {expect} = require('chai');
-const DEFAULT_TIMEOUT = 2000;
+const DEFAULT_TIMEOUT = 10000; // allow more time for BrowserStack sessions
 const utils = {
   host: (process.env.TEST_SERVER_HOST) ? process.env.TEST_SERVER_HOST : 'localhost',
   protocol: (process.env.TEST_SERVER_PROTOCOL) ? 'https' : 'http',
@@ -14,7 +14,7 @@ const utils = {
     const iframe = await $(frameRef);
     browser.switchFrame(iframe);
   },
-  async loadAndWaitForElement(url, selector, pause = 3000, timeout = DEFAULT_TIMEOUT, retries = 3, attempt = 1) {
+  async loadAndWaitForElement(url, selector, pause = 5000, timeout = DEFAULT_TIMEOUT, retries = 3, attempt = 1) {
     await browser.url(url);
     await browser.pause(pause);
     if (selector != null) {
@@ -27,7 +27,7 @@ const utils = {
       }
     }
   },
-  setupTest({url, waitFor, expectGAMCreative = null, pause = 3000, timeout = DEFAULT_TIMEOUT, retries = 3}, name, fn) {
+  setupTest({url, waitFor, expectGAMCreative = null, pause = 5000, timeout = DEFAULT_TIMEOUT, retries = 3}, name, fn) {
     describe(name, function () {
       this.retries(retries);
       before(() => utils.loadAndWaitForElement(url, waitFor, pause, timeout, retries));

--- a/wdio.shared.conf.js
+++ b/wdio.shared.conf.js
@@ -19,8 +19,8 @@ exports.config = {
   logLevel: 'info', // put option here: info | trace | debug | warn| error | silent
   bail: 1,
   waitforTimeout: 60000, // Default timeout for all waitFor* commands.
-  connectionRetryTimeout: 60000, // Default timeout in milliseconds for request if Selenium Grid doesn't send response
-  connectionRetryCount: 1, // Default request retries count
+  connectionRetryTimeout: 120000, // allow BrowserStack more time to start the session
+  connectionRetryCount: 3, // additional retries for transient session issues
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',

--- a/wdio.shared.conf.js
+++ b/wdio.shared.conf.js
@@ -19,7 +19,7 @@ exports.config = {
   logLevel: 'info', // put option here: info | trace | debug | warn| error | silent
   bail: 1,
   waitforTimeout: 60000, // Default timeout for all waitFor* commands.
-  connectionRetryTimeout: 120000, // allow BrowserStack more time to start the session
+  connectionRetryTimeout: 60000, // Default timeout in milliseconds for request if Selenium Grid doesn't send response
   connectionRetryCount: 3, // additional retries for transient session issues
   framework: 'mocha',
   mochaOpts: {


### PR DESCRIPTION
## Summary
- increase BrowserStack retry timeouts and counts for WebdriverIO
- wait longer for iframe rendering in e2e helper

## Testing
- `npx eslint test/helpers/testing-utils.js --cache --cache-strategy content`
- `npx gulp test --file test/spec/adloader_spec.js --nolint` *(failed: timed out during bundling)*

------
https://chatgpt.com/codex/tasks/task_b_6888e0d17978832b8b4eee6a634e8dd4