### PR TITLE
Timeout RTD Module: remove unused helpers

### DIFF
--- a/modules/timeoutRtdProvider.js
+++ b/modules/timeoutRtdProvider.js
@@ -2,7 +2,6 @@ import { submodule } from '../src/hook.js';
 import * as ajax from '../src/ajax.js';
 import { logInfo, deepAccess, logError } from '../src/utils.js';
 import { getGlobal } from '../src/prebidGlobal.js';
-import { getConnectionInfo } from '../libraries/connectionInfo/connectionUtils.js';
 import { bidderTimeoutFunctions } from '../libraries/bidderTimeoutUtils/bidderTimeoutUtils.js';
 
 /**
@@ -15,107 +14,6 @@ const SUBMODULE_NAME = 'timeout';
 export const timeoutRtdFunctions = {
   handleTimeoutIncrement
 };
-
-const entries = Object.entries || function(obj) {
-  const ownProps = Object.keys(obj);
-  let i = ownProps.length;
-  const resArray = new Array(i);
-  while (i--) { resArray[i] = [ownProps[i], obj[ownProps[i]]]; }
-  return resArray;
-};
-
-function getDeviceType() {
-  const userAgent = window.navigator.userAgent.toLowerCase();
-  if ((/ipad|android 3.0|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent))) {
-    return 5; // tablet
-  }
-  if ((/iphone|ipod|android|blackberry|opera|mini|windows\sce|palm|smartphone|iemobile/i.test(userAgent))) {
-    return 4; // mobile
-  }
-  return 2; // personal computer
-}
-
-function checkVideo(adUnits) {
-  return adUnits.some((adUnit) => {
-    return adUnit.mediaTypes && adUnit.mediaTypes.video;
-  });
-}
-
-function getConnectionSpeed() {
-  const connection = getConnectionInfo();
-  const connectionType = connection?.type || connection?.effectiveType;
-
-  switch (connectionType) {
-    case 'slow-2g':
-    case '2g':
-      return 'slow';
-
-    case '3g':
-      return 'medium';
-
-    case 'bluetooth':
-    case 'cellular':
-    case 'ethernet':
-    case 'wifi':
-    case 'wimax':
-    case '4g':
-    case '5g':
-      return 'fast';
-  }
-
-  return 'unknown';
-}
-/**
- * Calculate the time to be added to the timeout
- * @param {Array} adUnits
- * @param {Object} rules
- * @return {number}
- */
-function calculateTimeoutModifier(adUnits, rules) {
-  logInfo('Timeout rules', rules);
-  let timeoutModifier = 0;
-  let toAdd = 0;
-
-  if (rules.includesVideo) {
-    const hasVideo = timeoutRtdFunctions.checkVideo(adUnits);
-    toAdd = rules.includesVideo[hasVideo] || 0;
-    logInfo(`Adding ${toAdd} to timeout for includesVideo ${hasVideo}`)
-    timeoutModifier += toAdd;
-  }
-
-  if (rules.numAdUnits) {
-    const numAdUnits = adUnits.length;
-    if (rules.numAdUnits[numAdUnits]) {
-      timeoutModifier += rules.numAdUnits[numAdUnits];
-    } else {
-      for (const [rangeStr, timeoutVal] of entries(rules.numAdUnits)) {
-        const [lowerBound, upperBound] = rangeStr.split('-');
-        if (parseInt(lowerBound) <= numAdUnits && numAdUnits <= parseInt(upperBound)) {
-          logInfo(`Adding ${timeoutVal} to timeout for numAdUnits ${numAdUnits}`)
-          timeoutModifier += timeoutVal;
-          break;
-        }
-      }
-    }
-  }
-
-  if (rules.deviceType) {
-    const deviceType = timeoutRtdFunctions.getDeviceType();
-    toAdd = rules.deviceType[deviceType] || 0;
-    logInfo(`Adding ${toAdd} to timeout for deviceType ${deviceType}`)
-    timeoutModifier += toAdd;
-  }
-
-  if (rules.connectionSpeed) {
-    const connectionSpeed = timeoutRtdFunctions.getConnectionSpeed();
-    toAdd = rules.connectionSpeed[connectionSpeed] || 0;
-    logInfo(`Adding ${toAdd} to timeout for connectionSpeed ${connectionSpeed}`)
-    timeoutModifier += toAdd;
-  }
-
-  logInfo('timeout Modifier calculated', timeoutModifier);
-  return timeoutModifier;
-}
 
 /**
  *


### PR DESCRIPTION
## Summary
- Removed unused timeout helper utilities and the unused connection info import so the timeout RTD provider relies solely on the shared bidder timeout utilities without lint warnings.【F:modules/timeoutRtdProvider.js†L1-L64】

## Testing
- `npx eslint --cache --cache-strategy content modules/timeoutRtdProvider.js`【30b7f8†L1-L2】
- `npx gulp test --file test/spec/modules/timeoutRtdProvider_spec.js --nolint`【4968ce†L1-L11】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941a93fc688832b8194228aa010d7e1)