### PR TITLE
Teads Adapter: derive orientation from dimensions

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -25,6 +25,15 @@ const OB_USER_TOKEN_KEY = 'OB-USER-TOKEN';
 
 export const storage = getStorageManager({bidderCode: BIDDER_CODE});
 
+function getScreenOrientationFromDimensions(screenData) {
+  const width = screenData?.width;
+  const height = screenData?.height;
+
+  if (typeof width === 'number' && typeof height === 'number') {
+    return height >= width ? 'portrait-primary' : 'landscape-primary';
+  }
+}
+
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVL_ID,
@@ -59,6 +68,8 @@ export const spec = {
     const bids = validBidRequests.map(buildRequestObject);
     const topWindow = window.top;
 
+    const screenOrientation = getScreenOrientationFromDimensions(topWindow?.screen || screen);
+
     const payload = {
       referrer: getReferrerInfo(bidderRequest),
       pageReferrer: document.referrer,
@@ -73,7 +84,7 @@ export const spec = {
       deviceWidth: screen.width,
       deviceHeight: screen.height,
       devicePixelRatio: topWindow.devicePixelRatio,
-      screenOrientation: screen.orientation?.type,
+      screenOrientation: screenOrientation,
       historyLength: getHLen(),
       viewportHeight: getWinDimensions().visualViewport.height,
       viewportWidth: getWinDimensions().visualViewport.width,

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -368,12 +368,15 @@ describe('teadsBidAdapter', () => {
     it('should add screenOrientation info to payload', function () {
       const request = spec.buildRequests(bidRequests, bidderRequestDefault);
       const payload = JSON.parse(request.data);
-      const screenOrientation = window.top.screen.orientation?.type
+      const { width, height } = window.top.screen || {};
 
-      if (screenOrientation) {
+      if (typeof width === 'number' && typeof height === 'number') {
+        const screenOrientation = height >= width ? 'portrait-primary' : 'landscape-primary';
         expect(payload.screenOrientation).to.exist;
         expect(payload.screenOrientation).to.deep.equal(screenOrientation);
-      } else expect(payload.screenOrientation).to.not.exist;
+      } else {
+        expect(payload.screenOrientation).to.not.exist;
+      }
     });
 
     it('should add historyLength info to payload', function () {


### PR DESCRIPTION
## Summary
* Derive the Teads payload's screenOrientation value from available screen dimensions, defaulting ties to portrait-primary.【F:modules/teadsBidAdapter.js†L28-L88】
* Update the unit test to validate the new orientation fallback logic based on screen width and height values.【F:test/spec/modules/teadsBidAdapter_spec.js†L368-L379】

## Testing
* `npx eslint --cache --cache-strategy content modules/teadsBidAdapter.js test/spec/modules/teadsBidAdapter_spec.js`【4618be†L1-L3】
* `npx gulp test --nolint --file test/spec/modules/teadsBidAdapter_spec.js`【2d4d49†L1-L13】

------
https://chatgpt.com/codex/tasks/task_b_68d29ff27644832b8fc0ec39330deb2e