### PR TITLE
Core: restore fake timers in specs

### DIFF
--- a/test/spec/modules/adnuntiusAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adnuntiusAnalyticsAdapter_spec.js
@@ -309,6 +309,8 @@ describe('Adnuntius analytics adapter', function () {
   afterEach(function () {
     sandbox.restore();
     config.resetConfig();
+    clock.runAll();
+    clock.restore();
   });
 
   describe('when handling events', function () {

--- a/test/spec/modules/genericAnalyticsAdapter_spec.js
+++ b/test/spec/modules/genericAnalyticsAdapter_spec.js
@@ -17,6 +17,8 @@ describe('Generic analytics', () => {
     afterEach(() => {
       adapter.disableAnalytics();
       sandbox.restore();
+      clock.runAll();
+      clock.restore();
     });
 
     describe('configuration', () => {

--- a/test/spec/modules/geolocationRtdProvider_spec.js
+++ b/test/spec/modules/geolocationRtdProvider_spec.js
@@ -67,6 +67,11 @@ describe('Geolocation RTD Provider', function () {
       geolocationSubmodule.init(rtdConfig);
     });
 
+    afterEach(() => {
+      clock.runAll();
+      clock.restore();
+    });
+
     it('init should return true', function () {
       expect(geolocationSubmodule.init({})).is.true;
     });

--- a/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
+++ b/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
@@ -339,6 +339,8 @@ describe('Livewrapped analytics adapter', function () {
   afterEach(function () {
     sandbox.restore();
     config.resetConfig();
+    clock.runAll();
+    clock.restore();
   });
 
   describe('when handling events', function () {

--- a/test/spec/modules/magniteAnalyticsAdapter_spec.js
+++ b/test/spec/modules/magniteAnalyticsAdapter_spec.js
@@ -390,6 +390,8 @@ describe('magnite analytics adapter', function () {
     localStorageIsEnabledStub.restore();
     removeDataFromLocalStorageStub.restore();
     magniteAdapter.disableAnalytics();
+    clock.runAll();
+    clock.restore();
   });
 
   it('should require accountId', function () {

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -310,6 +310,8 @@ describe('pubmatic analytics adapter', function () {
   afterEach(function () {
     sandbox.restore();
     config.resetConfig();
+    clock.runAll();
+    clock.restore();
   });
 
   it('should require publisherId', function () {

--- a/test/spec/modules/r2b2AnalytiscAdapter_spec.js
+++ b/test/spec/modules/r2b2AnalytiscAdapter_spec.js
@@ -387,6 +387,8 @@ describe('r2b2 Analytics', function () {
     getGlobalStub.restore();
     ajaxStub.restore();
     r2b2Analytics.disableAnalytics();
+    clock.runAll();
+    clock.restore();
   });
 
   describe('config', () => {


### PR DESCRIPTION
## Summary
- restore Sinon fake timers in several adapter specs

## Testing
- `npx gulp test --nolint --file test/spec/modules/magniteAnalyticsAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/adnuntiusAnalyticsAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/genericAnalyticsAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/geolocationRtdProvider_spec.js`
- `npx gulp test --nolint --file test/spec/modules/livewrappedAnalyticsAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/pubmaticAnalyticsAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/r2b2AnalytiscAdapter_spec.js`


------
https://chatgpt.com/codex/tasks/task_b_688a765528f8832bb1b150b82cf97778