### PR TITLE
Core: clear gam video spec timers

### DIFF
--- a/test/spec/modules/gamAdServerVideo_spec.js
+++ b/test/spec/modules/gamAdServerVideo_spec.js
@@ -23,7 +23,7 @@ describe('The DFP video support module', function () {
     hook.ready();
   });
 
-  let sandbox, bid, adUnit;
+  let sandbox, bid, adUnit, serverRequestTimeout;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -38,6 +38,7 @@ describe('The DFP video support module', function () {
   });
 
   afterEach(() => {
+    clearTimeout(serverRequestTimeout);
     sandbox.restore();
   });
 
@@ -776,14 +777,12 @@ describe('The DFP video support module', function () {
 
     server.respond();
 
-    let timeout;
-
     const waitForSecondRequest = () => {
       if (server.requests.length >= 2) {
         server.respond();
-        clearTimeout(timeout);
+        clearTimeout(serverRequestTimeout);
       } else {
-        timeout = setTimeout(waitForSecondRequest, 50);
+        serverRequestTimeout = setTimeout(waitForSecondRequest, 50);
       }
     };
 


### PR DESCRIPTION
## Summary
- ensure local timers in `gamAdServerVideo_spec.js` get cleaned up between tests

## Testing
- `npx eslint --cache --cache-strategy content test/spec/modules/gamAdServerVideo_spec.js`
- `npx gulp test --file test/spec/modules/gamAdServerVideo_spec.js --nolint`

------
https://chatgpt.com/codex/tasks/task_b_688b7bd4c370832b86b2c4f41a7fc369