### PR TITLE
51Degrees RTD Provider: remove device pixel ratio helper

### DIFF
--- a/modules/51DegreesRtdProvider.js
+++ b/modules/51DegreesRtdProvider.js
@@ -8,7 +8,6 @@ import {
   mergeDeep,
   prefixLog,
 } from '../src/utils.js';
-import {getDevicePixelRatio} from '../libraries/devicePixelRatio/devicePixelRatio.js';
 
 const MODULE_NAME = '51Degrees';
 export const LOG_PREFIX = `[${MODULE_NAME} RTD Submodule]:`;
@@ -127,7 +126,7 @@ export const get51DegreesJSURL = (pathData, win) => {
   );
   deepSetNotEmptyValue(qs, '51D_ScreenPixelsHeight', _window?.screen?.height);
   deepSetNotEmptyValue(qs, '51D_ScreenPixelsWidth', _window?.screen?.width);
-  deepSetNotEmptyValue(qs, '51D_PixelRatio', getDevicePixelRatio(_window));
+  deepSetNotEmptyValue(qs, '51D_PixelRatio', _window?.devicePixelRatio);
 
   const _qs = formatQS(qs);
   const _qsString = _qs ? `${queryPrefix}${_qs}` : '';

--- a/test/spec/modules/51DegreesRtdProvider_spec.js
+++ b/test/spec/modules/51DegreesRtdProvider_spec.js
@@ -8,7 +8,6 @@ import {
   getBidRequestData,
   fiftyOneDegreesSubmodule,
 } from 'modules/51DegreesRtdProvider';
-import {getDevicePixelRatio} from 'libraries/devicePixelRatio/devicePixelRatio.js';
 import {mergeDeep} from '../../../src/utils.js';
 
 const inject51DegreesMeta = () => {
@@ -195,21 +194,14 @@ describe('51DegreesRtdProvider', function() {
       'platform': 'macOS',
       'platformVersion': '14.6.1'
     };
-    let mockWindow;
-    let pixelRatio;
-
-    beforeEach(function() {
-      mockWindow = {
-        ...window,
-        screen: {
-          height: 1117,
-          width: 1728,
-        },
-        devicePixelRatio: 2,
-      };
-
-      pixelRatio = getDevicePixelRatio(mockWindow);
-    });
+    const mockWindow = {
+      ...window,
+      screen: {
+        height: 1117,
+        width: 1728,
+      },
+      devicePixelRatio: 2,
+    };
 
     it('returns the cloud URL if the resourceKey is provided', function() {
       const config = {resourceKey: 'TEST_RESOURCE_KEY'};
@@ -217,7 +209,7 @@ describe('51DegreesRtdProvider', function() {
         'https://cloud.51degrees.com/api/v4/TEST_RESOURCE_KEY.js?' +
         `51D_ScreenPixelsHeight=${mockWindow.screen.height}&` +
         `51D_ScreenPixelsWidth=${mockWindow.screen.width}&` +
-        `51D_PixelRatio=${pixelRatio}`
+        `51D_PixelRatio=${mockWindow.devicePixelRatio}`
       );
     });
 
@@ -227,7 +219,7 @@ describe('51DegreesRtdProvider', function() {
         `https://example.com/51Degrees.core.js?` +
         `51D_ScreenPixelsHeight=${mockWindow.screen.height}&` +
         `51D_ScreenPixelsWidth=${mockWindow.screen.width}&` +
-        `51D_PixelRatio=${pixelRatio}`
+        `51D_PixelRatio=${mockWindow.devicePixelRatio}`
       );
     });
 
@@ -237,7 +229,7 @@ describe('51DegreesRtdProvider', function() {
         `https://example.com/51Degrees.core.js?test=1&` +
         `51D_ScreenPixelsHeight=${mockWindow.screen.height}&` +
         `51D_ScreenPixelsWidth=${mockWindow.screen.width}&` +
-        `51D_PixelRatio=${pixelRatio}`
+        `51D_PixelRatio=${mockWindow.devicePixelRatio}`
       );
     });
 
@@ -251,7 +243,7 @@ describe('51DegreesRtdProvider', function() {
         `51D_GetHighEntropyValues=${btoa(JSON.stringify(hev))}&` +
         `51D_ScreenPixelsHeight=${mockWindow.screen.height}&` +
         `51D_ScreenPixelsWidth=${mockWindow.screen.width}&` +
-        `51D_PixelRatio=${pixelRatio}`
+        `51D_PixelRatio=${mockWindow.devicePixelRatio}`
       );
     });
 
@@ -264,20 +256,18 @@ describe('51DegreesRtdProvider', function() {
         `https://example.com/51Degrees.core.js?` +
         `51D_ScreenPixelsHeight=${mockWindow.screen.height}&` +
         `51D_ScreenPixelsWidth=${mockWindow.screen.width}&` +
-        `51D_PixelRatio=${pixelRatio}`
+        `51D_PixelRatio=${mockWindow.devicePixelRatio}`
       );
     });
 
-    it('polyfills the device pixel ratio when it is not directly available', function() {
+    it('keeps the original URL if none of the additional parameters are available', function () {
+      // delete screen and devicePixelRatio properties to test the case when they are not available
+      delete mockWindow.screen;
+      delete mockWindow.devicePixelRatio;
+
       const config = {onPremiseJSUrl: 'https://example.com/51Degrees.core.js'};
-      const windowWithoutDpr = {innerWidth: 1200, outerWidth: 2400};
-
-      const derivedDpr = getDevicePixelRatio(windowWithoutDpr);
-
-      expect(get51DegreesJSURL(config, windowWithoutDpr)).to.equal(
-        `https://example.com/51Degrees.core.js?` +
-        `51D_PixelRatio=${derivedDpr}`
-      );
+      expect(get51DegreesJSURL(config, mockWindow)).to.equal('https://example.com/51Degrees.core.js');
+      expect(get51DegreesJSURL(config, window)).to.not.equal('https://example.com/51Degrees.core.js');
     });
   });
 


### PR DESCRIPTION
## Summary
- revert the 51Degrees RTD provider to use the native devicePixelRatio when building query parameters
- align the 51Degrees RTD provider tests with the restored devicePixelRatio expectations

## Testing
- npx eslint --cache --cache-strategy content modules/51DegreesRtdProvider.js test/spec/modules/51DegreesRtdProvider_spec.js
- npx gulp test --file test/spec/modules/51DegreesRtdProvider_spec.js --nolint

## Labels
- release: maintenance
- semver: patch

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f93a4c9d8832ba2334e262cb62fdc)