### PR TITLE
Permutive Modules: centralize GVL constant

### DIFF
--- a/metadata/modules.json
+++ b/metadata/modules.json
@@ -5248,7 +5248,7 @@
     {
       "componentType": "rtd",
       "componentName": "permutive",
-      "gvlid": 361,
+      "gvlid": null,
       "disclosureURL": null
     },
     {
@@ -5653,7 +5653,7 @@
     {
       "componentType": "userId",
       "componentName": "permutiveIdentityManagerId",
-      "gvlid": 361,
+      "gvlid": null,
       "disclosureURL": null,
       "aliasOf": null
     },

--- a/metadata/modules.json
+++ b/metadata/modules.json
@@ -5248,7 +5248,7 @@
     {
       "componentType": "rtd",
       "componentName": "permutive",
-      "gvlid": null,
+      "gvlid": 361,
       "disclosureURL": null
     },
     {
@@ -5653,7 +5653,7 @@
     {
       "componentType": "userId",
       "componentName": "permutiveIdentityManagerId",
-      "gvlid": null,
+      "gvlid": 361,
       "disclosureURL": null,
       "aliasOf": null
     },

--- a/metadata/modules/permutiveIdentityManagerIdSystem.json
+++ b/metadata/modules/permutiveIdentityManagerIdSystem.json
@@ -5,7 +5,7 @@
     {
       "componentType": "userId",
       "componentName": "permutiveIdentityManagerId",
-      "gvlid": 361,
+      "gvlid": null,
       "disclosureURL": null,
       "aliasOf": null
     }

--- a/metadata/modules/permutiveIdentityManagerIdSystem.json
+++ b/metadata/modules/permutiveIdentityManagerIdSystem.json
@@ -5,7 +5,7 @@
     {
       "componentType": "userId",
       "componentName": "permutiveIdentityManagerId",
-      "gvlid": null,
+      "gvlid": 361,
       "disclosureURL": null,
       "aliasOf": null
     }

--- a/metadata/modules/permutiveRtdProvider.json
+++ b/metadata/modules/permutiveRtdProvider.json
@@ -5,7 +5,7 @@
     {
       "componentType": "rtd",
       "componentName": "permutive",
-      "gvlid": null,
+      "gvlid": 361,
       "disclosureURL": null
     }
   ]

--- a/metadata/modules/permutiveRtdProvider.json
+++ b/metadata/modules/permutiveRtdProvider.json
@@ -5,7 +5,7 @@
     {
       "componentType": "rtd",
       "componentName": "permutive",
-      "gvlid": 361,
+      "gvlid": null,
       "disclosureURL": null
     }
   ]

--- a/modules/permutiveIdentityManagerIdSystem.js
+++ b/modules/permutiveIdentityManagerIdSystem.js
@@ -10,6 +10,7 @@ import {prefixLog, safeJSONParse} from '../src/utils.js'
  */
 
 const MODULE_NAME = 'permutiveIdentityManagerId'
+const PERMUTIVE_GVLID = 361
 const PERMUTIVE_ID_DATA_STORAGE_KEY = 'permutive-prebid-id'
 
 const ID5_DOMAIN = 'id5-sync.com'
@@ -80,6 +81,7 @@ export const permutiveIdentityManagerIdSubmodule = {
    * @type {string}
    */
   name: MODULE_NAME,
+  gvlid: PERMUTIVE_GVLID,
 
   /**
    * decode the stored id value for passing to bid requests

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -17,6 +17,7 @@ import {MODULE_TYPE_RTD} from '../src/activities/modules.js';
  */
 
 const MODULE_NAME = 'permutive'
+const PERMUTIVE_GVLID = 361
 
 const logger = prefixLog('[PermutiveRTD]')
 
@@ -466,6 +467,7 @@ let permutiveSDKInRealTime = false
 /** @type {RtdSubmodule} */
 export const permutiveSubmodule = {
   name: MODULE_NAME,
+  gvlid: PERMUTIVE_GVLID,
   getBidRequestData: function (reqBidsConfigObj, callback, customModuleConfig) {
     const completeBidRequestData = () => {
       logger.logInfo(`Request data updated`)


### PR DESCRIPTION
## Summary
- declare a `PERMUTIVE_GVLID` constant in the RTD module and reuse it in the exported submodule metadata to avoid repeating the literal vendor ID. 【F:modules/permutiveRtdProvider.js†L19-L27】【F:modules/permutiveRtdProvider.js†L467-L497】
- add the same constant to the identity manager module and reference it from the submodule descriptor so the GVL configuration stays centralized. 【F:modules/permutiveIdentityManagerIdSystem.js†L12-L24】【F:modules/permutiveIdentityManagerIdSystem.js†L78-L120】

## Testing
- `npx eslint modules/permutiveRtdProvider.js modules/permutiveIdentityManagerIdSystem.js --cache --cache-strategy content`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691626b5d28c832b9cf3ba3778c89d8e)