### PR TITLE
Core: use uuid for bid ids

### DIFF
--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -277,7 +277,7 @@ function getBids<SRC extends BidSource, BIDDER extends BidderCode | null>({bidde
           transactionId: adUnit.transactionId,
           adUnitId: adUnit.adUnitId,
           sizes: mediaTypes?.banner?.sizes || mediaTypes?.video?.playerSize || [],
-          bidId: (bid as any).bid_id || getUniqueIdentifierStr(),
+          bidId: (bid as any).bid_id || generateUUID(),
           bidderRequestId,
           auctionId,
           src,
@@ -513,7 +513,7 @@ const adapterManager = {
         const uniquePbsTid = generateUUID();
 
         (serverBidders.length === 0 && hasModuleBids ? [null] : serverBidders).forEach(bidderCode => {
-          const bidderRequestId = getUniqueIdentifierStr();
+          const bidderRequestId = generateUUID();
           const metrics = auctionMetrics.fork();
           const bidderRequest = addOrtb2({
             bidderCode,
@@ -552,7 +552,7 @@ const adapterManager = {
     // client adapters
     const adUnitsClientCopy = getAdUnitCopyForClientAdapters(adUnits);
     clientBidders.forEach(bidderCode => {
-      const bidderRequestId = getUniqueIdentifierStr();
+      const bidderRequestId = generateUUID();
       const metrics = auctionMetrics.fork();
       const bidderRequest = addOrtb2({
         bidderCode,


### PR DESCRIPTION
## Summary
- use generateUUID() for bidId and bidderRequestId instead of getUniqueIdentifierStr

## Testing
- `npx eslint --cache --cache-strategy content src/adapterManager.ts`
- `npx gulp test --file test/spec/modules/adWMGAnalyticsAdapter_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_688a57173a10832ba49f5ce5d30e2081